### PR TITLE
ci: require manual approval before releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,7 @@
 name: Automated Release
 
 on:
-  push:
-    branches:
-      - master
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -16,6 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: master
           fetch-depth: 0
 
       - name: Setup Node.js

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,10 @@ name: Automated Release
 on:
   workflow_dispatch:
 
+concurrency:
+  group: automated-release
+  cancel-in-progress: false
+
 permissions:
   contents: write
 


### PR DESCRIPTION
## Purpose

Prevent automatic publication from every push to `master` while the four P0 fixes are integrated and smoke-tested.

## Change

- Replace the release workflow's `push` trigger with `workflow_dispatch`.
- Explicitly build and version the current `master` branch when an authorized user starts the workflow.
- Leave the pull-request build/test workflow unchanged.

## Validation

- `git diff --check`
- Parsed `.github/workflows/build.yml` with Ruby Psych (`YAML_OK`).

## Release behavior

Merging PRs no longer publishes a release. After the integrated macOS smoke report is approved, an authorized user can start **Automated Release** manually.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to support manual execution.
  * Ensured releases are prepared from the master branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->