### PR TITLE
fix(desktop): separate vault unlock from user authentication

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,1 @@
+desktop/src/styles.css

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -27,6 +27,7 @@
     "watch": "ng build --watch --configuration development",
     "test": "npm run test:main && npm run test:renderer",
     "test:main": "vitest run -c vitest.config.main.js",
+    "test:security:electron": "node scripts/run-security-integration.js",
     "test:renderer": "vitest run -c vitest.config.renderer.mjs",
     "test:coverage": "vitest run -c vitest.config.main.js --coverage && vitest run -c vitest.config.renderer.mjs --coverage",
     "e2e": "playwright test",

--- a/desktop/scripts/run-security-integration.js
+++ b/desktop/scripts/run-security-integration.js
@@ -1,0 +1,20 @@
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+const electron = require('electron');
+const vitest = path.join(path.dirname(require.resolve('vitest/package.json')), 'vitest.mjs');
+
+const result = spawnSync(electron, [
+    vitest,
+    'run',
+    '-c',
+    'vitest.config.main.js',
+    'src/main/services/SecurityService.integration.spec.ts',
+    '--reporter=default'
+], {
+    cwd: process.cwd(),
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+    stdio: 'inherit'
+});
+
+if (result.error) throw result.error;
+process.exit(result.status ?? 1);

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -7,9 +7,12 @@ import { SessionService } from './services/SessionService';
 import { BackupService } from './services/BackupService';
 import { CrashService } from './services/CrashService';
 import { SecurityService } from './services/SecurityService';
+import { ElectronSafeStorageDeviceKeyStore } from './services/DeviceKeyStore';
 import { DatabaseService } from './services/DatabaseService';
 import { GoogleDriveService } from './services/GoogleDriveService';
 import { CloudSyncService } from './services/CloudSyncService';
+import { buildAuthenticatedLoginResult } from './services/AuthResult';
+import { ProvisioningService } from './services/ProvisioningService';
 import { ApiServer } from '../server/app';
 import {
     DEV_APP_NAME,
@@ -97,8 +100,9 @@ ipcMain.handle('utils:getRuntimeInfo', () => ({
 }));
 
 // Services
-const securityService = new SecurityService();
+const securityService = new SecurityService(new ElectronSafeStorageDeviceKeyStore());
 const databaseService = new DatabaseService();
+const provisioningService = new ProvisioningService(securityService, databaseService);
 const googleDriveService = new GoogleDriveService();
 const cloudSyncService = new CloudSyncService(databaseService);
 
@@ -282,6 +286,8 @@ app.on('before-quit', async (e) => {
 // IPC Handlers
 ipcMain.handle('auth:checkSetup', () => {
     const userDataPath = app.getPath('userData');
+    const dbName = process.env['NODE_ENV'] === 'test' ? 'nalamdesk-test.db' : 'nalamdesk.db';
+    securityService.reconcileProvisioning(getDatabasePath(userDataPath, dbName), userDataPath);
     return securityService.isSetup(userDataPath);
 });
 
@@ -292,22 +298,11 @@ ipcMain.handle('auth:setup', async (event, { password, clinicDetails, adminDetai
         const dbName = process.env['NODE_ENV'] === 'test' ? 'nalamdesk-test.db' : 'nalamdesk.db';
         const dbPath = getDatabasePath(userDataPath, dbName);
 
-        // 1. Setup Security (Generates DEK + Recovery Code)
-        const recoveryCode = await securityService.setup(password, dbPath, userDataPath);
-
-        // 2. Set DB Service
-        databaseService.setDb(securityService.getDb());
-
-        // 3. Migrate DB Schema
-        await databaseService.migrate();
-
-        // 4. Save Settings
-        databaseService.saveSettings(clinicDetails);
-
-        // 5. Create Admin User
-        // We pass password here, but remember, Auth is now decoupled from DB Key.
-        // The Admin Password is the same as the Master Password for simplicity in V1/V2 transition.
-        await databaseService.ensureAdminUser(password);
+        // One durable transaction covers vault creation, schema, clinic settings,
+        // and the administrator credential. The password never wraps the DEK.
+        const recoveryCode = await provisioningService.provision(
+            password, clinicDetails, dbPath, userDataPath
+        );
 
         console.log('[Auth] Setup Complete.');
         return { success: true, recoveryCode };
@@ -317,26 +312,25 @@ ipcMain.handle('auth:setup', async (event, { password, clinicDetails, adminDetai
     }
 });
 
-ipcMain.handle('auth:recover', async (event, { recoveryCode, newPassword }) => {
+ipcMain.handle('auth:recover', async (event, { recoveryCode }) => {
     try {
         console.log('[Auth] Starting Recovery...');
         const userDataPath = app.getPath('userData');
         const dbName = process.env['NODE_ENV'] === 'test' ? 'nalamdesk-test.db' : 'nalamdesk.db';
         const dbPath = getDatabasePath(userDataPath, dbName);
 
-        // 1. Recover Vault
-        const newRecoveryCode = await securityService.recover(recoveryCode, newPassword, userDataPath, dbPath);
+        // Recovery re-enrols this device. Account password recovery is a
+        // separate workflow owned by issue #6.
+        await securityService.recoverDevice(recoveryCode, userDataPath, dbPath);
 
         // 2. Set DB
         databaseService.setDb(securityService.getDb());
 
-        // 3. Update Admin Password in DB (since we reset it)
-        // Note: We need a way to find the admin user and update their password hash.
-        // DatabaseService needs a method for this.
-        // For now, let's assume 'admin' user exists.
-        await databaseService.updateUserPassword('admin', newPassword);
-
-        return { success: true, recoveryCode: newRecoveryCode };
+        await databaseService.migrate();
+        return {
+            success: true,
+            pendingRecoveryCode: securityService.getPendingRecoveryCode() || undefined
+        };
     } catch (e: any) {
         console.error('[Auth] Recovery failed:', e);
         return { success: false, error: e.message };
@@ -347,9 +341,12 @@ ipcMain.handle('auth:regenerateRecoveryCode', async (event, { password }) => {
     try {
         const user = sessionService.getUser();
         if (!user || user.role !== 'admin') throw new Error('Forbidden');
+        const argon2 = await import('argon2');
+        const admin = await databaseService.getUserByUsername('admin');
+        if (!admin || !password || !await argon2.verify(admin.password, password)) throw new Error('INVALID_CREDENTIALS');
 
         console.log('[Auth] Regenerating Recovery Code...');
-        const recoveryCode = await securityService.regenerateRecoveryCode(password);
+        const recoveryCode = await securityService.regenerateRecoveryCode();
         return { success: true, recoveryCode };
     } catch (e: any) {
         console.error('[Auth] Regenerate Recovery Code failed:', e);
@@ -357,32 +354,50 @@ ipcMain.handle('auth:regenerateRecoveryCode', async (event, { password }) => {
     }
 });
 
+ipcMain.handle('auth:acknowledgeRecoveryCode', (_event, { recoveryCode }) => {
+    const user = sessionService.getUser();
+    if (!user || user.role !== 'admin') throw new Error('Forbidden');
+    securityService.acknowledgePendingRecoveryCode(recoveryCode);
+    return { success: true };
+});
+
 ipcMain.handle('clipboard:writeText', (event, text) => {
     clipboard.writeText(text);
     return true;
 });
 
-async function tryUnlockDatabase(password: string): Promise<string | null> {
-    if (securityService.getDb()) return null; // Already open
+async function tryUnlockDatabase(legacySecret: string): Promise<{ error?: string; migrated?: boolean }> {
+    if (securityService.getDb()) return {};
 
     try {
         const userDataPath = app.getPath('userData');
         const dbName = process.env['NODE_ENV'] === 'test' ? 'nalamdesk-test.db' : 'nalamdesk.db';
         const dbPath = getDatabasePath(userDataPath, dbName);
 
-        // This handles Unlock OR V1->V2 Migration
-        await securityService.initialize(password, dbPath, userDataPath);
+        let result;
+        try {
+            result = await securityService.initializeDevice(dbPath, userDataPath);
+        } catch (error: any) {
+            if (error.message !== 'LEGACY_MIGRATION_REQUIRED') throw error;
+            // The submitted password is used only for this one-time legacy
+            // migration. It is not part of the v3 device unlock contract.
+            result = await securityService.migrateLegacy(legacySecret, dbPath, userDataPath);
+        }
         databaseService.setDb(securityService.getDb());
 
         // Ensure schema is up to date (safe idempotent)
         await databaseService.migrate();
-        return null;
+        return { migrated: result.migrated };
     } catch (e: any) {
-        if (e.message === 'NOT_SETUP') return 'SETUP_REQUIRED';
-        if (e.message === 'INVALID_PASSWORD') return 'INVALID_PASSWORD';
+        if (e.message === 'NOT_SETUP') return { error: 'SETUP_REQUIRED' };
+        if (e.message === 'INVALID_LEGACY_CREDENTIAL') return { error: 'INVALID_CREDENTIALS' };
+        if (['ENCRYPTION_UNAVAILABLE', 'INSECURE_LINUX_BACKEND', 'DEVICE_UNLOCK_FAILED'].includes(e.message)) {
+            return { error: 'RECOVERY_REQUIRED' };
+        }
+        if (e.message === 'VAULT_BINDING_MISMATCH') return { error: 'VAULT_BINDING_MISMATCH' };
 
         console.error('DB Init failed:', e);
-        return 'SYSTEM_ERROR';
+        return { error: 'SYSTEM_ERROR' };
     }
 }
 
@@ -411,7 +426,7 @@ async function handleAdminLogin(password: string): Promise<{ success: boolean; u
 
     sessionService.setUser(user);
     initializeServices(databaseService.getSettings());
-    return { success: true, user };
+    return buildAuthenticatedLoginResult(sessionService.getUser()!, securityService);
 }
 
 ipcMain.handle('auth:login', async (event, credentials) => {
@@ -420,8 +435,7 @@ ipcMain.handle('auth:login', async (event, credentials) => {
 
         // 1. Initialize / Unlock DB
         const unlockResult = await tryUnlockDatabase(password);
-        if (unlockResult === 'SETUP_REQUIRED') return { success: false, error: 'SETUP_REQUIRED' };
-        if (unlockResult === 'SYSTEM_ERROR') return { success: false, error: 'SYSTEM_ERROR' };
+        if (unlockResult.error) return { success: false, error: unlockResult.error };
 
         // 2. Check if DB is open
         const db = securityService.getDb();
@@ -436,7 +450,9 @@ ipcMain.handle('auth:login', async (event, credentials) => {
         // 3. Admin fast path
         if (username === 'admin') {
             const adminResult = await handleAdminLogin(password);
-            if (adminResult) return adminResult;
+            if (adminResult) {
+                return adminResult;
+            }
             // Fallthrough to standard validation if admin user missing from DB
         }
 
@@ -447,7 +463,7 @@ ipcMain.handle('auth:login', async (event, credentials) => {
         if (result.success && result.user) {
             sessionService.setUser(result.user);
             initializeServices(databaseService.getSettings());
-            return { success: true, user: result.user };
+            return buildAuthenticatedLoginResult(sessionService.getUser()!, securityService);
         }
 
         return { success: false, error: 'INVALID_CREDENTIALS' };

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -8,6 +8,7 @@ contextBridge.exposeInMainWorld('electron', {
     restoreSystemBackup: (path: string) => ipcRenderer.invoke('auth:restoreSystemBackup', path),
     setup: (data: any) => ipcRenderer.invoke('auth:setup', data),
     recover: (data: any) => ipcRenderer.invoke('auth:recover', data),
+    acknowledgeRecoveryCode: (recoveryCode: string) => ipcRenderer.invoke('auth:acknowledgeRecoveryCode', { recoveryCode }),
     regenerateRecoveryCode: (password: string) => ipcRenderer.invoke('auth:regenerateRecoveryCode', { password }),
     // ...
     backup: {

--- a/desktop/src/main/services/AuthResult.spec.ts
+++ b/desktop/src/main/services/AuthResult.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildAuthenticatedLoginResult } from './AuthResult';
+
+const user = (role: string) => ({ id: 1, username: role, role, name: role, sessionId: 'private-session-id' });
+
+describe('buildAuthenticatedLoginResult', () => {
+    it('discloses a pending recovery code only to an authenticated admin', () => {
+        const recovery = { getPendingRecoveryCode: vi.fn(() => 'NEW-RECOVERY-CODE') };
+        expect(buildAuthenticatedLoginResult(user('admin'), recovery)).toMatchObject({
+            success: true,
+            pendingRecoveryCode: 'NEW-RECOVERY-CODE'
+        });
+        expect(recovery.getPendingRecoveryCode).toHaveBeenCalledOnce();
+    });
+
+    it.each(['doctor', 'nurse', 'receptionist'])('never reads or returns pending recovery for %s', role => {
+        const recovery = { getPendingRecoveryCode: vi.fn(() => 'NEW-RECOVERY-CODE') };
+        const result = buildAuthenticatedLoginResult(user(role), recovery) as any;
+        expect(result.pendingRecoveryCode).toBeUndefined();
+        expect(recovery.getPendingRecoveryCode).not.toHaveBeenCalled();
+    });
+
+    it('allowlists IPC user fields and excludes session or credential internals', () => {
+        const result = buildAuthenticatedLoginResult({
+            ...user('admin'),
+            password: '$argon2id$hash'
+        } as any, { getPendingRecoveryCode: () => null }) as any;
+        expect(result.user.password).toBeUndefined();
+        expect(result.user.sessionId).toBeUndefined();
+    });
+});

--- a/desktop/src/main/services/AuthResult.ts
+++ b/desktop/src/main/services/AuthResult.ts
@@ -1,0 +1,25 @@
+import type { UserSession } from './SessionService';
+
+export interface PendingRecoveryReader { getPendingRecoveryCode(): string | null }
+
+/** Builds the only user object allowed across the authentication IPC boundary. */
+export function buildAuthenticatedLoginResult(user: UserSession, recovery: PendingRecoveryReader) {
+    const publicUser = {
+        id: user.id,
+        username: user.username,
+        role: user.role,
+        name: user.name,
+        ...(user.specialty ? { specialty: user.specialty } : {}),
+        ...(user.license_number ? { license_number: user.license_number } : {}),
+        ...(user.password_reset_required !== undefined
+            ? { password_reset_required: user.password_reset_required }
+            : {})
+    };
+    return {
+        success: true as const,
+        user: publicUser,
+        ...(user.role === 'admin'
+            ? { pendingRecoveryCode: recovery.getPendingRecoveryCode() || undefined }
+            : {})
+    };
+}

--- a/desktop/src/main/services/DatabaseService.ts
+++ b/desktop/src/main/services/DatabaseService.ts
@@ -34,15 +34,17 @@ export class DatabaseService {
         }
     }
 
-    async migrate() {
+    async migrate(options: { skipBackup?: boolean } = {}) {
         if (!this.db) throw new Error('DB not initialized');
 
         // Safety: Backup before migrating
-        try {
-            await this.createBackup(this.db.name);
-        } catch (e) {
-            console.error('[DB] Backup failed! Proceeding with caution...', e);
-            // Optional: Throw if backup is critical? For now, log and proceed (or user can't login).
+        if (!options.skipBackup) {
+            try {
+                await this.createBackup(this.db.name);
+            } catch (e) {
+                console.error('[DB] Backup failed! Proceeding with caution...', e);
+                // Optional: Throw if backup is critical? For now, log and proceed (or user can't login).
+            }
         }
 
         // Check Version

--- a/desktop/src/main/services/DeviceKeyStore.spec.ts
+++ b/desktop/src/main/services/DeviceKeyStore.spec.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const safeStorage = {
+    isEncryptionAvailable: vi.fn(),
+    getSelectedStorageBackend: vi.fn(),
+    encryptString: vi.fn(),
+    decryptString: vi.fn()
+};
+
+vi.mock('electron', () => ({ safeStorage }));
+
+describe('ElectronSafeStorageDeviceKeyStore', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.clearAllMocks();
+        safeStorage.isEncryptionAvailable.mockReturnValue(true);
+        safeStorage.getSelectedStorageBackend.mockReturnValue('keychain');
+    });
+
+    it('round-trips a 32-byte key without exposing plaintext to the config', async () => {
+        const key = Buffer.alloc(32, 7);
+        safeStorage.encryptString.mockReturnValue(Buffer.from('ciphertext'));
+        safeStorage.decryptString.mockReturnValue(key.toString('base64'));
+        const { ElectronSafeStorageDeviceKeyStore } = await import('./DeviceKeyStore');
+        const store = new ElectronSafeStorageDeviceKeyStore();
+        expect(store.protect(key)).toEqual(Buffer.from('ciphertext'));
+        expect(safeStorage.encryptString).toHaveBeenCalledWith(key.toString('base64'));
+        expect(store.unprotect(Buffer.from('ciphertext'))).toEqual(key);
+    });
+
+    it('fails when Electron reports encryption unavailable', async () => {
+        safeStorage.isEncryptionAvailable.mockReturnValue(false);
+        const { ElectronSafeStorageDeviceKeyStore } = await import('./DeviceKeyStore');
+        const store = new ElectronSafeStorageDeviceKeyStore();
+        expect(store.status()).toMatchObject({ available: false, reason: 'ENCRYPTION_UNAVAILABLE' });
+        expect(() => store.protect(Buffer.alloc(32))).toThrow('ENCRYPTION_UNAVAILABLE');
+    });
+
+    it('rejects Linux basic_text instead of silently weakening protection', async () => {
+        const originalPlatform = process.platform;
+        Object.defineProperty(process, 'platform', { value: 'linux' });
+        safeStorage.getSelectedStorageBackend.mockReturnValue('basic_text');
+        try {
+            const { ElectronSafeStorageDeviceKeyStore } = await import('./DeviceKeyStore');
+            expect(new ElectronSafeStorageDeviceKeyStore().status()).toMatchObject({
+                available: false,
+                reason: 'INSECURE_LINUX_BACKEND'
+            });
+        } finally {
+            Object.defineProperty(process, 'platform', { value: originalPlatform });
+        }
+    });
+});

--- a/desktop/src/main/services/DeviceKeyStore.ts
+++ b/desktop/src/main/services/DeviceKeyStore.ts
@@ -1,0 +1,41 @@
+import { safeStorage } from 'electron';
+
+export interface DeviceKeyStoreStatus {
+    available: boolean;
+    provider: string;
+    reason?: 'ENCRYPTION_UNAVAILABLE' | 'INSECURE_LINUX_BACKEND';
+}
+
+/** Device-bound wrapping boundary; injectable for tests and future platforms. */
+export interface DeviceKeyStore {
+    status(): DeviceKeyStoreStatus;
+    protect(value: Buffer): Buffer;
+    unprotect(value: Buffer): Buffer;
+}
+
+export class ElectronSafeStorageDeviceKeyStore implements DeviceKeyStore {
+    status(): DeviceKeyStoreStatus {
+        if (!safeStorage.isEncryptionAvailable()) {
+            return { available: false, provider: 'electron-safe-storage', reason: 'ENCRYPTION_UNAVAILABLE' };
+        }
+        if (process.platform === 'linux' && safeStorage.getSelectedStorageBackend() === 'basic_text') {
+            return { available: false, provider: 'electron-safe-storage', reason: 'INSECURE_LINUX_BACKEND' };
+        }
+        return { available: true, provider: 'electron-safe-storage' };
+    }
+
+    protect(value: Buffer): Buffer {
+        this.assertAvailable();
+        return safeStorage.encryptString(value.toString('base64'));
+    }
+
+    unprotect(value: Buffer): Buffer {
+        this.assertAvailable();
+        return Buffer.from(safeStorage.decryptString(value), 'base64');
+    }
+
+    private assertAvailable(): void {
+        const current = this.status();
+        if (!current.available) throw new Error(current.reason || 'DEVICE_KEY_UNAVAILABLE');
+    }
+}

--- a/desktop/src/main/services/ProvisioningService.spec.ts
+++ b/desktop/src/main/services/ProvisioningService.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ProvisioningService } from './ProvisioningService';
+
+describe('ProvisioningService', () => {
+    it.each(['migration', 'settings', 'admin'] as const)(
+        'aborts the durable fresh provisioning transaction when %s fails',
+        async failure => {
+            const security = {
+                setup: vi.fn().mockResolvedValue('RECOVERY'),
+                getDb: vi.fn().mockReturnValue({}),
+                completeProvisioning: vi.fn(),
+                abortProvisioning: vi.fn()
+            };
+            const database = {
+                setDb: vi.fn(),
+                migrate: failure === 'migration'
+                    ? vi.fn().mockRejectedValue(new Error('migration failed'))
+                    : vi.fn().mockResolvedValue(undefined),
+                saveSettings: failure === 'settings'
+                    ? vi.fn(() => { throw new Error('settings failed'); })
+                    : vi.fn(),
+                ensureAdminUser: failure === 'admin'
+                    ? vi.fn().mockRejectedValue(new Error('admin failed'))
+                    : vi.fn().mockResolvedValue(undefined)
+            };
+
+            await expect(new ProvisioningService(security, database).provision(
+                'admin-password', {}, '/db', '/data'
+            )).rejects.toThrow(`${failure} failed`);
+            expect(security.abortProvisioning).toHaveBeenCalledOnce();
+            expect(security.completeProvisioning).not.toHaveBeenCalled();
+        }
+    );
+
+    it('commits only after schema, settings, and administrator creation succeed', async () => {
+        const calls: string[] = [];
+        const security = {
+            setup: vi.fn(async () => { calls.push('setup'); return 'RECOVERY'; }),
+            getDb: vi.fn(() => ({})),
+            completeProvisioning: vi.fn(() => calls.push('complete')),
+            abortProvisioning: vi.fn()
+        };
+        const database = {
+            setDb: vi.fn(() => calls.push('set-db')),
+            migrate: vi.fn(async () => { calls.push('migrate'); }),
+            saveSettings: vi.fn(() => calls.push('settings')),
+            ensureAdminUser: vi.fn(async () => { calls.push('admin'); })
+        };
+        await expect(new ProvisioningService(security, database).provision(
+            'admin-password', {}, '/db', '/data'
+        )).resolves.toBe('RECOVERY');
+        expect(calls).toEqual(['setup', 'set-db', 'migrate', 'settings', 'admin', 'complete']);
+        expect(database.migrate).toHaveBeenCalledWith({ skipBackup: true });
+        expect(security.abortProvisioning).not.toHaveBeenCalled();
+    });
+});

--- a/desktop/src/main/services/ProvisioningService.ts
+++ b/desktop/src/main/services/ProvisioningService.ts
@@ -1,0 +1,42 @@
+export interface VaultProvisioner {
+    setup(adminPassword: string, dbPath: string, userDataPath: string): Promise<string>;
+    getDb(): any;
+    completeProvisioning(): void;
+    abortProvisioning(): void;
+}
+
+export interface ProvisioningDatabase {
+    setDb(db: any): void;
+    migrate(options?: { skipBackup?: boolean }): Promise<void>;
+    saveSettings(settings: any): unknown;
+    ensureAdminUser(password: string): Promise<void>;
+}
+
+/** Coordinates the full fresh-install transaction across vault and application data. */
+export class ProvisioningService {
+    constructor(
+        private readonly security: VaultProvisioner,
+        private readonly database: ProvisioningDatabase
+    ) { }
+
+    async provision(
+        adminPassword: string,
+        clinicDetails: any,
+        dbPath: string,
+        userDataPath: string
+    ): Promise<string> {
+        try {
+            const recoveryCode = await this.security.setup(adminPassword, dbPath, userDataPath);
+            this.database.setDb(this.security.getDb());
+            await this.database.migrate({ skipBackup: true });
+            this.database.saveSettings(clinicDetails);
+            await this.database.ensureAdminUser(adminPassword);
+            this.security.completeProvisioning();
+            return recoveryCode;
+        } catch (error) {
+            this.security.abortProvisioning();
+            this.database.setDb(null);
+            throw error;
+        }
+    }
+}

--- a/desktop/src/main/services/SecurityService.integration.spec.ts
+++ b/desktop/src/main/services/SecurityService.integration.spec.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import * as argon2 from 'argon2';
+// @ts-ignore native SQLCipher module
+import Database from 'better-sqlite3-multiple-ciphers';
+import type { DeviceKeyStore } from './DeviceKeyStore';
+import { SecurityService } from './SecurityService';
+import { DatabaseService } from './DatabaseService';
+import { ProvisioningService } from './ProvisioningService';
+
+class IntegrationDeviceStore implements DeviceKeyStore {
+    constructor(private readonly mask: number) { }
+    status() { return { available: true, provider: 'integration-device-store' }; }
+    protect(value: Buffer) { return Buffer.from(value.map(byte => byte ^ this.mask)); }
+    unprotect(value: Buffer) { return this.protect(value); }
+}
+
+// The native SQLCipher module is rebuilt for Electron by postinstall, so these
+// run under Electron's Node mode rather than the host Node ABI.
+describe.skipIf(!process.versions.electron)('SecurityService SQLCipher integration', () => {
+    let directory: string;
+    let dbPath: string;
+
+    beforeEach(() => {
+        directory = fs.mkdtempSync(path.join(os.tmpdir(), 'nalamdesk-vault-integration-'));
+        dbPath = path.join(directory, 'nalamdesk.db');
+    });
+    afterEach(() => fs.rmSync(directory, { recursive: true, force: true }));
+
+    const createEncryptedDb = (key: Buffer, value = 'legacy-preserved') => {
+        const db = new Database(dbPath);
+        db.pragma(`key = "x'${key.toString('hex')}'"`);
+        db.exec(`CREATE TABLE clinical_data (value TEXT); INSERT INTO clinical_data VALUES ('${value}')`);
+        db.close();
+    };
+    const wrapLegacyV2 = (dek: Buffer, kek: Buffer) => {
+        const iv = crypto.randomBytes(16);
+        const cipher = crypto.createCipheriv('aes-256-gcm', kek, iv);
+        const ciphertext = Buffer.concat([cipher.update(dek), cipher.final()]);
+        return {
+            iv: iv.toString('hex'),
+            wrappedKey: Buffer.concat([cipher.getAuthTag(), ciphertext]).toString('hex')
+        };
+    };
+
+    it('cold-starts the same encrypted database using only the device envelope', async () => {
+        const store = new IntegrationDeviceStore(0x42);
+        const first = new SecurityService(store);
+        await first.setup('admin-login-only', dbPath, directory);
+        first.getDb().exec('CREATE TABLE clinical_data (value TEXT); INSERT INTO clinical_data VALUES (\'preserved\')');
+        first.completeProvisioning();
+        first.closeDb();
+
+        const coldStart = new SecurityService(store);
+        await coldStart.initializeDevice(dbPath, directory);
+        expect(coldStart.getDb().prepare('SELECT value FROM clinical_data').get()).toEqual({ value: 'preserved' });
+        coldStart.closeDb();
+    });
+
+    it.each(['migration', 'settings', 'admin'] as const)(
+        'rolls back real fresh provisioning after a %s failure and succeeds on retry',
+        async failure => {
+            const store = new IntegrationDeviceStore(0x44);
+            const security = new SecurityService(store);
+            const database = new DatabaseService();
+            if (failure === 'migration') {
+                vi.spyOn(database, 'migrate').mockRejectedValueOnce(new Error('forced migration failure'));
+            } else if (failure === 'settings') {
+                vi.spyOn(database, 'saveSettings').mockImplementationOnce(() => {
+                    throw new Error('forced settings failure');
+                });
+            } else {
+                vi.spyOn(database, 'ensureAdminUser').mockRejectedValueOnce(new Error('forced admin failure'));
+            }
+            await expect(new ProvisioningService(security, database).provision(
+                'admin-password', { clinic_name: 'Test Clinic' }, dbPath, directory
+            )).rejects.toThrow(`forced ${failure} failure`);
+            expect(fs.existsSync(dbPath)).toBe(false);
+            expect(fs.existsSync(path.join(directory, 'security.json'))).toBe(false);
+            expect(fs.existsSync(path.join(directory, 'security-setup.json'))).toBe(false);
+
+            const retrySecurity = new SecurityService(store);
+            const retryDatabase = new DatabaseService();
+            const code = await new ProvisioningService(retrySecurity, retryDatabase).provision(
+                'admin-password', { clinic_name: 'Test Clinic' }, dbPath, directory
+            );
+            expect(retrySecurity.getPendingRecoveryCode()).toBe(code);
+            expect(await retryDatabase.validateUser('admin', 'admin-password')).toMatchObject({ success: true });
+            retrySecurity.closeDb();
+            await expect(new SecurityService(store).initializeDevice(dbPath, directory))
+                .resolves.toEqual({ migrated: false });
+        }
+    );
+
+    it('re-enrols a new device through the recovery envelope', async () => {
+        const original = new SecurityService(new IntegrationDeviceStore(0x11));
+        const code = await original.setup('admin-login-only', dbPath, directory);
+        original.completeProvisioning();
+        original.closeDb();
+
+        const replacementStore = new IntegrationDeviceStore(0x77);
+        const replacement = new SecurityService(replacementStore);
+        await expect(replacement.recoverDevice(code, directory, dbPath)).resolves.toEqual({ migrated: false });
+        replacement.closeDb();
+        await expect(new SecurityService(replacementStore).initializeDevice(dbPath, directory)).resolves.toEqual({ migrated: false });
+    });
+
+    it('rejects valid key material paired with a different vault identity', async () => {
+        const store = new IntegrationDeviceStore(0x42);
+        const service = new SecurityService(store);
+        await service.setup('admin-login-only', dbPath, directory);
+        service.completeProvisioning();
+        service.closeDb();
+        const configPath = path.join(directory, 'security.json');
+        const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+        config.vaultId = '00000000-0000-4000-8000-000000000000';
+        fs.writeFileSync(configPath, JSON.stringify(config));
+
+        await expect(new SecurityService(store).initializeDevice(dbPath, directory)).rejects.toThrow('VAULT_BINDING_MISMATCH');
+    });
+
+    it('allows admin, doctor, nurse, and receptionist to be first login after separate cold starts', async () => {
+        const store = new IntegrationDeviceStore(0x24);
+        const setup = new SecurityService(store);
+        await setup.setup('admin-password', dbPath, directory);
+        setup.getDb().exec(`CREATE TABLE users (
+            id INTEGER PRIMARY KEY, username TEXT, password TEXT, role TEXT, name TEXT,
+            active INTEGER DEFAULT 1, password_reset_required INTEGER DEFAULT 0
+        )`);
+        const insert = setup.getDb().prepare('INSERT INTO users (id, username, password, role, name) VALUES (?, ?, ?, ?, ?)');
+        const roles = ['admin', 'doctor', 'nurse', 'receptionist'];
+        for (const [index, role] of roles.entries()) {
+            insert.run(index + 1, role, await argon2.hash(`${role}-password`), role, role);
+        }
+        setup.completeProvisioning();
+        setup.closeDb();
+
+        for (const role of roles) {
+            const coldStart = new SecurityService(store);
+            await coldStart.initializeDevice(dbPath, directory);
+            const database = new DatabaseService();
+            database.setDb(coldStart.getDb());
+            await expect(database.validateUser(role, `${role}-password`)).resolves.toMatchObject({
+                success: true,
+                user: { role }
+            });
+            coldStart.closeDb();
+        }
+    });
+
+    it('migrates a real v2 SQLCipher database and preserves data across restart', async () => {
+        const store = new IntegrationDeviceStore(0x31);
+        const builder = new SecurityService(store) as any;
+        const dek = crypto.randomBytes(32);
+        createEncryptedDb(dek);
+        const salt = crypto.randomBytes(16);
+        const wrapped = wrapLegacyV2(dek, await builder.deriveLegacyKey('legacy-master', salt));
+        fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+            version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
+        }));
+
+        const migrated = new SecurityService(store);
+        await expect(migrated.migrateLegacy('legacy-master', dbPath, directory)).resolves.toEqual({ migrated: true });
+        expect(migrated.getDb().prepare('SELECT value FROM clinical_data').get()).toEqual({ value: 'legacy-preserved' });
+        expect(migrated.getPendingRecoveryCode()).toBeTruthy();
+        migrated.closeDb();
+        await expect(new SecurityService(store).initializeDevice(dbPath, directory)).resolves.toEqual({ migrated: false });
+    });
+
+    it('migrates and rekeys a real v1 SQLCipher database', async () => {
+        const store = new IntegrationDeviceStore(0x17);
+        const builder = new SecurityService(store) as any;
+        const salt = crypto.randomBytes(16);
+        fs.writeFileSync(path.join(directory, 'salt.bin'), salt);
+        const legacyKey = await builder.deriveLegacyKey('legacy-master', salt);
+        createEncryptedDb(legacyKey);
+
+        const migrated = new SecurityService(store);
+        await migrated.migrateLegacy('legacy-master', dbPath, directory);
+        expect(migrated.getDb().prepare('SELECT value FROM clinical_data').get()).toEqual({ value: 'legacy-preserved' });
+        expect(fs.existsSync(path.join(directory, 'salt.bin.migrated'))).toBe(true);
+    });
+
+    it('restores the real v1 database and old key when migration fails after rekey', async () => {
+        const store = new IntegrationDeviceStore(0x61);
+        const builder = new SecurityService(store) as any;
+        const salt = crypto.randomBytes(16);
+        fs.writeFileSync(path.join(directory, 'salt.bin'), salt);
+        const legacyKey = await builder.deriveLegacyKey('legacy-master', salt);
+        createEncryptedDb(legacyKey, 'rollback-preserved');
+        const failing = new SecurityService(store, {
+            onStep: step => { if (step === 'migration-after-rekey') throw new Error('forced crash'); }
+        });
+
+        await expect(failing.migrateLegacy('legacy-master', dbPath, directory)).rejects.toThrow('forced crash');
+        const restored = new Database(dbPath);
+        restored.pragma(`key = "x'${legacyKey.toString('hex')}'"`);
+        expect(restored.prepare('SELECT value FROM clinical_data').get()).toEqual({ value: 'rollback-preserved' });
+        restored.close();
+    });
+
+    it.each([
+        { version: 1 as const, path: 'final' as const },
+        { version: 1 as const, path: 'transition' as const },
+        { version: 2 as const, path: 'final' as const },
+        { version: 2 as const, path: 'transition' as const }
+    ])('survives v$version device loss before acknowledgement through the $path recovery path', async ({ version, path: recoveryPath }) => {
+        const legacySecret = `legacy-v${version}`;
+        const oldStore = new IntegrationDeviceStore(0x21);
+        const builder = new SecurityService(oldStore) as any;
+        if (version === 1) {
+            const salt = crypto.randomBytes(16);
+            fs.writeFileSync(path.join(directory, 'salt.bin'), salt);
+            createEncryptedDb(await builder.deriveLegacyKey(legacySecret, salt), 'device-loss-preserved');
+        } else {
+            const dek = crypto.randomBytes(32);
+            createEncryptedDb(dek, 'device-loss-preserved');
+            const salt = crypto.randomBytes(16);
+            const wrapped = wrapLegacyV2(dek, await builder.deriveLegacyKey(legacySecret, salt));
+            fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+                version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
+            }));
+        }
+
+        const migrated = new SecurityService(oldStore);
+        await migrated.migrateLegacy(legacySecret, dbPath, directory);
+        const pendingFinalCode = migrated.getPendingRecoveryCode()!;
+        migrated.closeDb();
+
+        const newStore = new IntegrationDeviceStore(0x72);
+        const recovered = new SecurityService(newStore);
+        await recovered.recoverDevice(
+            recoveryPath === 'final' ? pendingFinalCode : legacySecret,
+            directory,
+            dbPath
+        );
+        expect(recovered.getDb().prepare('SELECT value FROM clinical_data').get())
+            .toEqual({ value: 'device-loss-preserved' });
+        if (recoveryPath === 'final') {
+            expect(recovered.getPendingRecoveryCode()).toBeNull();
+        } else {
+            const rotatedCode = recovered.getPendingRecoveryCode();
+            expect(rotatedCode).toBeTruthy();
+            recovered.acknowledgePendingRecoveryCode(rotatedCode!);
+        }
+        recovered.closeDb();
+        await expect(new SecurityService(newStore).initializeDevice(dbPath, directory))
+            .resolves.toEqual({ migrated: false });
+        await expect(new SecurityService(oldStore).initializeDevice(dbPath, directory))
+            .rejects.toThrow('DEVICE_UNLOCK_FAILED');
+    });
+});

--- a/desktop/src/main/services/SecurityService.spec.ts
+++ b/desktop/src/main/services/SecurityService.spec.ts
@@ -1,107 +1,697 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { DeviceKeyStore } from './DeviceKeyStore';
 import { SecurityService } from './SecurityService';
 
-// Mock dependencies
 vi.mock('argon2', () => ({
-    hash: vi.fn(),
-    argon2id: 2
+    argon2id: 2,
+    hash: vi.fn(async (secret: string, options: { salt: Buffer }) =>
+        crypto.createHash('sha256').update(options.salt).update(secret).digest())
 }));
 
-// Mock better-sqlite3-multiple-ciphers (used in app)
-const mockPragma = vi.fn();
-const mockPrepare = vi.fn();
-const mockGet = vi.fn();
-const mockClose = vi.fn();
+interface DbState { vault?: { vault_id: string; key_version: number } }
+const databases = new Map<string, DbState>();
+let rejectOpen = false;
+let failInsert = false;
 
-mockPrepare.mockReturnValue({ get: mockGet });
-
-vi.mock('better-sqlite3-multiple-ciphers', () => {
-    return {
-        default: class {
-            pragma: any;
-            prepare: any;
-            close: any;
-            constructor() {
-                this.pragma = mockPragma;
-                this.prepare = mockPrepare;
-                this.close = mockClose;
-            }
+vi.mock('better-sqlite3-multiple-ciphers', () => ({
+    default: class MockDatabase {
+        private state: DbState;
+        constructor(private file: string) {
+            this.state = databases.get(file) || {};
+            databases.set(file, this.state);
         }
-    };
-});
+        pragma(statement: string) {
+            if (rejectOpen && statement.startsWith('key =')) throw new Error('file is not a database');
+        }
+        exec() { }
+        prepare(sql: string) {
+            if (sql.includes('count(*)')) return { get: () => ({ count: 1 }) };
+            if (sql.startsWith('SELECT vault_id')) return { get: () => this.state.vault };
+            if (sql.startsWith('INSERT INTO')) return {
+                run: (vaultId: string, keyVersion: number) => {
+                    if (failInsert) throw new Error('forced binding failure');
+                    this.state.vault = { vault_id: vaultId, key_version: keyVersion };
+                }
+            };
+            throw new Error(`Unexpected SQL: ${sql}`);
+        }
+        close() { }
+    }
+}));
 
+class MemoryDeviceKeyStore implements DeviceKeyStore {
+    available = true;
+    private maskByte = 0x5a;
+    status() {
+        return this.available
+            ? { available: true, provider: 'test-device-store' }
+            : { available: false, provider: 'test-device-store', reason: 'ENCRYPTION_UNAVAILABLE' as const };
+    }
+    protect(value: Buffer): Buffer { return Buffer.from(value.map(byte => byte ^ this.maskByte)); }
+    unprotect(value: Buffer): Buffer { return this.protect(value); }
+}
 
-describe('SecurityService', () => {
-    let service: SecurityService;
-    let argon2: any;
+describe('SecurityService v3', () => {
+    let directory: string;
+    let dbPath: string;
+    let store: MemoryDeviceKeyStore;
 
-    beforeEach(async () => {
-        vi.clearAllMocks();
-        argon2 = await import('argon2');
-        service = new SecurityService();
-
-        // Default mock behaviors
-        argon2.hash.mockResolvedValue(Buffer.from('mocked-hash-key'));
-        mockGet.mockReturnValue({ 'count(*)': 1 }); // Success by default
+    beforeEach(() => {
+        directory = fs.mkdtempSync(path.join(os.tmpdir(), 'nalamdesk-security-'));
+        dbPath = path.join(directory, 'nalamdesk.db');
+        fs.writeFileSync(dbPath, '');
+        databases.clear();
+        rejectOpen = false;
+        failInsert = false;
+        store = new MemoryDeviceKeyStore();
     });
 
-    describe('deriveKey', () => {
-        it('should derive a 32-byte key using argon2id', async () => {
-            const password = 'my-secret-password';
-            const salt = Buffer.alloc(16, 'a');
-            const result = await service.deriveKey(password, salt);
+    afterEach(() => fs.rmSync(directory, { recursive: true, force: true }));
 
-            expect(argon2.hash).toHaveBeenCalledWith(password, expect.objectContaining({
-                type: 2, // argon2id
-                raw: true,
-                salt: salt // Ensuring salt is passed
+    it('creates a v3 config without the admin password or plaintext DEK', async () => {
+        const service = new SecurityService(store);
+        const code = await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        const text = fs.readFileSync(path.join(directory, 'security.json'), 'utf8');
+        const config = JSON.parse(text);
+
+        expect(config.version).toBe(3);
+        expect(config.vaultId).toMatch(/^[0-9a-f-]{36}$/);
+        expect(config.keyVersion).toBe(1);
+        expect(config.device.provider).toBe('test-device-store');
+        expect(config.recovery.kdf).toBe('argon2id');
+        expect(text).not.toContain('admin-secret');
+        expect(code).toMatch(/^[A-F0-9]{8}(?:-[A-F0-9]{8}){3}$/);
+    });
+
+    it('unlocks after a cold start without receiving any user password', async () => {
+        const first = new SecurityService(store);
+        await first.setup('admin-secret', dbPath, directory);
+        first.completeProvisioning();
+        first.closeDb();
+
+        const coldStart = new SecurityService(store);
+        await expect(coldStart.initializeDevice(dbPath, directory)).resolves.toEqual({ migrated: false });
+        expect(coldStart.getDb()).toBeTruthy();
+    });
+
+    it('fails closed when device encryption is unavailable', async () => {
+        store.available = false;
+        const service = new SecurityService(store);
+        await expect(service.setup('irrelevant', dbPath, directory)).rejects.toThrow('ENCRYPTION_UNAVAILABLE');
+    });
+
+    it('rolls back a newly-created database when setup fails after binding and permits retry', async () => {
+        const failing = new SecurityService(store);
+        vi.spyOn(failing as any, 'saveConfigAtomic').mockImplementation(() => { throw new Error('forced config failure'); });
+        await expect(failing.setup('admin-secret', dbPath, directory)).rejects.toThrow('forced config failure');
+        expect(fs.existsSync(dbPath)).toBe(false);
+        expect(fs.existsSync(path.join(directory, 'security.json'))).toBe(false);
+        expect(fs.existsSync(path.join(directory, 'security-setup.json'))).toBe(false);
+
+        databases.delete(dbPath);
+        const retry = new SecurityService(store);
+        await expect(retry.setup('admin-secret', dbPath, directory)).resolves.toBeTruthy();
+        retry.completeProvisioning();
+    });
+
+    it('rolls back an interrupted full provisioning on restart and permits retry', async () => {
+        const interrupted = new SecurityService(store);
+        await interrupted.setup('admin-secret', dbPath, directory);
+        expect(fs.existsSync(path.join(directory, 'security-setup.json'))).toBe(true);
+        interrupted.closeDb();
+
+        const restarted = new SecurityService(store);
+        restarted.reconcileProvisioning(dbPath, directory);
+        expect(fs.existsSync(dbPath)).toBe(false);
+        expect(fs.existsSync(path.join(directory, 'security.json'))).toBe(false);
+        expect(fs.existsSync(path.join(directory, 'security-setup.json'))).toBe(false);
+
+        databases.delete(dbPath);
+        const code = await restarted.setup('admin-secret', dbPath, directory);
+        restarted.completeProvisioning();
+        expect(code).toBe(restarted.getPendingRecoveryCode());
+    });
+
+    it('keeps a fresh recovery code device-encrypted until exact acknowledgement', async () => {
+        const service = new SecurityService(store);
+        const code = await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        const configText = fs.readFileSync(path.join(directory, 'security.json'), 'utf8');
+        expect(configText).not.toContain(code);
+        service.closeDb();
+
+        const restarted = new SecurityService(store);
+        await restarted.initializeDevice(dbPath, directory);
+        expect(restarted.getPendingRecoveryCode()).toBe(code);
+        expect(() => restarted.acknowledgePendingRecoveryCode(`${code}X`)).toThrow('INVALID_RECOVERY_ACK');
+        restarted.acknowledgePendingRecoveryCode(code);
+        expect(restarted.getPendingRecoveryCode()).toBeNull();
+    });
+
+    it('reconciles an already-complete provisioning journal after cleanup interruption', async () => {
+        let failed = false;
+        const service = new SecurityService(store, {
+            onStep: step => {
+                if (step === 'cleanup-setup-journal' && !failed) {
+                    failed = true;
+                    throw new Error('cleanup interrupted');
+                }
+            }
+        });
+        await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        expect(fs.existsSync(path.join(directory, 'security-setup.json'))).toBe(true);
+        service.closeDb();
+
+        const restarted = new SecurityService(store);
+        restarted.reconcileProvisioning(dbPath, directory);
+        expect(fs.existsSync(path.join(directory, 'security-setup.json'))).toBe(false);
+        await expect(restarted.initializeDevice(dbPath, directory)).resolves.toEqual({ migrated: false });
+    });
+
+    it('refuses and preserves an existing unclaimed database during fresh setup', async () => {
+        fs.writeFileSync(dbPath, 'existing clinic data');
+        await expect(new SecurityService(store).setup('admin-secret', dbPath, directory))
+            .rejects.toThrow('UNCLAIMED_DATABASE_PRESENT');
+        expect(fs.readFileSync(dbPath, 'utf8')).toBe('existing clinic data');
+    });
+
+    it('requires recovery when the device envelope cannot be decrypted', async () => {
+        const service = new SecurityService(store);
+        await service.setup('irrelevant', dbPath, directory);
+        service.completeProvisioning();
+        service.closeDb();
+        vi.spyOn(store, 'unprotect').mockImplementation(() => { throw new Error('keychain denied'); });
+
+        await expect(new SecurityService(store).initializeDevice(dbPath, directory)).rejects.toThrow('DEVICE_UNLOCK_FAILED');
+    });
+
+    it('re-enrols a replacement device with the recovery code', async () => {
+        const originalStore = new MemoryDeviceKeyStore();
+        const original = new SecurityService(originalStore);
+        const recoveryCode = await original.setup('admin-secret', dbPath, directory);
+        original.completeProvisioning();
+        original.closeDb();
+
+        const replacementStore = new MemoryDeviceKeyStore();
+        (replacementStore as any).maskByte = 0x33;
+        const replacement = new SecurityService(replacementStore);
+        await expect(replacement.recoverDevice(recoveryCode, directory, dbPath)).resolves.toEqual({ migrated: false });
+        replacement.closeDb();
+        await expect(new SecurityService(replacementStore).initializeDevice(dbPath, directory)).resolves.toEqual({ migrated: false });
+    });
+
+    it('rejects an incorrect recovery code without rewriting config', async () => {
+        const service = new SecurityService(store);
+        await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        service.closeDb();
+        const before = fs.readFileSync(path.join(directory, 'security.json'));
+
+        await expect(service.recoverDevice('WRONG-CODE', directory, dbPath)).rejects.toThrow('INVALID_RECOVERY_CODE');
+        expect(fs.readFileSync(path.join(directory, 'security.json'))).toEqual(before);
+    });
+
+    it('detects a swapped security config using the database vault binding', async () => {
+        const service = new SecurityService(store);
+        await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        service.closeDb();
+        const configPath = path.join(directory, 'security.json');
+        const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+        config.vaultId = crypto.randomUUID();
+        fs.writeFileSync(configPath, JSON.stringify(config));
+
+        await expect(new SecurityService(store).initializeDevice(dbPath, directory)).rejects.toThrow('VAULT_BINDING_MISMATCH');
+    });
+
+    it('migrates v2 to v3 and durably protects the pending recovery acknowledgement', async () => {
+        const legacyBuilder = new SecurityService(store) as any;
+        const salt = crypto.randomBytes(16);
+        const legacyKey = crypto.randomBytes(32);
+        const kek = await legacyBuilder.deriveKey('legacy-master', salt);
+        const wrapped = legacyBuilder.aesEncrypt(legacyKey, kek);
+        fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+            version: 2,
+            salt: salt.toString('hex'),
+            wrappedKey: wrapped.wrappedKey,
+            iv: wrapped.iv
+        }));
+
+        const service = new SecurityService(store);
+        const result = await service.migrateLegacy('legacy-master', dbPath, directory);
+        const migratedText = fs.readFileSync(path.join(directory, 'security.json'), 'utf8');
+        const migrated = JSON.parse(migratedText);
+        expect(result.migrated).toBe(true);
+        const pendingCode = service.getPendingRecoveryCode();
+        expect(pendingCode).toMatch(/^[A-F0-9]{8}(?:-[A-F0-9]{8}){3}$/);
+        expect(migrated.version).toBe(3);
+        expect(migrated.migratedFrom).toBe(2);
+        expect(migratedText).not.toContain('legacy-master');
+        expect(migratedText).not.toContain(pendingCode!);
+        expect(fs.existsSync(`${dbPath}.pre-v3-migration`)).toBe(false);
+        expect(fs.existsSync(path.join(directory, 'security-migration.json'))).toBe(false);
+    });
+
+    it('can migrate v2 through its legacy recovery wrapper when the master password is unavailable', async () => {
+        const legacyBuilder = new SecurityService(store) as any;
+        const legacyKey = crypto.randomBytes(32);
+        const passwordSalt = crypto.randomBytes(16);
+        const recoverySalt = crypto.randomBytes(16);
+        const passwordWrapped = legacyBuilder.aesEncrypt(legacyKey, await legacyBuilder.deriveLegacyKey('old-master', passwordSalt));
+        const recoveryWrapped = legacyBuilder.aesEncrypt(legacyKey, await legacyBuilder.deriveLegacyKey('old-recovery', recoverySalt));
+        fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+            version: 2,
+            salt: passwordSalt.toString('hex'),
+            wrappedKey: passwordWrapped.wrappedKey,
+            iv: passwordWrapped.iv,
+            recovery: {
+                salt: recoverySalt.toString('hex'),
+                wrappedKey: recoveryWrapped.wrappedKey,
+                iv: recoveryWrapped.iv
+            }
+        }));
+
+        const service = new SecurityService(store);
+        const result = await service.recoverDevice('old-recovery', directory, dbPath);
+        expect(result.migrated).toBe(true);
+        expect(service.getPendingRecoveryCode()).toBeTruthy();
+        expect(JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8')).version).toBe(3);
+    });
+
+    it('keeps migration recovery acknowledgement across restart until explicitly cleared', async () => {
+        const legacyBuilder = new SecurityService(store) as any;
+        const salt = crypto.randomBytes(16);
+        const key = crypto.randomBytes(32);
+        const wrapped = legacyBuilder.aesEncrypt(key, await legacyBuilder.deriveLegacyKey('legacy', salt));
+        fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+            version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
+        }));
+        await new SecurityService(store).migrateLegacy('legacy', dbPath, directory);
+
+        const restarted = new SecurityService(store);
+        await restarted.initializeDevice(dbPath, directory);
+        const pending = restarted.getPendingRecoveryCode();
+        expect(pending).toBeTruthy();
+        expect(() => restarted.acknowledgePendingRecoveryCode('WRONG-CODE')).toThrow('INVALID_RECOVERY_ACK');
+        restarted.acknowledgePendingRecoveryCode(pending!);
+        expect(restarted.getPendingRecoveryCode()).toBeNull();
+    });
+
+    it.each([1, 2] as const)(
+        'recovers a migrated v%s vault on a new device with the final pending code and retires transition recovery',
+        async version => {
+            const legacySecret = `legacy-v${version}`;
+            if (version === 1) {
+                fs.writeFileSync(path.join(directory, 'salt.bin'), crypto.randomBytes(16));
+            } else {
+                const builder = new SecurityService(store) as any;
+                const salt = crypto.randomBytes(16);
+                const key = crypto.randomBytes(32);
+                const wrapped = builder.aesEncrypt(key, await builder.deriveLegacyKey(legacySecret, salt));
+                fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+                    version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
+                }));
+            }
+            const migrated = new SecurityService(store);
+            await migrated.migrateLegacy(legacySecret, dbPath, directory);
+            const finalCode = migrated.getPendingRecoveryCode()!;
+            migrated.closeDb();
+
+            const replacementStore = new MemoryDeviceKeyStore();
+            (replacementStore as any).maskByte = 0x33;
+            const replacement = new SecurityService(replacementStore);
+            await replacement.recoverDevice(finalCode, directory, dbPath);
+            expect(replacement.getPendingRecoveryCode()).toBeNull();
+            expect(JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8')).transitionRecovery).toBeUndefined();
+            replacement.closeDb();
+            await expect(new SecurityService(replacementStore).initializeDevice(dbPath, directory))
+                .resolves.toEqual({ migrated: false });
+        }
+    );
+
+    it.each([1, 2] as const)(
+        'recovers a migrated v%s vault on a new device with its transition secret and rotates recovery again',
+        async version => {
+            const legacySecret = `legacy-v${version}`;
+            if (version === 1) {
+                fs.writeFileSync(path.join(directory, 'salt.bin'), crypto.randomBytes(16));
+            } else {
+                const builder = new SecurityService(store) as any;
+                const salt = crypto.randomBytes(16);
+                const key = crypto.randomBytes(32);
+                const wrapped = builder.aesEncrypt(key, await builder.deriveLegacyKey(legacySecret, salt));
+                fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+                    version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
+                }));
+            }
+            const migrated = new SecurityService(store);
+            await migrated.migrateLegacy(legacySecret, dbPath, directory);
+            migrated.closeDb();
+
+            const replacementStore = new MemoryDeviceKeyStore();
+            (replacementStore as any).maskByte = 0x33;
+            const replacement = new SecurityService(replacementStore);
+            await replacement.recoverDevice(legacySecret, directory, dbPath);
+            const rotatedCode = replacement.getPendingRecoveryCode();
+            expect(rotatedCode).toMatch(/^[A-F0-9]{8}(?:-[A-F0-9]{8}){3}$/);
+            const config = JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8'));
+            expect(config.transitionRecovery?.purpose).toBe('legacy-transition');
+            expect(() => replacement.acknowledgePendingRecoveryCode('WRONG')).toThrow('INVALID_RECOVERY_ACK');
+            replacement.acknowledgePendingRecoveryCode(rotatedCode!);
+            replacement.closeDb();
+            await expect(new SecurityService(store).initializeDevice(dbPath, directory))
+                .rejects.toThrow('DEVICE_UNLOCK_FAILED');
+            await expect(new SecurityService(replacementStore).initializeDevice(dbPath, directory))
+                .resolves.toEqual({ migrated: false });
+        }
+    );
+
+    it('migrates a v1 direct-password database with a journaled rekey', async () => {
+        fs.writeFileSync(path.join(directory, 'salt.bin'), crypto.randomBytes(16));
+        const service = new SecurityService(store);
+        const result = await service.migrateLegacy('legacy-master', dbPath, directory);
+        const config = JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8'));
+
+        expect(result).toMatchObject({ migrated: true });
+        expect(config).toMatchObject({ version: 3, migratedFrom: 1 });
+        expect(fs.existsSync(path.join(directory, 'salt.bin'))).toBe(false);
+        expect(fs.existsSync(path.join(directory, 'salt.bin.migrated'))).toBe(true);
+    });
+
+    it('rolls the database back when migration fails after the snapshot', async () => {
+        const legacyBuilder = new SecurityService(store) as any;
+        const salt = crypto.randomBytes(16);
+        const legacyKey = crypto.randomBytes(32);
+        const wrapped = legacyBuilder.aesEncrypt(legacyKey, await legacyBuilder.deriveKey('legacy-master', salt));
+        fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+            version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
+        }));
+        const original = fs.readFileSync(dbPath);
+        const originalConfig = fs.readFileSync(path.join(directory, 'security.json'));
+        failInsert = true;
+
+        await expect(new SecurityService(store).migrateLegacy('legacy-master', dbPath, directory)).rejects.toThrow('forced binding failure');
+        expect(fs.readFileSync(dbPath)).toEqual(original);
+        expect(fs.readFileSync(path.join(directory, 'security.json'))).toEqual(originalConfig);
+    });
+
+    it.each(['cleanup-database-backup', 'cleanup-config-backup', 'cleanup-journal'] as const)(
+        'keeps committed migration authoritative when %s fails and reconciles on restart',
+        async cleanupStep => {
+            const legacyBuilder = new SecurityService(store) as any;
+            const salt = crypto.randomBytes(16);
+            const key = crypto.randomBytes(32);
+            const wrapped = legacyBuilder.aesEncrypt(key, await legacyBuilder.deriveLegacyKey('legacy', salt));
+            fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+                version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
             }));
-            expect(result).toEqual(Buffer.from('mocked-hash-key'));
-        });
+            let failed = false;
+            const service = new SecurityService(store, {
+                onStep: step => {
+                    if (step === cleanupStep && !failed) { failed = true; throw new Error('cleanup failure'); }
+                }
+            });
+            await expect(service.migrateLegacy('legacy', dbPath, directory)).resolves.toEqual({ migrated: true });
+            expect(JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8')).version).toBe(3);
+            service.closeDb();
+            await expect(new SecurityService(store).initializeDevice(dbPath, directory)).resolves.toEqual({ migrated: false });
+            expect(fs.existsSync(path.join(directory, 'security-migration.json'))).toBe(false);
+        }
+    );
 
-        it('should propagate errors from argon2', async () => {
-            argon2.hash.mockRejectedValue(new Error('Argon error'));
-            await expect(service.deriveKey('pass', Buffer.alloc(16))).rejects.toThrow('Argon error');
+    it('never rolls back after the atomic v3 config commit point', async () => {
+        const legacyBuilder = new SecurityService(store) as any;
+        const salt = crypto.randomBytes(16);
+        const key = crypto.randomBytes(32);
+        const wrapped = legacyBuilder.aesEncrypt(key, await legacyBuilder.deriveLegacyKey('legacy', salt));
+        fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+            version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
+        }));
+        const service = new SecurityService(store, {
+            onStep: step => { if (step === 'migration-after-config-commit') throw new Error('post-commit failure'); }
         });
+        await expect(service.migrateLegacy('legacy', dbPath, directory)).resolves.toEqual({ migrated: true });
+        expect(JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8')).version).toBe(3);
     });
 
-    describe('initDb', () => {
-        const mockKey = Buffer.from('test-key');
-        const dbPath = 'test.db';
-
-        it('should initialize database with correct pragma key', () => {
-            (service as any).initDb(dbPath, mockKey);
-
-            expect(mockPragma).toHaveBeenCalledWith(`key = "x'${mockKey.toString('hex')}'"`);
-            expect(mockPrepare).toHaveBeenCalledWith('SELECT count(*) FROM sqlite_master'); // Verification query
-            expect(service.getDb()).toBeDefined();
+    it('reconciles a failed legacy-salt cleanup without rolling back committed v1 migration', async () => {
+        fs.writeFileSync(path.join(directory, 'salt.bin'), crypto.randomBytes(16));
+        let failed = false;
+        const service = new SecurityService(store, {
+            onStep: step => {
+                if (step === 'cleanup-legacy-salt' && !failed) { failed = true; throw new Error('cleanup failure'); }
+            }
         });
-
-        it('should throw INVALID_PASSWORD on sqlite error "file is not a database"', () => {
-            // Simulate wrong password error
-            mockGet.mockImplementation(() => { throw new Error('file is not a database'); });
-
-            expect(() => (service as any).initDb(dbPath, mockKey)).toThrow('INVALID_PASSWORD');
-            expect(service.getDb()).toBeUndefined(); // Should not have set the db
-        });
-
-        it('should rethrow other errors', () => {
-            mockGet.mockImplementation(() => { throw new Error('Disk full'); });
-            expect(() => (service as any).initDb(dbPath, mockKey)).toThrow('Disk full');
-        });
+        await service.migrateLegacy('legacy-master', dbPath, directory);
+        service.closeDb();
+        await expect(new SecurityService(store).initializeDevice(dbPath, directory)).resolves.toEqual({ migrated: false });
+        expect(fs.existsSync(path.join(directory, 'salt.bin.migrated'))).toBe(true);
     });
 
-    describe('closeDb', () => {
-        it('should close the database if open', () => {
-            (service as any).initDb('path', Buffer.from('key'));
-            service.closeDb();
-            expect(mockClose).toHaveBeenCalled();
-            expect(service.getDb()).toBeNull();
-        });
+    it('reconciles an interrupted pre-commit migration by restoring its snapshots', async () => {
+        const configPath = path.join(directory, 'security.json');
+        const backupPath = `${dbPath}.pre-v3-migration`;
+        const configBackup = `${configPath}.pre-v3-migration`;
+        fs.writeFileSync(dbPath, 'partially migrated');
+        fs.writeFileSync(backupPath, 'original database');
+        fs.writeFileSync(configPath, JSON.stringify({ version: 3, incomplete: true }));
+        fs.writeFileSync(configBackup, JSON.stringify({ version: 2, salt: '00', wrappedKey: '00', iv: '00' }));
+        fs.writeFileSync(path.join(directory, 'security-migration.json'), JSON.stringify({
+            version: 1,
+            sourceVersion: 2,
+            phase: 'snapshot-created',
+            databaseBackup: backupPath,
+            configBackup,
+            startedAt: new Date().toISOString()
+        }));
 
-        it('should do nothing if db is not open', () => {
-            service.closeDb();
-            expect(mockClose).not.toHaveBeenCalled();
+        await expect(new SecurityService(store).initializeDevice(dbPath, directory)).rejects.toThrow('LEGACY_MIGRATION_REQUIRED');
+        expect(fs.readFileSync(dbPath, 'utf8')).toBe('original database');
+        expect(JSON.parse(fs.readFileSync(configPath, 'utf8')).version).toBe(2);
+        expect(fs.existsSync(path.join(directory, 'security-migration.json'))).toBe(false);
+    });
+
+    it('records rollback restoration before best-effort cleanup and never needs an already deleted snapshot', async () => {
+        const configPath = path.join(directory, 'security.json');
+        const backupPath = `${dbPath}.pre-v3-migration`;
+        const configBackup = `${configPath}.pre-v3-migration`;
+        fs.writeFileSync(dbPath, 'partially migrated');
+        fs.writeFileSync(backupPath, 'original database');
+        fs.writeFileSync(configPath, JSON.stringify({ version: 3, incomplete: true }));
+        fs.writeFileSync(configBackup, JSON.stringify({ version: 2, salt: '00', wrappedKey: '00', iv: '00' }));
+        fs.writeFileSync(path.join(directory, 'security-migration.json'), JSON.stringify({
+            version: 1,
+            sourceVersion: 2,
+            phase: 'snapshot-created',
+            databaseBackup: backupPath,
+            configBackup,
+            startedAt: new Date().toISOString()
+        }));
+        let failed = false;
+        const firstRestart = new SecurityService(store, {
+            onStep: step => {
+                if (step === 'cleanup-rollback-database-backup' && !failed) {
+                    failed = true;
+                    throw new Error('cleanup interrupted');
+                }
+            }
         });
+        await expect(firstRestart.initializeDevice(dbPath, directory)).rejects.toThrow('LEGACY_MIGRATION_REQUIRED');
+        const journal = JSON.parse(fs.readFileSync(path.join(directory, 'security-migration.json'), 'utf8'));
+        expect(journal.phase).toBe('rollback-restored');
+        // Simulate another cleanup artifact already having disappeared.
+        if (fs.existsSync(configBackup)) fs.unlinkSync(configBackup);
+
+        await expect(new SecurityService(store).initializeDevice(dbPath, directory))
+            .rejects.toThrow('LEGACY_MIGRATION_REQUIRED');
+        expect(fs.readFileSync(dbPath, 'utf8')).toBe('original database');
+        expect(fs.existsSync(path.join(directory, 'security-migration.json'))).toBe(false);
+    });
+
+    it('exposes only portable recovery metadata for backup consumers', async () => {
+        const service = new SecurityService(store);
+        await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        const metadata = service.getPortableVaultMetadata() as any;
+        expect(metadata.device).toBeUndefined();
+        expect(Object.keys(metadata).sort()).toEqual(['keyVersion', 'recovery', 'vaultId', 'version']);
+    });
+
+    it('installs portable metadata only after recovery and vault-binding validation', async () => {
+        const source = new SecurityService(store);
+        const recoveryCode = await source.setup('admin-secret', dbPath, directory);
+        source.completeProvisioning();
+        const metadata = source.getPortableVaultMetadata();
+        source.closeDb();
+
+        const restoreDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'nalamdesk-security-restore-'));
+        const restoreDbPath = path.join(restoreDirectory, 'nalamdesk.db');
+        fs.copyFileSync(dbPath, restoreDbPath);
+        databases.set(restoreDbPath, { vault: { ...databases.get(dbPath)!.vault! } });
+        try {
+            const restored = new SecurityService(store);
+            await restored.installPortableVaultMetadata(metadata, recoveryCode, restoreDbPath, restoreDirectory);
+            expect(JSON.parse(fs.readFileSync(path.join(restoreDirectory, 'security.json'), 'utf8'))).toMatchObject({
+                version: 3,
+                vaultId: metadata.vaultId
+            });
+        } finally {
+            fs.rmSync(restoreDirectory, { recursive: true, force: true });
+        }
+    });
+
+    it('retires transition recovery when portable metadata is installed with the primary code', async () => {
+        const legacySecret = 'legacy-portable-secret';
+        const builder = new SecurityService(store) as any;
+        const salt = crypto.randomBytes(16);
+        const key = crypto.randomBytes(32);
+        const wrapped = builder.aesEncrypt(key, await builder.deriveLegacyKey(legacySecret, salt));
+        fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+            version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
+        }));
+        const migrated = new SecurityService(store);
+        await migrated.migrateLegacy(legacySecret, dbPath, directory);
+        const finalCode = migrated.getPendingRecoveryCode()!;
+        const metadata = migrated.getPortableVaultMetadata();
+        expect(metadata.transitionRecovery).toBeTruthy();
+        migrated.closeDb();
+
+        const restoreDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'nalamdesk-security-transition-'));
+        const restoreDbPath = path.join(restoreDirectory, 'nalamdesk.db');
+        fs.copyFileSync(dbPath, restoreDbPath);
+        databases.set(restoreDbPath, { vault: { ...databases.get(dbPath)!.vault! } });
+        try {
+            const restored = new SecurityService(store);
+            await restored.installPortableVaultMetadata(metadata, finalCode, restoreDbPath, restoreDirectory);
+            const installed = JSON.parse(fs.readFileSync(path.join(restoreDirectory, 'security.json'), 'utf8'));
+            expect(installed.transitionRecovery).toBeUndefined();
+            expect(installed.pendingRecoveryAck).toBeUndefined();
+            restored.closeDb();
+            await expect(new SecurityService(store).recoverDevice(
+                legacySecret, restoreDirectory, restoreDbPath
+            )).rejects.toThrow('INVALID_RECOVERY_CODE');
+        } finally {
+            fs.rmSync(restoreDirectory, { recursive: true, force: true });
+        }
+    });
+
+    it('closes the database and restores the prior config when device recovery commit fails', async () => {
+        const source = new SecurityService(store);
+        const recoveryCode = await source.setup('admin-secret', dbPath, directory);
+        source.completeProvisioning();
+        source.closeDb();
+        const configPath = path.join(directory, 'security.json');
+        const before = fs.readFileSync(configPath, 'utf8');
+
+        const replacement = new SecurityService(store);
+        const save = (replacement as any).saveConfigAtomic.bind(replacement);
+        vi.spyOn(replacement as any, 'saveConfigAtomic').mockImplementation((config: any) => {
+            save(config);
+            throw new Error('forced post-commit failure');
+        });
+        await expect(replacement.recoverDevice(recoveryCode, directory, dbPath))
+            .rejects.toThrow('forced post-commit failure');
+        expect(replacement.getDb()).toBeFalsy();
+        expect(fs.readFileSync(configPath, 'utf8')).toBe(before);
+    });
+
+    it('closes the database and restores an existing config when portable install commit fails', async () => {
+        const source = new SecurityService(store);
+        const recoveryCode = await source.setup('admin-secret', dbPath, directory);
+        source.completeProvisioning();
+        const metadata = source.getPortableVaultMetadata();
+        source.closeDb();
+
+        const restoreDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'nalamdesk-security-install-failure-'));
+        const restoreDbPath = path.join(restoreDirectory, 'nalamdesk.db');
+        const restoreConfigPath = path.join(restoreDirectory, 'security.json');
+        const previous = '{"sentinel":true}';
+        fs.copyFileSync(dbPath, restoreDbPath);
+        fs.writeFileSync(restoreConfigPath, previous);
+        databases.set(restoreDbPath, { vault: { ...databases.get(dbPath)!.vault! } });
+        try {
+            const restored = new SecurityService(store);
+            const save = (restored as any).saveConfigAtomic.bind(restored);
+            vi.spyOn(restored as any, 'saveConfigAtomic').mockImplementation((config: any) => {
+                save(config);
+                throw new Error('forced portable commit failure');
+            });
+            await expect(restored.installPortableVaultMetadata(
+                metadata, recoveryCode, restoreDbPath, restoreDirectory
+            )).rejects.toThrow('forced portable commit failure');
+            expect(restored.getDb()).toBeFalsy();
+            expect(fs.readFileSync(restoreConfigPath, 'utf8')).toBe(previous);
+        } finally {
+            fs.rmSync(restoreDirectory, { recursive: true, force: true });
+        }
+    });
+
+    it('rejects hostile portable KDF parameters before deriving a key', async () => {
+        const source = new SecurityService(store);
+        const recoveryCode = await source.setup('admin-secret', dbPath, directory);
+        source.completeProvisioning();
+        const metadata = source.getPortableVaultMetadata();
+        source.closeDb();
+        metadata.recovery.kdfParams.memoryCost = Number.MAX_SAFE_INTEGER;
+
+        await expect(new SecurityService(store).installPortableVaultMetadata(
+            metadata,
+            recoveryCode,
+            dbPath,
+            directory
+        )).rejects.toThrow('INVALID_RECOVERY_ENVELOPE');
+    });
+
+    it('authenticates the recovery envelope against vault context using AAD', async () => {
+        const service = new SecurityService(store);
+        const code = await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        const metadata = service.getPortableVaultMetadata();
+        service.closeDb();
+        metadata.vaultId = crypto.randomUUID();
+        await expect(new SecurityService(store).installPortableVaultMetadata(
+            metadata, code, dbPath, directory
+        )).rejects.toThrow();
+    });
+
+    it.each(['EPERM', 'EINVAL'])(
+        'propagates Windows regular-file fsync %s failures',
+        code => {
+            const failure = Object.assign(new Error(`regular file ${code}`), { code });
+            const service = new SecurityService(store, {
+                platform: 'win32',
+                fsync: () => { throw failure; }
+            });
+            expect(() => (service as any).fsyncFile(dbPath)).toThrow(`regular file ${code}`);
+        }
+    );
+
+    it.each(['EPERM', 'EINVAL', 'ENOSYS', 'ENOTSUP'])(
+        'tolerates Windows directory fsync incompatibility %s',
+        code => {
+            const unsupported = Object.assign(new Error(`directory ${code}`), { code });
+            const service = new SecurityService(store, {
+                platform: 'win32',
+                fsync: () => { throw unsupported; }
+            });
+            (service as any).configurePaths(dbPath, directory);
+            expect(() => (service as any).fsyncDirectory()).not.toThrow();
+        }
+    );
+
+    it('propagates genuine Windows directory fsync I/O failures', () => {
+        const failure = Object.assign(new Error('directory device I/O failure'), { code: 'EIO' });
+        const service = new SecurityService(store, {
+            platform: 'win32',
+            fsync: () => { throw failure; }
+        });
+        (service as any).configurePaths(dbPath, directory);
+        expect(() => (service as any).fsyncDirectory()).toThrow('directory device I/O failure');
     });
 });

--- a/desktop/src/main/services/SecurityService.spec.ts
+++ b/desktop/src/main/services/SecurityService.spec.ts
@@ -384,6 +384,24 @@ describe('SecurityService v3', () => {
         expect(fs.existsSync(path.join(directory, 'salt.bin.migrated'))).toBe(true);
     });
 
+    it('retires transitional recovery artifacts when regenerating the primary code', async () => {
+        fs.writeFileSync(path.join(directory, 'salt.bin'), crypto.randomBytes(16));
+        const service = new SecurityService(store);
+        await service.migrateLegacy('legacy-master', dbPath, directory);
+        const migratedConfig = JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8'));
+
+        expect(migratedConfig.pendingRecoveryAck).toBeTruthy();
+        expect(migratedConfig.transitionRecovery).toBeTruthy();
+
+        const replacementCode = await service.regenerateRecoveryCode();
+        const updatedConfig = JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8'));
+
+        expect(replacementCode).toMatch(/^[A-F0-9]{8}(?:-[A-F0-9]{8}){3}$/);
+        expect(updatedConfig.pendingRecoveryAck).toBeUndefined();
+        expect(updatedConfig.transitionRecovery).toBeUndefined();
+        expect(service.getPendingRecoveryCode()).toBeNull();
+    });
+
     it('rolls the database back when migration fails after the snapshot', async () => {
         const legacyBuilder = new SecurityService(store) as any;
         const salt = crypto.randomBytes(16);

--- a/desktop/src/main/services/SecurityService.ts
+++ b/desktop/src/main/services/SecurityService.ts
@@ -310,6 +310,8 @@ export class SecurityService {
         const config = this.loadConfigV3();
         const recoveryCode = this.generateRecoveryCodeString();
         config.recovery = await this.createRecoveryEnvelope(this.dek, recoveryCode, config.vaultId, config.keyVersion);
+        delete config.pendingRecoveryAck;
+        delete config.transitionRecovery;
         this.saveConfigAtomic(config);
         return recoveryCode;
     }

--- a/desktop/src/main/services/SecurityService.ts
+++ b/desktop/src/main/services/SecurityService.ts
@@ -1,403 +1,1006 @@
 import * as argon2 from 'argon2';
-// @ts-ignore - types might be missing or need specific import
+// @ts-ignore native module has no compatible default declaration
 import Database from 'better-sqlite3-multiple-ciphers';
-import * as path from 'path';
 import * as crypto from 'crypto';
 import * as fs from 'fs';
+import * as path from 'path';
+import type { DeviceKeyStore } from './DeviceKeyStore';
 
-/**
- * Security Config Interface stored in security.json
- */
-interface SecurityConfig {
-    version: number;
-    salt: string; // Hex string
-    wrappedKey: string; // Encrypted DEK (Hex string) - Encrypted with Password
-    iv: string; // IV used for wrapping key (Hex string)
-    recovery?: {
-        salt: string; // Hex string (Salt for recovery code)
-        wrappedKey: string; // Encrypted DEK (Hex string) - Encrypted with Recovery Code
-        iv: string; // IV used for recovery wrapping
+export interface RecoveryEnvelope {
+    algorithm: 'aes-256-gcm';
+    kdf: 'argon2id';
+    kdfParams: {
+        timeCost: number;
+        memoryCost: number;
+        parallelism: number;
+        hashLength: number;
     };
+    salt: string;
+    iv: string;
+    wrappedKey: string;
+    aadVersion: 1;
 }
 
+interface PendingRecoveryAck {
+    protectedPayload: string;
+    createdAt: string;
+    reason: 'fresh-setup' | 'legacy-migration' | 'transition-recovery';
+}
+
+export interface TransitionRecoveryEnvelope extends RecoveryEnvelope {
+    purpose: 'legacy-transition';
+}
+
+export interface SecurityConfigV3 {
+    version: 3;
+    vaultId: string;
+    keyVersion: number;
+    device: { provider: string; protectedPayload: string };
+    recovery: RecoveryEnvelope;
+    migratedFrom?: 1 | 2;
+    pendingRecoveryAck?: PendingRecoveryAck;
+    transitionRecovery?: TransitionRecoveryEnvelope;
+}
+
+interface SecurityConfigV2 {
+    version: 2;
+    salt: string;
+    wrappedKey: string;
+    iv: string;
+    recovery?: { salt: string; wrappedKey: string; iv: string };
+}
+
+export interface SetupStatus {
+    isSetup: boolean;
+    hasRecovery: boolean;
+    vaultState: 'not-setup' | 'ready' | 'legacy-migration-required' | 'recovery-required' | 'corrupt';
+    configVersion?: number;
+}
+
+export interface VaultUnlockResult { migrated: boolean }
+
+interface MigrationJournal {
+    version: 1;
+    sourceVersion: 1 | 2;
+    phase: 'snapshot-created' | 'database-rekeyed' | 'config-committing' | 'config-written' | 'rollback-restored';
+    databaseBackup: string;
+    configBackup?: string;
+    legacySaltPath?: string;
+    startedAt: string;
+}
+
+export interface SetupJournal {
+    version: 1;
+    phase: 'started' | 'vault-created' | 'complete';
+    databaseCreated: boolean;
+    startedAt: string;
+}
+
+export type SecurityStep =
+    | 'setup-after-journal' | 'setup-after-bind' | 'setup-after-config-commit'
+    | 'migration-after-snapshot' | 'migration-after-rekey' | 'migration-after-bind'
+    | 'migration-after-config-commit' | 'cleanup-legacy-salt' | 'cleanup-database-backup'
+    | 'cleanup-config-backup' | 'cleanup-journal' | 'cleanup-rollback-database-backup'
+    | 'cleanup-rollback-config-backup' | 'cleanup-rollback-journal' | 'cleanup-setup-journal';
+
+export interface SecurityServiceHooks {
+    onStep?: (step: SecurityStep) => void;
+    platform?: NodeJS.Platform;
+    fsync?: (fd: number) => void;
+}
+
+const CONFIG_FILE = 'security.json';
+const JOURNAL_FILE = 'security-migration.json';
+const SETUP_JOURNAL_FILE = 'security-setup.json';
+const LEGACY_SALT_FILE = 'salt.bin';
+const VAULT_TABLE = '__nalamdesk_vault';
+const RECOVERY_KDF_PARAMS = Object.freeze({ timeCost: 3, memoryCost: 65536, parallelism: 1, hashLength: 32 });
+
 /**
- * SecurityService handles database encryption using SQLCipher with a Key Wrapping Architecture.
- * 
- * V2 Architecture:
- * - Data Encryption Key (DEK): A random 32-byte key that actually encrypts the DB.
- * - Key Encryption Key (KEK): Derived from User Password (or Recovery Code).
- * - The DEK is encrypted (wrapped) by the KEK and stored in security.json.
- * 
- * This allows:
- * 1. Password Changes (Re-wrap DEK with new Password KEK) without re-encrypting the whole DB.
- * 2. Password Recovery (Unwrap DEK with Recovery Code KEK, then Re-wrap with new Password KEK).
+ * Owns the SQLCipher DEK. User passwords are intentionally absent from the v3
+ * unlock path: device unlock and user authentication are separate operations.
  */
 export class SecurityService {
     private db: any;
-    private dbPath: string = '';
-    private appUserDataPath: string = '';
-
-    // In-memory DEK (cleared on app exit)
+    private dbPath = '';
+    private appUserDataPath = '';
     private dek: Buffer | null = null;
 
-    /**
-     * Checks if the application is already set up.
-     */
-    isSetup(userDataPath: string): { isSetup: boolean, hasRecovery: boolean } {
-        const configPath = path.join(userDataPath, 'security.json');
-        const legacySaltPath = path.join(userDataPath, 'salt.bin');
+    constructor(
+        private readonly deviceKeyStore: DeviceKeyStore,
+        private readonly hooks: SecurityServiceHooks = {}
+    ) { }
 
-        if (fs.existsSync(configPath)) {
-            try {
-                const config = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as SecurityConfig;
-                return { isSetup: true, hasRecovery: !!config.recovery };
-            } catch (e) {
-                return { isSetup: true, hasRecovery: false }; // Corrupt file? Treat as setup but broken? Or just assume true.
+    isSetup(userDataPath: string): SetupStatus {
+        const configPath = path.join(userDataPath, CONFIG_FILE);
+        const legacySaltPath = path.join(userDataPath, LEGACY_SALT_FILE);
+        if (!fs.existsSync(configPath)) {
+            return fs.existsSync(legacySaltPath)
+                ? { isSetup: true, hasRecovery: false, vaultState: 'legacy-migration-required', configVersion: 1 }
+                : { isSetup: false, hasRecovery: false, vaultState: 'not-setup' };
+        }
+        try {
+            const config = JSON.parse(fs.readFileSync(configPath, 'utf8')) as SecurityConfigV3 | SecurityConfigV2;
+            if (config.version === 3) {
+                return {
+                    isSetup: true,
+                    hasRecovery: true,
+                    vaultState: this.deviceKeyStore.status().available ? 'ready' : 'recovery-required',
+                    configVersion: 3
+                };
             }
+            if (config.version === 2) {
+                return { isSetup: true, hasRecovery: !!config.recovery, vaultState: 'legacy-migration-required', configVersion: 2 };
+            }
+            return { isSetup: true, hasRecovery: false, vaultState: 'corrupt', configVersion: (config as any).version };
+        } catch {
+            return { isSetup: true, hasRecovery: false, vaultState: 'corrupt' };
         }
-
-        // If legacy salt exists, we consider it "Setup" (will migrate on login)
-        if (fs.existsSync(legacySaltPath)) {
-            return { isSetup: true, hasRecovery: false };
-        }
-
-        return { isSetup: false, hasRecovery: false };
     }
 
-    /**
-     * Fresh Setup: Generates new DEK, creates security.json, and initializes DB.
-     * Returns the Recovery Code for the user to save.
-     */
-    async setup(password: string, dbPath: string, userDataPath: string): Promise<string> {
-        this.appUserDataPath = userDataPath;
-        this.dbPath = dbPath;
-
-        // 1. Generate Random DEK
-        this.dek = crypto.randomBytes(32);
-
-        // 2. Generate Recovery Code
+    /** adminPassword remains only for caller compatibility; it never wraps the DEK. */
+    async setup(_adminPassword: string, dbPath: string, userDataPath: string): Promise<string> {
+        this.configurePaths(dbPath, userDataPath);
+        this.assertDeviceStoreAvailable();
+        this.reconcileSetupJournal();
+        if (fs.existsSync(path.join(userDataPath, CONFIG_FILE))) throw new Error('ALREADY_SETUP');
+        const databaseCreated = !fs.existsSync(dbPath) || fs.statSync(dbPath).size === 0;
+        if (!databaseCreated) throw new Error('UNCLAIMED_DATABASE_PRESENT');
+        const journal: SetupJournal = {
+            version: 1,
+            phase: 'started',
+            databaseCreated,
+            startedAt: new Date().toISOString()
+        };
+        this.saveSetupJournal(journal);
+        this.step('setup-after-journal');
+        const dek = crypto.randomBytes(32);
         const recoveryCode = this.generateRecoveryCodeString();
-
-        // 3. Create Security Config (Wrap DEK with Password AND Recovery Code)
-        const config = await this.createSecurityConfig(this.dek, password, recoveryCode);
-        this.saveConfig(config);
-
-        // 4. Initialize DB with DEK
-        this.initDb(this.dbPath, this.dek);
-
-        return recoveryCode;
-    }
-
-    /**
-     * Initialize / Unlock the encrypted database.
-     * Handles V1 -> V2 Migration transparently.
-     */
-    async initialize(password: string, dbPath: string, userDataPath: string): Promise<void> {
-        this.appUserDataPath = userDataPath;
-        this.dbPath = dbPath;
-
-        const configPath = path.join(userDataPath, 'security.json');
-        const legacySaltPath = path.join(userDataPath, 'salt.bin');
-
-        // CASE 1: V2 Setup Exists
-        if (fs.existsSync(configPath)) {
-            console.log('[Security] Loading V2 Configuration...');
-            const config = this.loadConfig();
-
-            // Unwrap DEK using Password
-            try {
-                this.dek = await this.unwrapKey(config.wrappedKey, config.iv, config.salt, password);
-                this.initDb(this.dbPath, this.dek);
-                console.log('[Security] Vault Unlocked (V2).');
-            } catch (e) {
-                console.error('[Security] Failed to unlock vault:', e);
-                throw new Error('INVALID_PASSWORD');
-            }
-            return;
-        }
-
-        // CASE 2: V1 Legacy Exists -> Migrate to V2
-        if (fs.existsSync(legacySaltPath)) {
-            console.log('[Security] Detected V1 Setup. Starting Migration to V2...');
-            await this.migrateV1toV2(password, legacySaltPath);
-            return;
-        }
-
-        // CASE 3: No Setup -> Should have called setup() instead.
-        throw new Error('NOT_SETUP');
-    }
-
-
-    /**
-     * Recover Password using Recovery Code.
-     * Sets a new password and re-wraps the DEK.
-     */
-    async recover(recoveryCode: string, newPassword: string, userDataPath: string, dbPath: string): Promise<string> {
-        this.appUserDataPath = userDataPath;
-        this.dbPath = dbPath;
-
-        const config = this.loadConfig();
-        if (!config.recovery) {
-            throw new Error('NO_RECOVERY_CODE_SET');
-        }
-
-        // 1. Unwrap DEK using Recovery Code
+        const config = await this.createV3Config(dek, recoveryCode, undefined, undefined, 'fresh-setup');
         try {
-            this.dek = await this.unwrapKey(config.recovery.wrappedKey, config.recovery.iv, config.recovery.salt, recoveryCode);
-        } catch (e) {
-            throw new Error('INVALID_RECOVERY_CODE');
-        }
-
-        // 2. Rotate Security Config (New Password KEK + New Recovery Code KEK)
-        const newRecoveryCode = this.generateRecoveryCodeString();
-
-        // Wrap DEK with NEW Password
-        const salt = crypto.randomBytes(16);
-        const kek = await this.deriveKey(newPassword, salt);
-        const { encrypted: wrappedKey, iv } = this.aesEncrypt(this.dek, kek);
-
-        // Wrap DEK with NEW Recovery Code
-        const rSalt = crypto.randomBytes(16);
-        const rKek = await this.deriveKey(newRecoveryCode, rSalt);
-        const { encrypted: rWrappedKey, iv: rIv } = this.aesEncrypt(this.dek, rKek);
-
-        const newConfig: SecurityConfig = {
-            version: 2,
-            salt: salt.toString('hex'),
-            wrappedKey: wrappedKey,
-            iv: iv,
-            recovery: {
-                salt: rSalt.toString('hex'),
-                wrappedKey: rWrappedKey,
-                iv: rIv
-            }
-        };
-
-        this.saveConfig(newConfig);
-
-        // 3. Open DB
-        this.initDb(this.dbPath, this.dek);
-        console.log('[Security] Password reset successful. Vault Unlocked. Recovery Code Rotated.');
-
-        return newRecoveryCode;
-    }
-
-    /**
-     * Helper: Generate a secure recovery code string (Format: XXXX-XXXX-XXXX-XXXX)
-     */
-    generateRecoveryCodeString(): string {
-        // Generate 16 bytes of random entropy, generic human-readable format
-        const bytes = crypto.randomBytes(10); // 20 hex chars
-        const hex = bytes.toString('hex').toUpperCase();
-        return `${hex.slice(0, 5)}-${hex.slice(5, 10)}-${hex.slice(10, 15)}-${hex.slice(15, 20)}`;
-    }
-
-    /**
-     * Regenerate Recovery Code (for Admin).
-     * Requires the current password to unlock logic (though DEK is already in memory).
-     * Re-wraps the DEK with valid Password and NEW Recovery Code.
-     */
-    async regenerateRecoveryCode(password: string): Promise<string> {
-        if (!this.dek) {
-            // Try to load/unlock if not in memory (shouldn't happen if logged in, but safety first)
-            // Or assume DEK is available if app is running and unlocked.
-            // If DEK is missing, we must fail or ask to unlock.
-            throw new Error('VAULT_LOCKED');
-        }
-
-        const config = this.loadConfig();
-
-        // Vefiry password by attempting to derive KEK and check against wrappedKey?
-        // Or just rely on the fact we are re-wrapping. 
-        // Better to re-wrap properly.
-
-        // 1. Generate NEW Recovery Code
-        const newRecoveryCode = this.generateRecoveryCodeString();
-
-        // 2. Create NEW Security Config
-        // We re-use the existing DEK (this.dek).
-        const newConfig = await this.createSecurityConfig(this.dek, password, newRecoveryCode);
-
-        this.saveConfig(newConfig);
-
-        return newRecoveryCode;
-    }
-
-    // ==================================================================================
-    //                                  PRIVATE HELPERS
-    // ==================================================================================
-
-    private async createSecurityConfig(dek: Buffer, password: string, recoveryCode: string): Promise<SecurityConfig> {
-        // 1. Wrap with Password
-        const salt = crypto.randomBytes(16);
-        const kek = await this.deriveKey(password, salt);
-        const { encrypted: wrappedKey, iv } = this.aesEncrypt(dek, kek);
-
-        // 2. Wrap with Recovery Code
-        const rSalt = crypto.randomBytes(16);
-        const rKek = await this.deriveKey(recoveryCode, rSalt);
-        const { encrypted: rWrappedKey, iv: rIv } = this.aesEncrypt(dek, rKek);
-
-        return {
-            version: 2,
-            salt: salt.toString('hex'),
-            wrappedKey: wrappedKey,
-            iv: iv,
-            recovery: {
-                salt: rSalt.toString('hex'),
-                wrappedKey: rWrappedKey,
-                iv: rIv
-            }
-        };
-    }
-
-    private async unwrapKey(wrappedKeyHex: string, ivHex: string, saltHex: string, secret: string): Promise<Buffer> {
-        const salt = Buffer.from(saltHex, 'hex');
-        const kek = await this.deriveKey(secret, salt);
-        return this.aesDecrypt(wrappedKeyHex, ivHex, kek);
-    }
-
-    /**
-     * Migrate V1 (Direct Password) to V2 (Wrapped Key)
-     * 1. Derive OLD Key from Password + Old Salt.
-     * 2. Open DB with OLD Key.
-     * 3. Change DB Key to NEW Random DEK (`PRAGMA rekey`).
-     * 4. Wrap NEW DEK with Password and Save Config.
-     */
-    private async migrateV1toV2(password: string, legacySaltPath: string): Promise<void> {
-        const salt = fs.readFileSync(legacySaltPath);
-
-        // 1. Derive V1 Key
-        const oldKey = await this.deriveKeyArgon2(password, salt); // Use raw argon2 like V1
-
-        // 2. Open DB with V1 Key to verify password
-        try {
-            this.initDb(this.dbPath, oldKey);
-        } catch (e) {
-            throw new Error('INVALID_PASSWORD'); // Pass through
-        }
-
-        console.log('[Security] V1 Key Verified. Rekeying database...');
-
-        // 3. Generate NEW Random DEK
-        this.dek = crypto.randomBytes(32);
-        const newKeyHex = this.dek.toString('hex');
-
-        // 4. PRAGMA rekey (Change DB Encryption Key)
-        this.db.pragma(`rekey = "x'${newKeyHex}'"`);
-
-        // 5. Create V2 Config (Wrap DEK)
-        // Note: We don't have a recovery code yet. User will need to generate one later.
-        const configSalt = crypto.randomBytes(16);
-        const kek = await this.deriveKey(password, configSalt);
-        const { encrypted: wrappedKey, iv } = this.aesEncrypt(this.dek, kek);
-
-        const config: SecurityConfig = {
-            version: 2,
-            salt: configSalt.toString('hex'),
-            wrappedKey: wrappedKey,
-            iv: iv,
-            // recovery: undefined // No recovery code yet
-        };
-
-        this.saveConfig(config);
-
-        // 6. Cleanup V1 Salt
-        // fs.unlinkSync(legacySaltPath); // Optional: keep for safety or backup? Let's keep it but maybe rename?
-        console.log('[Security] Migration to V2 Complete.');
-    }
-
-    private saveConfig(config: SecurityConfig) {
-        const configPath = path.join(this.appUserDataPath, 'security.json');
-        fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
-    }
-
-    private loadConfig(): SecurityConfig {
-        const configPath = path.join(this.appUserDataPath, 'security.json');
-        return JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    }
-
-    /**
-     * V2 Key Derivation (Standardized)
-     * Uses Argon2id but we can tune parameters if needed. 
-     * We keep it simple to match V1 but ensure it's consistent.
-     */
-    private async deriveKey(secret: string, salt: Buffer): Promise<Buffer> {
-        return argon2.hash(secret, {
-            type: argon2.argon2id,
-            raw: true,
-            salt: salt
-        });
-    }
-
-    /**
-     * V1 Key Derivation (Strictly for backward compat with exact V1 params if any)
-     * V1 used default params.
-     */
-    private async deriveKeyArgon2(password: string, salt: Buffer): Promise<Buffer> {
-        return argon2.hash(password, {
-            type: argon2.argon2id,
-            raw: true,
-            salt: salt
-        });
-    }
-
-    private aesEncrypt(data: Buffer, key: Buffer): { encrypted: string, iv: string } {
-        const iv = crypto.randomBytes(16); // IV for AES-256-GCM
-        const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
-        const encrypted = Buffer.concat([cipher.update(data), cipher.final()]);
-        const tag = cipher.getAuthTag();
-        // Return IV + AuthTag + EncryptedData as hex string or define a format
-        // Simple format: iv (hex) | tag (hex) | encrypted (hex)
-        // Actually, let's keep IV separate in JSON for clarity. 
-        // Combine Tag + Encrypted
-        return {
-            encrypted: Buffer.concat([tag, encrypted]).toString('hex'), // First 16 bytes is tag
-            iv: iv.toString('hex')
-        };
-    }
-
-    private aesDecrypt(encryptedHex: string, ivHex: string, key: Buffer): Buffer {
-        const encryptedAndTag = Buffer.from(encryptedHex, 'hex');
-        const tag = encryptedAndTag.subarray(0, 16);
-        const encrypted = encryptedAndTag.subarray(16);
-        const iv = Buffer.from(ivHex, 'hex');
-
-        const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
-        decipher.setAuthTag(tag);
-        return Buffer.concat([decipher.update(encrypted), decipher.final()]);
-    }
-
-    private initDb(filePath: string, key: Buffer): void {
-        try {
-            this.dbPath = filePath;
-            const isDevMode = process.env['NODE_ENV'] !== 'production';
-            const db = new Database(filePath, isDevMode ? { verbose: console.log } : {});
-
-            const hexKey = key.toString('hex');
-            db.pragma(`key = "x'${hexKey}'"`);
-
-            // Verify
-            db.prepare('SELECT count(*) FROM sqlite_master').get();
-
-            this.db = db;
-            console.log('[Security] Database opened successfully');
-        } catch (error: any) {
-            console.error('[Security] Database initialization failed:', error);
-            if (error.message && (error.message.includes('file is not a database') || error.message.includes('SqliteError'))) {
-                throw new Error('INVALID_PASSWORD');
-            }
+            this.initDb(dbPath, dek);
+            this.bindVault(config.vaultId, config.keyVersion, true);
+            this.db.pragma('wal_checkpoint(TRUNCATE)');
+            this.step('setup-after-bind');
+            this.saveConfigAtomic(config);
+            this.step('setup-after-config-commit');
+            journal.phase = 'vault-created';
+            this.saveSetupJournal(journal);
+            this.dek = dek;
+            return recoveryCode;
+        } catch (error) {
+            this.closeDb();
+            this.rollbackSetup(journal);
             throw error;
         }
     }
 
-    getDb() { return this.db; }
-    closeDb() {
-        if (this.db) {
-            this.db.close();
-            this.db = null;
-            this.dek = null; // Clear key from memory on close
+    /** Marks the entire setup pipeline (vault, schema, settings, admin) durable. */
+    completeProvisioning(): void {
+        const journal = this.loadSetupJournal();
+        if (!journal || journal.phase !== 'vault-created') throw new Error('PROVISIONING_NOT_STARTED');
+        this.db?.pragma('wal_checkpoint(TRUNCATE)');
+        journal.phase = 'complete';
+        this.saveSetupJournal(journal);
+        this.cleanupSetupJournal();
+    }
+
+    /** Rolls back only files created by the in-progress fresh provisioning. */
+    abortProvisioning(): void {
+        const journal = this.loadSetupJournal();
+        if (!journal || journal.phase === 'complete') return;
+        this.rollbackSetup(journal);
+    }
+
+    /** Reconciles an interrupted setup before setup-state is presented. */
+    reconcileProvisioning(dbPath: string, userDataPath: string): void {
+        this.configurePaths(dbPath, userDataPath);
+        this.reconcileSetupJournal();
+    }
+
+    /** Unlock v3 using only the OS-bound device envelope. */
+    async initializeDevice(dbPath: string, userDataPath: string): Promise<VaultUnlockResult> {
+        this.configurePaths(dbPath, userDataPath);
+        this.reconcileSetupJournal();
+        this.reconcileMigrationJournal();
+        const status = this.isSetup(userDataPath);
+        if (!status.isSetup) throw new Error('NOT_SETUP');
+        if (status.vaultState === 'legacy-migration-required') throw new Error('LEGACY_MIGRATION_REQUIRED');
+        if (status.vaultState === 'corrupt') throw new Error('SECURITY_CONFIG_CORRUPT');
+        this.assertDeviceStoreAvailable();
+        const config = this.loadConfigV3();
+        try {
+            const dek = this.unprotectDeviceDek(config);
+            this.initDb(dbPath, dek);
+            this.bindVault(config.vaultId, config.keyVersion, false);
+            this.dek = dek;
+            return { migrated: false };
+        } catch (error: any) {
+            this.closeDb();
+            if (error?.message === 'VAULT_BINDING_MISMATCH') throw error;
+            throw new Error('DEVICE_UNLOCK_FAILED');
         }
     }
-    getDbPath() { return this.dbPath; }
+
+    /** One-time compatibility path. The legacy secret is never retained in v3. */
+    async migrateLegacy(legacySecret: string, dbPath: string, userDataPath: string): Promise<VaultUnlockResult> {
+        this.configurePaths(dbPath, userDataPath);
+        this.assertDeviceStoreAvailable();
+        this.reconcileMigrationJournal();
+        const configPath = path.join(userDataPath, CONFIG_FILE);
+        if (fs.existsSync(configPath)) {
+            const parsed = JSON.parse(fs.readFileSync(configPath, 'utf8')) as SecurityConfigV3 | SecurityConfigV2;
+            if (parsed.version === 3) return this.initializeDevice(dbPath, userDataPath);
+            if (parsed.version !== 2) throw new Error('UNSUPPORTED_SECURITY_CONFIG');
+            return this.migrateV2(parsed, legacySecret);
+        }
+        const saltPath = path.join(userDataPath, LEGACY_SALT_FILE);
+        if (!fs.existsSync(saltPath)) throw new Error('NOT_SETUP');
+        return this.migrateV1(legacySecret, saltPath);
+    }
+
+    /** Re-enrol this device from the portable recovery envelope. */
+    async recoverDevice(recoveryCode: string, userDataPath: string, dbPath: string): Promise<VaultUnlockResult> {
+        this.configurePaths(dbPath, userDataPath);
+        this.assertDeviceStoreAvailable();
+        const status = this.isSetup(userDataPath);
+        if (status.configVersion === 2) {
+            return this.migrateLegacy(recoveryCode, dbPath, userDataPath);
+        }
+        const config = this.loadConfigV3();
+        const previousConfigText = fs.readFileSync(path.join(userDataPath, CONFIG_FILE), 'utf8');
+        let dek: Buffer;
+        let usedTransition = false;
+        this.validateRecoveryEnvelope(config.recovery);
+        try {
+            dek = await this.unwrapRecovery(config.recovery, recoveryCode, config.vaultId, config.keyVersion);
+        } catch {
+            if (config.transitionRecovery?.purpose !== 'legacy-transition') throw new Error('INVALID_RECOVERY_CODE');
+            this.validateRecoveryEnvelope(config.transitionRecovery);
+            try {
+                dek = await this.unwrapRecovery(
+                    config.transitionRecovery,
+                    recoveryCode,
+                    config.vaultId,
+                    config.keyVersion,
+                    'legacy-transition'
+                );
+                usedTransition = true;
+            } catch { throw new Error('INVALID_RECOVERY_CODE'); }
+        }
+        try {
+            this.initDb(dbPath, dek);
+            this.bindVault(config.vaultId, config.keyVersion, false);
+        } catch (error: any) {
+            this.closeDb();
+            dek.fill(0);
+            if (error?.message === 'VAULT_BINDING_MISMATCH') throw error;
+            throw new Error('INVALID_RECOVERY_CODE');
+        }
+        try {
+            const updated: SecurityConfigV3 = {
+                ...config,
+                device: this.createDeviceEnvelope(dek, config.vaultId, config.keyVersion)
+            };
+            if (usedTransition) {
+                const freshCode = this.generateRecoveryCodeString();
+                updated.recovery = await this.createRecoveryEnvelope(dek, freshCode, config.vaultId, config.keyVersion);
+                updated.transitionRecovery = await this.createTransitionRecoveryEnvelope(
+                    dek, recoveryCode, config.vaultId, config.keyVersion
+                );
+                updated.pendingRecoveryAck = this.createPendingRecoveryAck(
+                    freshCode, config.vaultId, config.keyVersion, 'transition-recovery'
+                );
+            } else {
+                // Possession of the primary code retires every transitional artifact.
+                delete updated.pendingRecoveryAck;
+                delete updated.transitionRecovery;
+            }
+            this.saveConfigAtomic(updated);
+            this.dek = dek;
+            return { migrated: false };
+        } catch (error) {
+            this.failEnrollment(dek, previousConfigText);
+            throw error;
+        }
+    }
+
+    async regenerateRecoveryCode(): Promise<string> {
+        if (!this.dek) throw new Error('VAULT_LOCKED');
+        const config = this.loadConfigV3();
+        const recoveryCode = this.generateRecoveryCodeString();
+        config.recovery = await this.createRecoveryEnvelope(this.dek, recoveryCode, config.vaultId, config.keyVersion);
+        this.saveConfigAtomic(config);
+        return recoveryCode;
+    }
+
+    /** Re-wrap the unchanged DEK for this device; independent of all user credentials. */
+    rotateDeviceEnvelope(): void {
+        if (!this.dek) throw new Error('VAULT_LOCKED');
+        this.assertDeviceStoreAvailable();
+        const config = this.loadConfigV3();
+        config.device = this.createDeviceEnvelope(this.dek, config.vaultId, config.keyVersion);
+        this.saveConfigAtomic(config);
+    }
+
+    getPendingRecoveryCode(): string | null {
+        const config = this.loadConfigV3();
+        if (!config.pendingRecoveryAck) return null;
+        const payload = this.unprotectContextPayload(config.pendingRecoveryAck.protectedPayload);
+        if (payload.version !== 1 || payload.purpose !== 'recovery-ack' ||
+            payload.vaultId !== config.vaultId || payload.keyVersion !== config.keyVersion ||
+            typeof payload.recoveryCode !== 'string') {
+            throw new Error('PENDING_RECOVERY_CONTEXT_MISMATCH');
+        }
+        return payload.recoveryCode;
+    }
+
+    acknowledgePendingRecoveryCode(recoveryCode: string): void {
+        const config = this.loadConfigV3();
+        if (!config.pendingRecoveryAck) throw new Error('NO_PENDING_RECOVERY_CODE');
+        const pending = this.getPendingRecoveryCode();
+        if (!pending || !this.constantTimeEqual(pending, recoveryCode)) throw new Error('INVALID_RECOVERY_ACK');
+        delete config.pendingRecoveryAck;
+        delete config.transitionRecovery;
+        this.saveConfigAtomic(config);
+    }
+
+    /** Frozen portable contract consumed by issue #8. */
+    getPortableVaultMetadata(): Pick<SecurityConfigV3, 'version' | 'vaultId' | 'keyVersion' | 'recovery' | 'transitionRecovery'> {
+        const { version, vaultId, keyVersion, recovery, transitionRecovery } = this.loadConfigV3();
+        return { version, vaultId, keyVersion, recovery, ...(transitionRecovery ? { transitionRecovery } : {}) };
+    }
+
+    /** Frozen restore contract consumed by issue #8. */
+    async installPortableVaultMetadata(
+        metadata: Pick<SecurityConfigV3, 'version' | 'vaultId' | 'keyVersion' | 'recovery' | 'transitionRecovery'>,
+        recoveryCode: string,
+        dbPath: string,
+        userDataPath: string
+    ): Promise<void> {
+        this.configurePaths(dbPath, userDataPath);
+        this.assertDeviceStoreAvailable();
+        const configPath = path.join(userDataPath, CONFIG_FILE);
+        const previousConfigText = fs.existsSync(configPath)
+            ? fs.readFileSync(configPath, 'utf8')
+            : undefined;
+        let dek: Buffer;
+        let usedTransition = false;
+        this.validateRecoveryEnvelope(metadata.recovery);
+        try {
+            dek = await this.unwrapRecovery(metadata.recovery, recoveryCode, metadata.vaultId, metadata.keyVersion);
+        } catch {
+            if (metadata.transitionRecovery?.purpose !== 'legacy-transition') throw new Error('INVALID_RECOVERY_CODE');
+            this.validateRecoveryEnvelope(metadata.transitionRecovery);
+            dek = await this.unwrapRecovery(
+                metadata.transitionRecovery,
+                recoveryCode,
+                metadata.vaultId,
+                metadata.keyVersion,
+                'legacy-transition'
+            );
+            usedTransition = true;
+        }
+        try {
+            this.initDb(dbPath, dek);
+            this.bindVault(metadata.vaultId, metadata.keyVersion, false);
+        } catch (error) {
+            this.closeDb();
+            dek.fill(0);
+            throw error;
+        }
+        try {
+            const config: SecurityConfigV3 = {
+                ...metadata,
+                device: this.createDeviceEnvelope(dek, metadata.vaultId, metadata.keyVersion)
+            };
+            if (usedTransition) {
+                const freshCode = this.generateRecoveryCodeString();
+                config.recovery = await this.createRecoveryEnvelope(
+                    dek, freshCode, metadata.vaultId, metadata.keyVersion
+                );
+                config.transitionRecovery = await this.createTransitionRecoveryEnvelope(
+                    dek, recoveryCode, metadata.vaultId, metadata.keyVersion
+                );
+                config.pendingRecoveryAck = this.createPendingRecoveryAck(
+                    freshCode, metadata.vaultId, metadata.keyVersion, 'transition-recovery'
+                );
+            } else {
+                delete config.pendingRecoveryAck;
+                delete config.transitionRecovery;
+            }
+            this.saveConfigAtomic(config);
+            this.dek = dek;
+        } catch (error) {
+            this.failEnrollment(dek, previousConfigText);
+            throw error;
+        }
+    }
+
+    generateRecoveryCodeString(): string {
+        const hex = crypto.randomBytes(16).toString('hex').toUpperCase();
+        return `${hex.slice(0, 8)}-${hex.slice(8, 16)}-${hex.slice(16, 24)}-${hex.slice(24, 32)}`;
+    }
+
+    async deriveKey(secret: string, salt: Buffer): Promise<Buffer> {
+        return argon2.hash(secret, {
+            type: argon2.argon2id,
+            raw: true,
+            salt,
+            ...RECOVERY_KDF_PARAMS
+        });
+    }
+
+    getDb(): any { return this.db; }
+    getDbPath(): string { return this.dbPath; }
+    getVaultId(): string | null { try { return this.loadConfigV3().vaultId; } catch { return null; } }
+
+    closeDb(): void {
+        if (this.db) this.db.close();
+        this.db = null;
+        if (this.dek) this.dek.fill(0);
+        this.dek = null;
+    }
+
+    private async migrateV2(config: SecurityConfigV2, secret: string): Promise<VaultUnlockResult> {
+        let oldDek: Buffer;
+        try {
+            oldDek = await this.unwrapLegacy(config.wrappedKey, config.iv, config.salt, secret);
+        } catch {
+            if (!config.recovery) throw new Error('INVALID_LEGACY_CREDENTIAL');
+            try {
+                oldDek = await this.unwrapLegacy(
+                    config.recovery.wrappedKey,
+                    config.recovery.iv,
+                    config.recovery.salt,
+                    secret
+                );
+            } catch { throw new Error('INVALID_LEGACY_CREDENTIAL'); }
+        }
+        try {
+            this.initDb(this.dbPath, oldDek);
+            this.db.pragma('wal_checkpoint(TRUNCATE)');
+            this.closeDb();
+        } catch {
+            this.closeDb();
+            throw new Error('INVALID_LEGACY_CREDENTIAL');
+        }
+        return this.commitLegacyMigration(2, oldDek, this.generateRecoveryCodeString(), secret, false);
+    }
+
+    private async migrateV1(secret: string, saltPath: string): Promise<VaultUnlockResult> {
+        const oldKey = await this.deriveLegacyKey(secret, fs.readFileSync(saltPath));
+        try { this.initDb(this.dbPath, oldKey); } catch { throw new Error('INVALID_LEGACY_CREDENTIAL'); }
+        this.db.pragma('wal_checkpoint(TRUNCATE)');
+        this.closeDb();
+        return this.commitLegacyMigration(1, crypto.randomBytes(32), this.generateRecoveryCodeString(), secret, true, oldKey, saltPath);
+    }
+
+    private async commitLegacyMigration(
+        sourceVersion: 1 | 2,
+        dek: Buffer,
+        recoveryCode: string,
+        legacySecret: string,
+        rekey: boolean,
+        oldKey?: Buffer,
+        saltPath?: string
+    ): Promise<VaultUnlockResult> {
+        const backup = `${this.dbPath}.pre-v3-migration`;
+        const configPath = path.join(this.appUserDataPath, CONFIG_FILE);
+        const configBackup = `${configPath}.pre-v3-migration`;
+        const journal: MigrationJournal = {
+            version: 1,
+            sourceVersion,
+            phase: 'snapshot-created',
+            databaseBackup: backup,
+            configBackup: fs.existsSync(configPath) ? configBackup : undefined,
+            legacySaltPath: saltPath,
+            startedAt: new Date().toISOString()
+        };
+        fs.copyFileSync(this.dbPath, backup);
+        this.fsyncFile(backup);
+        if (journal.configBackup) {
+            fs.copyFileSync(configPath, journal.configBackup);
+            this.fsyncFile(journal.configBackup);
+        }
+        this.saveJournal(journal);
+        this.step('migration-after-snapshot');
+        let committed = false;
+        try {
+            if (rekey) {
+                this.initDb(this.dbPath, oldKey!);
+                this.db.pragma(`rekey = "x'${dek.toString('hex')}'"`);
+                this.db.pragma('wal_checkpoint(TRUNCATE)');
+                this.closeDb();
+                journal.phase = 'database-rekeyed';
+                this.saveJournal(journal);
+                this.step('migration-after-rekey');
+            }
+            this.initDb(this.dbPath, dek);
+            const config = await this.createV3Config(dek, recoveryCode, sourceVersion, legacySecret, 'legacy-migration');
+            this.bindVault(config.vaultId, config.keyVersion, true);
+            // Make the binding durable in the main database before the config
+            // commit becomes authoritative.
+            this.db.pragma('wal_checkpoint(TRUNCATE)');
+            this.step('migration-after-bind');
+            journal.phase = 'config-committing';
+            this.saveJournal(journal);
+            this.saveConfigAtomic(config);
+            committed = true;
+            this.step('migration-after-config-commit');
+            journal.phase = 'config-written';
+            this.saveJournal(journal);
+            this.dek = dek;
+            this.cleanupCommittedMigration(journal, saltPath);
+            return { migrated: true };
+        } catch (error) {
+            if (committed || this.hasV3Config()) {
+                this.dek = dek;
+                this.cleanupCommittedMigration(journal, saltPath);
+                return { migrated: true };
+            }
+            this.closeDb();
+            this.restoreMigrationSnapshot(journal);
+            this.cleanupRollbackArtifacts(journal);
+            throw error;
+        }
+    }
+
+    private reconcileMigrationJournal(): void {
+        const journalPath = this.journalPath();
+        if (!fs.existsSync(journalPath)) return;
+        const journal = JSON.parse(fs.readFileSync(journalPath, 'utf8')) as MigrationJournal;
+        const configCommitted = this.hasV3Config();
+        if (!configCommitted) {
+            this.closeDb();
+            if (journal.phase !== 'rollback-restored') this.restoreMigrationSnapshot(journal);
+            this.cleanupRollbackArtifacts(journal);
+            return;
+        }
+        this.cleanupCommittedMigration(journal, journal.legacySaltPath);
+    }
+
+    private async createV3Config(
+        dek: Buffer,
+        recoveryCode: string,
+        migratedFrom?: 1 | 2,
+        legacySecret?: string,
+        pendingReason?: PendingRecoveryAck['reason']
+    ): Promise<SecurityConfigV3> {
+        const vaultId = crypto.randomUUID();
+        const keyVersion = 1;
+        const config: SecurityConfigV3 = {
+            version: 3,
+            vaultId,
+            keyVersion,
+            device: this.createDeviceEnvelope(dek, vaultId, keyVersion),
+            recovery: await this.createRecoveryEnvelope(dek, recoveryCode, vaultId, keyVersion)
+        };
+        if (pendingReason) {
+            config.pendingRecoveryAck = this.createPendingRecoveryAck(
+                recoveryCode, vaultId, keyVersion, pendingReason
+            );
+        }
+        if (migratedFrom && legacySecret) {
+            config.migratedFrom = migratedFrom;
+            config.transitionRecovery = await this.createTransitionRecoveryEnvelope(
+                dek, legacySecret, vaultId, keyVersion
+            );
+        }
+        return config;
+    }
+
+    private async createRecoveryEnvelope(
+        dek: Buffer,
+        code: string,
+        vaultId: string,
+        keyVersion: number,
+        purpose: 'recovery-dek' | 'legacy-transition' = 'recovery-dek'
+    ): Promise<RecoveryEnvelope> {
+        const salt = crypto.randomBytes(16);
+        const wrapped = this.aesEncrypt(
+            dek,
+            await this.deriveKey(code, salt),
+            this.recoveryAad(vaultId, keyVersion, purpose)
+        );
+        return {
+            algorithm: 'aes-256-gcm',
+            kdf: 'argon2id',
+            kdfParams: { ...RECOVERY_KDF_PARAMS },
+            aadVersion: 1,
+            salt: salt.toString('hex'),
+            ...wrapped
+        };
+    }
+
+    private async unwrapRecovery(
+        envelope: RecoveryEnvelope,
+        code: string,
+        vaultId: string,
+        keyVersion: number,
+        purpose: 'recovery-dek' | 'legacy-transition' = 'recovery-dek'
+    ): Promise<Buffer> {
+        this.validateRecoveryEnvelope(envelope);
+        const salt = Buffer.from(envelope.salt, 'hex');
+        const key = await argon2.hash(code, {
+            type: argon2.argon2id,
+            raw: true,
+            salt,
+            ...envelope.kdfParams
+        });
+        return this.aesDecrypt(envelope.wrappedKey, envelope.iv, key, this.recoveryAad(vaultId, keyVersion, purpose));
+    }
+
+    private validateRecoveryEnvelope(envelope: RecoveryEnvelope): void {
+        const params = envelope?.kdfParams;
+        const validHex = (value: unknown, bytes: number) =>
+            typeof value === 'string' && value.length === bytes * 2 && /^[0-9a-f]+$/i.test(value);
+        if (envelope?.algorithm !== 'aes-256-gcm' || envelope?.kdf !== 'argon2id' || envelope?.aadVersion !== 1 ||
+            !validHex(envelope.salt, 16) || !validHex(envelope.iv, 12) ||
+            typeof envelope.wrappedKey !== 'string' || envelope.wrappedKey.length !== 96 ||
+            !/^[0-9a-f]+$/i.test(envelope.wrappedKey) || !params ||
+            !Number.isInteger(params.timeCost) || params.timeCost < 1 || params.timeCost > 10 ||
+            !Number.isInteger(params.memoryCost) || params.memoryCost < 8192 || params.memoryCost > 1048576 ||
+            !Number.isInteger(params.parallelism) || params.parallelism < 1 || params.parallelism > 16 ||
+            params.hashLength !== 32) {
+            throw new Error('INVALID_RECOVERY_ENVELOPE');
+        }
+    }
+
+    private async unwrapLegacy(wrappedKey: string, iv: string, salt: string, secret: string): Promise<Buffer> {
+        return this.aesDecrypt(wrappedKey, iv, await this.deriveLegacyKey(secret, Buffer.from(salt, 'hex')));
+    }
+
+    private async deriveLegacyKey(secret: string, salt: Buffer): Promise<Buffer> {
+        return argon2.hash(secret, { type: argon2.argon2id, raw: true, salt });
+    }
+
+    private aesEncrypt(data: Buffer, key: Buffer, aad?: Buffer): { wrappedKey: string; iv: string } {
+        const iv = crypto.randomBytes(12);
+        const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+        if (aad) cipher.setAAD(aad);
+        const ciphertext = Buffer.concat([cipher.update(data), cipher.final()]);
+        return { wrappedKey: Buffer.concat([cipher.getAuthTag(), ciphertext]).toString('hex'), iv: iv.toString('hex') };
+    }
+
+    private aesDecrypt(value: string, ivHex: string, key: Buffer, aad?: Buffer): Buffer {
+        const valueBuffer = Buffer.from(value, 'hex');
+        const decipher = crypto.createDecipheriv('aes-256-gcm', key, Buffer.from(ivHex, 'hex'));
+        if (aad) decipher.setAAD(aad);
+        decipher.setAuthTag(valueBuffer.subarray(0, 16));
+        return Buffer.concat([decipher.update(valueBuffer.subarray(16)), decipher.final()]);
+    }
+
+    private bindVault(vaultId: string, keyVersion: number, create: boolean): void {
+        if (create) {
+            this.db.exec(`CREATE TABLE IF NOT EXISTS ${VAULT_TABLE} (singleton INTEGER PRIMARY KEY CHECK(singleton = 1), vault_id TEXT NOT NULL, key_version INTEGER NOT NULL)`);
+        }
+        let row;
+        try {
+            row = this.db.prepare(`SELECT vault_id, key_version FROM ${VAULT_TABLE} WHERE singleton = 1`).get();
+        } catch {
+            throw new Error('VAULT_BINDING_MISMATCH');
+        }
+        if (!row && create) {
+            this.db.prepare(`INSERT INTO ${VAULT_TABLE} (singleton, vault_id, key_version) VALUES (1, ?, ?)`).run(vaultId, keyVersion);
+            return;
+        }
+        if (!row || row.vault_id !== vaultId || row.key_version !== keyVersion) throw new Error('VAULT_BINDING_MISMATCH');
+    }
+
+    private initDb(filePath: string, key: Buffer): void {
+        // Never enable verbose SQL logging here: SQLCipher's key PRAGMA would
+        // disclose the live DEK to logs even in a development build.
+        const db = new Database(filePath);
+        try {
+            db.pragma(`key = "x'${key.toString('hex')}'"`);
+            db.prepare('SELECT count(*) FROM sqlite_master').get();
+            this.db = db;
+        } catch (error: any) {
+            db.close();
+            if (String(error?.message).includes('file is not a database')) throw new Error('INVALID_PASSWORD');
+            throw error;
+        }
+    }
+
+    private configurePaths(dbPath: string, userDataPath: string): void {
+        this.dbPath = dbPath;
+        this.appUserDataPath = userDataPath;
+    }
+
+    private assertDeviceStoreAvailable(): void {
+        const status = this.deviceKeyStore.status();
+        if (!status.available) throw new Error(status.reason || 'DEVICE_KEY_UNAVAILABLE');
+    }
+
+    private loadConfigV3(): SecurityConfigV3 {
+        const config = JSON.parse(fs.readFileSync(path.join(this.appUserDataPath, CONFIG_FILE), 'utf8')) as SecurityConfigV3;
+        if (config.version !== 3) throw new Error('LEGACY_MIGRATION_REQUIRED');
+        if (!config.vaultId || !Number.isInteger(config.keyVersion) || config.keyVersion < 1 ||
+            !config.device?.protectedPayload || !config.recovery?.wrappedKey || !config.recovery?.kdfParams) {
+            throw new Error('SECURITY_CONFIG_CORRUPT');
+        }
+        return config;
+    }
+
+    private saveConfigAtomic(config: SecurityConfigV3): void {
+        fs.mkdirSync(this.appUserDataPath, { recursive: true });
+        const target = path.join(this.appUserDataPath, CONFIG_FILE);
+        const temporary = `${target}.tmp`;
+        const fd = fs.openSync(temporary, 'w', 0o600);
+        try {
+            fs.writeFileSync(fd, JSON.stringify(config, null, 2), 'utf8');
+            this.fsyncDescriptor(fd);
+        } finally { fs.closeSync(fd); }
+        fs.renameSync(temporary, target);
+        this.fsyncDirectory();
+    }
+
+    private failEnrollment(dek: Buffer, previousConfigText?: string): void {
+        this.closeDb();
+        dek.fill(0);
+        const target = path.join(this.appUserDataPath, CONFIG_FILE);
+        const temporary = `${target}.tmp`;
+        if (previousConfigText === undefined) {
+            for (const file of [target, temporary]) {
+                if (fs.existsSync(file)) fs.unlinkSync(file);
+            }
+            this.fsyncDirectory();
+            return;
+        }
+        this.saveTextAtomic(target, previousConfigText);
+    }
+
+    private saveTextAtomic(target: string, text: string): void {
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        const temporary = `${target}.tmp`;
+        const fd = fs.openSync(temporary, 'w', 0o600);
+        try {
+            fs.writeFileSync(fd, text, 'utf8');
+            this.fsyncDescriptor(fd);
+        } finally { fs.closeSync(fd); }
+        fs.renameSync(temporary, target);
+        this.fsyncDirectory();
+    }
+
+    private journalPath(): string { return path.join(this.appUserDataPath, JOURNAL_FILE); }
+    private saveJournal(journal: MigrationJournal): void {
+        const target = this.journalPath();
+        const temporary = `${target}.tmp`;
+        const fd = fs.openSync(temporary, 'w', 0o600);
+        try {
+            fs.writeFileSync(fd, JSON.stringify(journal, null, 2), 'utf8');
+            this.fsyncDescriptor(fd);
+        } finally { fs.closeSync(fd); }
+        fs.renameSync(temporary, target);
+        this.fsyncDirectory();
+    }
+
+    private hasV3Config(): boolean {
+        try {
+            const config = JSON.parse(fs.readFileSync(path.join(this.appUserDataPath, CONFIG_FILE), 'utf8'));
+            return config.version === 3 && !!config.vaultId && !!config.device?.protectedPayload;
+        } catch { return false; }
+    }
+
+    private restoreMigrationSnapshot(journal: MigrationJournal): void {
+        if (!fs.existsSync(journal.databaseBackup)) throw new Error('MIGRATION_SNAPSHOT_MISSING');
+        if (journal.configBackup && !fs.existsSync(journal.configBackup)) throw new Error('MIGRATION_SNAPSHOT_MISSING');
+        for (const suffix of ['-wal', '-shm']) {
+            const sidecar = `${this.dbPath}${suffix}`;
+            if (fs.existsSync(sidecar)) fs.unlinkSync(sidecar);
+        }
+        if (fs.existsSync(journal.databaseBackup)) fs.copyFileSync(journal.databaseBackup, this.dbPath);
+        const configPath = path.join(this.appUserDataPath, CONFIG_FILE);
+        if (journal.configBackup && fs.existsSync(journal.configBackup)) {
+            fs.copyFileSync(journal.configBackup, configPath);
+        } else if (fs.existsSync(configPath)) {
+            fs.unlinkSync(configPath);
+        }
+        journal.phase = 'rollback-restored';
+        this.saveJournal(journal);
+    }
+
+    private createDeviceEnvelope(dek: Buffer, vaultId: string, keyVersion: number): SecurityConfigV3['device'] {
+        return {
+            provider: this.deviceKeyStore.status().provider,
+            protectedPayload: this.protectContextPayload({
+                version: 1,
+                purpose: 'device-dek',
+                vaultId,
+                keyVersion,
+                dek: dek.toString('base64')
+            })
+        };
+    }
+
+    private createPendingRecoveryAck(
+        recoveryCode: string,
+        vaultId: string,
+        keyVersion: number,
+        reason: PendingRecoveryAck['reason']
+    ): PendingRecoveryAck {
+        return {
+            protectedPayload: this.protectContextPayload({
+                version: 1,
+                purpose: 'recovery-ack',
+                vaultId,
+                keyVersion,
+                recoveryCode
+            }),
+            createdAt: new Date().toISOString(),
+            reason
+        };
+    }
+
+    private async createTransitionRecoveryEnvelope(
+        dek: Buffer,
+        legacySecret: string,
+        vaultId: string,
+        keyVersion: number
+    ): Promise<TransitionRecoveryEnvelope> {
+        return {
+            ...await this.createRecoveryEnvelope(
+                dek, legacySecret, vaultId, keyVersion, 'legacy-transition'
+            ),
+            purpose: 'legacy-transition'
+        };
+    }
+
+    private unprotectDeviceDek(config: SecurityConfigV3): Buffer {
+        const payload = this.unprotectContextPayload(config.device.protectedPayload);
+        if (payload.version !== 1 || payload.purpose !== 'device-dek' ||
+            payload.vaultId !== config.vaultId || payload.keyVersion !== config.keyVersion ||
+            typeof payload.dek !== 'string') {
+            throw new Error('VAULT_BINDING_MISMATCH');
+        }
+        const dek = Buffer.from(payload.dek, 'base64');
+        if (dek.length !== 32) throw new Error('INVALID_DEVICE_ENVELOPE');
+        return dek;
+    }
+
+    private protectContextPayload(payload: Record<string, unknown>): string {
+        return this.deviceKeyStore.protect(Buffer.from(JSON.stringify(payload), 'utf8')).toString('base64');
+    }
+
+    private unprotectContextPayload(value: string): any {
+        try {
+            return JSON.parse(this.deviceKeyStore.unprotect(Buffer.from(value, 'base64')).toString('utf8'));
+        } catch { throw new Error('INVALID_DEVICE_ENVELOPE'); }
+    }
+
+    private recoveryAad(
+        vaultId: string,
+        keyVersion: number,
+        purpose: 'recovery-dek' | 'legacy-transition' = 'recovery-dek'
+    ): Buffer {
+        return Buffer.from(`nalamdesk|v3|${purpose}|${vaultId}|${keyVersion}`, 'utf8');
+    }
+
+    private constantTimeEqual(left: string, right: string): boolean {
+        const leftBuffer = Buffer.from(left, 'utf8');
+        const rightBuffer = Buffer.from(right, 'utf8');
+        if (leftBuffer.length !== rightBuffer.length) {
+            // Keep a fixed-cost comparison even when lengths differ.
+            crypto.timingSafeEqual(leftBuffer, Buffer.alloc(leftBuffer.length));
+            return false;
+        }
+        return crypto.timingSafeEqual(leftBuffer, rightBuffer);
+    }
+
+    private cleanupCommittedMigration(journal: MigrationJournal, saltPath?: string): void {
+        let clean = true;
+        const attempt = (step: SecurityStep, action: () => void) => {
+            try { this.step(step); action(); } catch { clean = false; }
+        };
+        if (saltPath && fs.existsSync(saltPath)) {
+            attempt('cleanup-legacy-salt', () => fs.renameSync(saltPath, `${saltPath}.migrated`));
+        }
+        if (fs.existsSync(journal.databaseBackup)) {
+            attempt('cleanup-database-backup', () => fs.unlinkSync(journal.databaseBackup));
+        }
+        if (journal.configBackup && fs.existsSync(journal.configBackup)) {
+            attempt('cleanup-config-backup', () => fs.unlinkSync(journal.configBackup!));
+        }
+        if (clean && fs.existsSync(this.journalPath())) {
+            attempt('cleanup-journal', () => fs.unlinkSync(this.journalPath()));
+        }
+    }
+
+    private cleanupRollbackArtifacts(journal: MigrationJournal): void {
+        let clean = true;
+        const attempt = (step: SecurityStep, file?: string) => {
+            if (!file || !fs.existsSync(file)) return;
+            try { this.step(step); fs.unlinkSync(file); } catch { clean = false; }
+        };
+        attempt('cleanup-rollback-database-backup', journal.databaseBackup);
+        attempt('cleanup-rollback-config-backup', journal.configBackup);
+        if (clean) attempt('cleanup-rollback-journal', this.journalPath());
+    }
+
+    private setupJournalPath(): string { return path.join(this.appUserDataPath, SETUP_JOURNAL_FILE); }
+    private saveSetupJournal(journal: SetupJournal): void {
+        this.saveJsonAtomic(this.setupJournalPath(), journal);
+    }
+
+    private loadSetupJournal(): SetupJournal | null {
+        try { return JSON.parse(fs.readFileSync(this.setupJournalPath(), 'utf8')) as SetupJournal; }
+        catch { return null; }
+    }
+
+    private reconcileSetupJournal(): void {
+        const journalPath = this.setupJournalPath();
+        if (!fs.existsSync(journalPath)) return;
+        const journal = JSON.parse(fs.readFileSync(journalPath, 'utf8')) as SetupJournal;
+        if (journal.phase === 'complete') this.cleanupSetupJournal();
+        else this.rollbackSetup(journal);
+    }
+
+    private rollbackSetup(journal: SetupJournal): void {
+        this.closeDb();
+        if (journal.databaseCreated) {
+            for (const file of [this.dbPath, `${this.dbPath}-wal`, `${this.dbPath}-shm`]) {
+                if (fs.existsSync(file)) fs.unlinkSync(file);
+            }
+        }
+        const configPath = path.join(this.appUserDataPath, CONFIG_FILE);
+        for (const file of [configPath, `${configPath}.tmp`]) {
+            if (fs.existsSync(file)) fs.unlinkSync(file);
+        }
+        this.cleanupSetupJournal();
+    }
+
+    private cleanupSetupJournal(): void {
+        try {
+            this.step('cleanup-setup-journal');
+            if (fs.existsSync(this.setupJournalPath())) fs.unlinkSync(this.setupJournalPath());
+        } catch { /* committed setup is authoritative; reconcile cleanup on next start */ }
+    }
+
+    private saveJsonAtomic(target: string, value: unknown): void {
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        const temporary = `${target}.tmp`;
+        const fd = fs.openSync(temporary, 'w', 0o600);
+        try {
+            fs.writeFileSync(fd, JSON.stringify(value, null, 2), 'utf8');
+            this.fsyncDescriptor(fd);
+        } finally { fs.closeSync(fd); }
+        fs.renameSync(temporary, target);
+        this.fsyncDirectory();
+    }
+
+    private step(step: SecurityStep): void { this.hooks.onStep?.(step); }
+
+    private fsyncFile(filePath: string): void {
+        // Windows FlushFileBuffers requires a handle opened with write access.
+        // POSIX accepts a read-only descriptor and avoids broadening access.
+        const platform = this.hooks.platform ?? process.platform;
+        const fd = fs.openSync(filePath, platform === 'win32' ? 'r+' : 'r');
+        try { this.fsyncDescriptor(fd); } finally { fs.closeSync(fd); }
+    }
+
+    private fsyncDirectory(): void {
+        const platform = this.hooks.platform ?? process.platform;
+        try {
+            const directory = fs.openSync(this.appUserDataPath, 'r');
+            try { this.fsyncDescriptor(directory); } finally { fs.closeSync(directory); }
+        } catch (error) {
+            // Windows does not expose directory handles compatible with fsync.
+            // All other failures remain fatal so supported platforms retain
+            // the durability guarantee.
+            if (!this.isUnsupportedWindowsFsync(error, platform)) throw error;
+        }
+    }
+
+    private fsyncDescriptor(fd: number): void {
+        // Regular files are opened writable (including r+ on Windows), so an
+        // fsync failure is a real durability failure and must never be hidden.
+        (this.hooks.fsync ?? fs.fsyncSync)(fd);
+    }
+
+    private isUnsupportedWindowsFsync(error: unknown, platform: NodeJS.Platform): boolean {
+        if (platform !== 'win32' || !error || typeof error !== 'object') return false;
+        const code = (error as NodeJS.ErrnoException).code;
+        return code === 'EPERM' || code === 'EINVAL' || code === 'ENOSYS' || code === 'ENOTSUP';
+    }
 }

--- a/desktop/src/main/services/SessionService.spec.ts
+++ b/desktop/src/main/services/SessionService.spec.ts
@@ -39,4 +39,21 @@ describe('SessionService', () => {
         expect(service.getUser()).toBeNull();
         expect(service.isAuthenticated()).toBe(false);
     });
+
+    it('allowlists session fields and never retains a password hash', () => {
+        service.setUser({
+            id: 1,
+            username: 'admin',
+            role: 'admin',
+            name: 'Administrator',
+            password_reset_required: 0,
+            password: '$argon2id$secret-hash'
+        } as any);
+        const session = service.getUser() as any;
+        expect(session.password).toBeUndefined();
+        expect(session.password_reset_required).toBe(0);
+        expect(Object.keys(session).sort()).toEqual([
+            'id', 'name', 'password_reset_required', 'role', 'sessionId', 'username'
+        ]);
+    });
 });

--- a/desktop/src/main/services/SessionService.ts
+++ b/desktop/src/main/services/SessionService.ts
@@ -7,6 +7,7 @@ export interface UserSession {
     name: string;
     specialty?: string;
     license_number?: string;
+    password_reset_required?: number;
     sessionId?: string;
 }
 
@@ -18,7 +19,13 @@ export class SessionService {
             throw new Error('Invalid user session data');
         }
         this.currentUser = {
-            ...user,
+            id: user.id,
+            username: user.username,
+            role: user.role,
+            name: user.name,
+            ...(user.specialty ? { specialty: user.specialty } : {}),
+            ...(user.license_number ? { license_number: user.license_number } : {}),
+            ...(user.password_reset_required !== undefined ? { password_reset_required: user.password_reset_required } : {}),
             sessionId: crypto.randomUUID()
         };
     }

--- a/desktop/src/main/verify-security.ts
+++ b/desktop/src/main/verify-security.ts
@@ -1,5 +1,6 @@
 
 import { SecurityService } from './services/SecurityService';
+import type { DeviceKeyStore } from './services/DeviceKeyStore';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -10,11 +11,17 @@ async function testSecurity() {
     if (!fs.existsSync(userDataPath)) fs.mkdirSync(userDataPath);
     if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
 
-    const security = new SecurityService();
-    const password = 'mySecretPassword';
+    let protectedKey: Buffer | null = null;
+    const deviceStore: DeviceKeyStore = {
+        status: () => ({ available: true, provider: 'verification-memory-store' }),
+        protect: (value) => { protectedKey = Buffer.from(value); return Buffer.from(value); },
+        unprotect: () => { if (!protectedKey) throw new Error('missing key'); return Buffer.from(protectedKey); }
+    };
+    const security = new SecurityService(deviceStore);
+    const password = 'adminLoginPassword';
 
-    console.log('1. Initializing DB (Fresh)...');
-    await security.initialize(password, dbPath, userDataPath);
+    console.log('1. Creating a fresh device-bound vault...');
+    await security.setup(password, dbPath, userDataPath);
 
     const db = security.getDb();
     db.exec(`CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY, secret TEXT)`);
@@ -23,23 +30,10 @@ async function testSecurity() {
     console.log('2. Data inserted. Closing DB.');
     security.closeDb();
 
-    console.log('3. Attempting to open with WRONG password...');
-    const security2 = new SecurityService();
+    console.log('3. Cold-starting without a user password...');
     try {
-        await security2.initialize('wrongPassword', dbPath, userDataPath);
-        console.error('FAIL: Database should NOT open with wrong key!');
-    } catch (e: any) {
-        if (e.message === 'INVALID_PASSWORD') {
-            console.log('PASS: Correctly rejected wrong password.');
-        } else {
-            console.error('FAIL: Unexpected error:', e);
-        }
-    }
-
-    console.log('4. Attempting to open with CORRECT password...');
-    try {
-        const security3 = new SecurityService();
-        await security3.initialize(password, dbPath, userDataPath);
+        const security3 = new SecurityService(deviceStore);
+        await security3.initializeDevice(dbPath, userDataPath);
         const row = security3.getDb().prepare('SELECT * FROM test').get() as any;
         if (row && row.secret === 'This is a secret message') {
             console.log('PASS: Data recovered successfully:', row.secret);
@@ -48,7 +42,7 @@ async function testSecurity() {
         }
         security3.closeDb();
     } catch (e) {
-        console.error('FAIL: Could not reopen with correct key:', e);
+        console.error('FAIL: Could not reopen with the device key:', e);
     }
 
     // Cleanup

--- a/desktop/src/main/verify-security.ts
+++ b/desktop/src/main/verify-security.ts
@@ -11,11 +11,10 @@ async function testSecurity() {
     if (!fs.existsSync(userDataPath)) fs.mkdirSync(userDataPath);
     if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
 
-    let protectedKey: Buffer | null = null;
     const deviceStore: DeviceKeyStore = {
         status: () => ({ available: true, provider: 'verification-memory-store' }),
-        protect: (value) => { protectedKey = Buffer.from(value); return Buffer.from(value); },
-        unprotect: () => { if (!protectedKey) throw new Error('missing key'); return Buffer.from(protectedKey); }
+        protect: (value) => Buffer.from(value),
+        unprotect: (value) => Buffer.from(value)
     };
     const security = new SecurityService(deviceStore);
     const password = 'adminLoginPassword';

--- a/desktop/src/renderer/app/login/login.component.spec.ts
+++ b/desktop/src/renderer/app/login/login.component.spec.ts
@@ -27,7 +27,7 @@ describe('LoginComponent', () => {
         mockAuthService = {
             login: vi.fn(),
             getUser: vi.fn(),
-            acknowledgeRecoveryCode: vi.fn().mockResolvedValue(undefined),
+            acknowledgeRecoveryCode: vi.fn().mockResolvedValue({ success: true }),
             checkSetup: vi.fn().mockResolvedValue({ isSetup: true }) // Default to setup complete
         };
         mockRuntimeService = {
@@ -50,16 +50,18 @@ describe('LoginComponent', () => {
         expect(mockRouter.navigate).not.toHaveBeenCalled();
     });
 
-    it('explains when a legacy administrator migration is required', async () => {
+    it('uses a generic notice when additional vault verification is required', async () => {
         mockAuthService.checkSetup.mockResolvedValue({ isSetup: true, vaultState: 'legacy-migration-required' });
         await component.ngOnInit();
-        expect(component.vaultNotice).toContain('administrator must sign in once');
+        expect(component.vaultNotice).toContain('Additional security verification may be required');
+        expect(component.vaultNotice).not.toContain('migration');
     });
 
-    it('directs the user to device recovery when the OS key is unavailable', async () => {
+    it('does not disclose the specific vault state in the notice', async () => {
         mockAuthService.checkSetup.mockResolvedValue({ isSetup: true, vaultState: 'recovery-required' });
         await component.ngOnInit();
-        expect(component.vaultNotice).toContain('Recover Device');
+        expect(component.vaultNotice).toContain('Additional security verification may be required');
+        expect(component.vaultNotice).not.toContain('protected vault key');
     });
 
     it('should initialize with default values', () => {
@@ -81,7 +83,7 @@ describe('LoginComponent', () => {
         await component.onLogin();
 
         expect(component.isLoading).toBe(false);
-        expect(component.error).toBe('Invalid config');
+        expect(component.error).toBe('Sign-in failed. Check your credentials or use Recover Device if access is unavailable.');
         expect(mockRouter.navigate).not.toHaveBeenCalled();
     });
 
@@ -95,6 +97,20 @@ describe('LoginComponent', () => {
         expect(component.isLoading).toBe(false);
         expect(component.error).toBe('');
         expect(mockRouter.navigate).toHaveBeenCalledWith(['/dashboard']);
+    });
+
+    it('keeps the recovery code visible when acknowledgement fails', async () => {
+        component.username = 'admin';
+        component.password = 'legacy-password';
+        mockAuthService.login.mockResolvedValue({ success: true, pendingRecoveryCode: 'AAAA-BBBB-CCCC-DDDD' });
+        mockAuthService.acknowledgeRecoveryCode.mockResolvedValue({ success: false });
+
+        await component.onLogin();
+        await component.acknowledgeMigration();
+
+        expect(component.pendingRecoveryCode).toBe('AAAA-BBBB-CCCC-DDDD');
+        expect(component.error).toContain('Could not confirm');
+        expect(mockRouter.navigate).not.toHaveBeenCalled();
     });
 
     it('requires acknowledgement of the new recovery code after legacy migration', async () => {
@@ -123,7 +139,7 @@ describe('LoginComponent', () => {
             // Should be caught by component, but if rethrown, catch here
         }
 
-        expect(component.error).toBe('Login Error');
+        expect(component.error).toBe('Sign-in failed. Check your credentials or use Recover Device if access is unavailable.');
         expect(mockRouter.navigate).not.toHaveBeenCalled();
     });
 });

--- a/desktop/src/renderer/app/login/login.component.spec.ts
+++ b/desktop/src/renderer/app/login/login.component.spec.ts
@@ -27,6 +27,7 @@ describe('LoginComponent', () => {
         mockAuthService = {
             login: vi.fn(),
             getUser: vi.fn(),
+            acknowledgeRecoveryCode: vi.fn().mockResolvedValue(undefined),
             checkSetup: vi.fn().mockResolvedValue({ isSetup: true }) // Default to setup complete
         };
         mockRuntimeService = {
@@ -47,6 +48,18 @@ describe('LoginComponent', () => {
         mockAuthService.checkSetup.mockResolvedValue({ isSetup: true });
         await component.ngOnInit();
         expect(mockRouter.navigate).not.toHaveBeenCalled();
+    });
+
+    it('explains when a legacy administrator migration is required', async () => {
+        mockAuthService.checkSetup.mockResolvedValue({ isSetup: true, vaultState: 'legacy-migration-required' });
+        await component.ngOnInit();
+        expect(component.vaultNotice).toContain('administrator must sign in once');
+    });
+
+    it('directs the user to device recovery when the OS key is unavailable', async () => {
+        mockAuthService.checkSetup.mockResolvedValue({ isSetup: true, vaultState: 'recovery-required' });
+        await component.ngOnInit();
+        expect(component.vaultNotice).toContain('Recover Device');
     });
 
     it('should initialize with default values', () => {
@@ -81,6 +94,20 @@ describe('LoginComponent', () => {
 
         expect(component.isLoading).toBe(false);
         expect(component.error).toBe('');
+        expect(mockRouter.navigate).toHaveBeenCalledWith(['/dashboard']);
+    });
+
+    it('requires acknowledgement of the new recovery code after legacy migration', async () => {
+        component.username = 'admin';
+        component.password = 'legacy-password';
+        mockAuthService.login.mockResolvedValue({ success: true, pendingRecoveryCode: 'AAAA-BBBB-CCCC-DDDD' });
+
+        await component.onLogin();
+
+        expect(component.pendingRecoveryCode).toBe('AAAA-BBBB-CCCC-DDDD');
+        expect(mockRouter.navigate).not.toHaveBeenCalled();
+        await component.acknowledgeMigration();
+        expect(mockAuthService.acknowledgeRecoveryCode).toHaveBeenCalledWith('AAAA-BBBB-CCCC-DDDD');
         expect(mockRouter.navigate).toHaveBeenCalledWith(['/dashboard']);
     });
 

--- a/desktop/src/renderer/app/login/login.component.ts
+++ b/desktop/src/renderer/app/login/login.component.ts
@@ -17,8 +17,20 @@ import { RuntimeService } from '../services/runtime.service';
         <div *ngIf="error" class="bg-red-900/50 border border-red-500 text-red-200 px-4 py-2 rounded mb-4 text-sm">
           {{ error }}
         </div>
+        <div *ngIf="vaultNotice" class="bg-blue-950/60 border border-blue-600 text-blue-100 px-4 py-2 rounded mb-4 text-sm">
+          {{ vaultNotice }}
+        </div>
 
-        <form (ngSubmit)="onLogin()">
+        <div *ngIf="pendingRecoveryCode" class="bg-amber-950 border border-amber-500 p-4 rounded mb-4 text-sm">
+          <p class="font-bold text-amber-300 mb-2">Security upgrade complete</p>
+          <p class="text-amber-100 mb-2">Save this new recovery code before continuing. The old vault password wrapper has been removed.</p>
+          <code class="block bg-gray-950 p-2 rounded select-all break-all">{{ pendingRecoveryCode }}</code>
+          <button type="button" (click)="acknowledgeMigration()" class="mt-3 w-full bg-amber-600 hover:bg-amber-700 py-2 rounded font-bold">
+            I have saved this code
+          </button>
+        </div>
+
+        <form (ngSubmit)="onLogin()" *ngIf="!pendingRecoveryCode">
           <div class="mb-4">
             <label class="block text-gray-400 text-sm font-bold mb-2" for="username">
               Username
@@ -60,7 +72,7 @@ import { RuntimeService } from '../services/runtime.service';
         </form>
         
         <div class="mt-4 text-center flex justify-between text-xs text-gray-400">
-            <a routerLink="/recover" class="hover:text-blue-400">Forgot Password?</a>
+            <a routerLink="/recover" class="hover:text-blue-400">Recover Device</a>
             <div class="flex flex-col items-end">
                 <span>Secure Local-First Access</span>
                 <div *ngIf="runtime.lanAccessUrl" class="mt-1 flex items-center gap-1.5 bg-gray-700/50 px-2 py-0.5 rounded-md border border-gray-600/30">
@@ -82,6 +94,9 @@ export class LoginComponent implements OnInit {
   password = '';
   error = '';
   isLoading = false;
+  pendingRecoveryCode = '';
+  vaultNotice = '';
+  private pendingRoute = '/dashboard';
   isElectron = !!(globalThis as any).electron;
 
   constructor(
@@ -96,6 +111,10 @@ export class LoginComponent implements OnInit {
     const status = await this.authService.checkSetup();
     if (!status.isSetup) {
       this.router.navigate(['/setup']);
+    } else if (status.vaultState === 'legacy-migration-required') {
+      this.vaultNotice = 'Security upgrade required: the administrator must sign in once. A new recovery code will be shown.';
+    } else if (status.vaultState === 'recovery-required') {
+      this.vaultNotice = 'This device cannot access its protected vault key. Use Recover Device below.';
     }
 
     if (this.isElectron) {
@@ -119,10 +138,11 @@ export class LoginComponent implements OnInit {
           const user = this.authService.getUser();
           this.password = ''; // Clear sensitive data
 
-          if (user && user.password_reset_required) {
-            this.router.navigate(['/change-password']);
+          this.pendingRoute = user && user.password_reset_required ? '/change-password' : '/dashboard';
+          if (result.pendingRecoveryCode) {
+            this.pendingRecoveryCode = result.pendingRecoveryCode;
           } else {
-            this.router.navigate(['/dashboard']);
+            this.router.navigate([this.pendingRoute]);
           }
         } else {
           this.password = ''; // Clear sensitive data on failure too
@@ -130,6 +150,10 @@ export class LoginComponent implements OnInit {
 
           if (this.error === 'SYSTEM_LOCKED') {
             this.error = 'System Locked. Please login as Administrator to unlock.';
+          } else if (this.error === 'RECOVERY_REQUIRED') {
+            this.error = 'Device recovery is required before anyone can sign in.';
+          } else if (this.error === 'VAULT_BINDING_MISMATCH') {
+            this.error = 'The database and security metadata do not belong to the same vault.';
           }
         }
       });
@@ -140,5 +164,11 @@ export class LoginComponent implements OnInit {
         console.error(e);
       });
     }
+  }
+
+  async acknowledgeMigration() {
+    await this.authService.acknowledgeRecoveryCode(this.pendingRecoveryCode);
+    this.pendingRecoveryCode = '';
+    this.router.navigate([this.pendingRoute]);
   }
 }

--- a/desktop/src/renderer/app/login/login.component.ts
+++ b/desktop/src/renderer/app/login/login.component.ts
@@ -111,10 +111,8 @@ export class LoginComponent implements OnInit {
     const status = await this.authService.checkSetup();
     if (!status.isSetup) {
       this.router.navigate(['/setup']);
-    } else if (status.vaultState === 'legacy-migration-required') {
-      this.vaultNotice = 'Security upgrade required: the administrator must sign in once. A new recovery code will be shown.';
-    } else if (status.vaultState === 'recovery-required') {
-      this.vaultNotice = 'This device cannot access its protected vault key. Use Recover Device below.';
+    } else if (status.vaultState && !['ready', 'not-setup'].includes(status.vaultState)) {
+      this.vaultNotice = 'Additional security verification may be required. Sign in or use Recover Device if access is unavailable.';
     }
 
     if (this.isElectron) {
@@ -146,29 +144,31 @@ export class LoginComponent implements OnInit {
           }
         } else {
           this.password = ''; // Clear sensitive data on failure too
-          this.error = result.error || 'Login failed';
-
-          if (this.error === 'SYSTEM_LOCKED') {
-            this.error = 'System Locked. Please login as Administrator to unlock.';
-          } else if (this.error === 'RECOVERY_REQUIRED') {
-            this.error = 'Device recovery is required before anyone can sign in.';
-          } else if (this.error === 'VAULT_BINDING_MISMATCH') {
-            this.error = 'The database and security metadata do not belong to the same vault.';
-          }
+          this.error = 'Sign-in failed. Check your credentials or use Recover Device if access is unavailable.';
         }
       });
     } catch (e) {
       this.ngZone.run(() => {
         this.isLoading = false;
-        this.error = 'Login Error';
+        this.error = 'Sign-in failed. Check your credentials or use Recover Device if access is unavailable.';
         console.error(e);
       });
     }
   }
 
   async acknowledgeMigration() {
-    await this.authService.acknowledgeRecoveryCode(this.pendingRecoveryCode);
-    this.pendingRecoveryCode = '';
-    this.router.navigate([this.pendingRoute]);
+    this.error = '';
+    try {
+      const result = await this.authService.acknowledgeRecoveryCode(this.pendingRecoveryCode);
+      if (!result.success) {
+        this.error = 'Could not confirm the recovery code. Please try again.';
+        return;
+      }
+      this.pendingRecoveryCode = '';
+      this.router.navigate([this.pendingRoute]);
+    } catch (error) {
+      this.error = 'Could not confirm the recovery code. Please try again.';
+      console.error(error);
+    }
   }
 }

--- a/desktop/src/renderer/app/login/recovery/recovery.component.spec.ts
+++ b/desktop/src/renderer/app/login/recovery/recovery.component.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@angular/compiler';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RecoveryComponent } from './recovery.component';
+
+describe('RecoveryComponent', () => {
+    let component: RecoveryComponent;
+    let router: { navigate: ReturnType<typeof vi.fn> };
+    let authService: { acknowledgeRecoveryCode: ReturnType<typeof vi.fn>; recover: ReturnType<typeof vi.fn> };
+
+    beforeEach(() => {
+        router = { navigate: vi.fn() };
+        authService = {
+            acknowledgeRecoveryCode: vi.fn(),
+            recover: vi.fn()
+        };
+        component = new RecoveryComponent(router as any, authService as any);
+    });
+
+    it('keeps the rotated code visible when acknowledgement fails', async () => {
+        component.newRecoveryCode = 'AAAA-BBBB-CCCC-DDDD';
+        authService.acknowledgeRecoveryCode.mockResolvedValue({ success: false });
+
+        await component.finish();
+
+        expect(component.newRecoveryCode).toBe('AAAA-BBBB-CCCC-DDDD');
+        expect(component.error).toContain('Could not confirm');
+        expect(router.navigate).not.toHaveBeenCalled();
+    });
+
+    it('returns to login only after acknowledging a rotated code', async () => {
+        component.newRecoveryCode = 'AAAA-BBBB-CCCC-DDDD';
+        authService.acknowledgeRecoveryCode.mockResolvedValue({ success: true });
+
+        await component.finish();
+
+        expect(authService.acknowledgeRecoveryCode).toHaveBeenCalledWith('AAAA-BBBB-CCCC-DDDD');
+        expect(component.newRecoveryCode).toBe('');
+        expect(router.navigate).toHaveBeenCalledWith(['/login']);
+    });
+
+    it('returns directly to login when no acknowledgement is pending', async () => {
+        await component.finish();
+
+        expect(authService.acknowledgeRecoveryCode).not.toHaveBeenCalled();
+        expect(router.navigate).toHaveBeenCalledWith(['/login']);
+    });
+});

--- a/desktop/src/renderer/app/login/recovery/recovery.component.ts
+++ b/desktop/src/renderer/app/login/recovery/recovery.component.ts
@@ -28,8 +28,8 @@ import { AuthService } from '../../services/auth.service';
             <button (click)="copyCode()" class="mt-2 text-sm text-blue-600 font-bold">{{ isCopied ? 'Copied!' : 'Copy' }}</button>
           </div>
           <div class="flex justify-center">
-              <button (click)="finish()" class="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-6 rounded">
-                  {{ newRecoveryCode ? 'I have saved this code' : 'Return to Login' }}
+              <button (click)="finish()" [disabled]="isLoading" class="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-6 rounded disabled:opacity-50 disabled:cursor-not-allowed">
+                  {{ isLoading ? 'Confirming...' : (newRecoveryCode ? 'I have saved this code' : 'Return to Login') }}
               </button>
           </div>
         </div>
@@ -114,7 +114,27 @@ export class RecoveryComponent {
     this.isCopied = true;
   }
 
-  finish() {
-    this.router.navigate(['/login']);
+  async finish() {
+    if (!this.newRecoveryCode) {
+      this.router.navigate(['/login']);
+      return;
+    }
+
+    this.isLoading = true;
+    this.error = '';
+    try {
+      const result = await this.authService.acknowledgeRecoveryCode(this.newRecoveryCode);
+      if (!result.success) {
+        this.error = 'Could not confirm the recovery code. Please try again.';
+        return;
+      }
+      this.newRecoveryCode = '';
+      this.router.navigate(['/login']);
+    } catch (error) {
+      this.error = 'Could not confirm the recovery code. Please try again.';
+      console.error(error);
+    } finally {
+      this.isLoading = false;
+    }
   }
 }

--- a/desktop/src/renderer/app/login/recovery/recovery.component.ts
+++ b/desktop/src/renderer/app/login/recovery/recovery.component.ts
@@ -11,29 +11,25 @@ import { AuthService } from '../../services/auth.service';
   template: `
     <div class="min-h-screen flex items-center justify-center bg-gray-900 text-white p-6">
       <div class="bg-gray-800 p-8 rounded-lg shadow-xl w-full max-w-md border border-gray-700">
-        <h2 class="text-2xl font-bold mb-6 text-center text-red-400">Recover Password</h2>
+        <h2 class="text-2xl font-bold mb-6 text-center text-red-400">Recover This Device</h2>
         
         <div *ngIf="error" class="bg-red-900/50 border border-red-500 text-red-200 px-4 py-2 rounded mb-6 text-sm">
           {{ error }}
         </div>
         
         <div *ngIf="success" class="bg-green-100 border border-green-500 rounded p-6 mb-6">
-          <h3 class="text-green-800 font-bold text-lg mb-2">Password Reset Successful!</h3>
+          <h3 class="text-green-800 font-bold text-lg mb-2">Device Recovery Successful</h3>
           <p class="text-green-700 text-sm mb-4">
-              Your recovery code has been rotated for security. 
-              <strong>You must save this new code</strong> to recover your account in the future.
+              This device can access the clinic vault again. User passwords were not changed.
           </p>
-          
-          <div class="bg-white p-3 rounded border border-gray-300 mb-4 flex justify-between items-center">
-              <code class="text-lg font-mono font-bold text-gray-800">{{ newRecoveryCode }}</code>
-              <button (click)="copyCode()" class="text-sm text-blue-600 hover:text-blue-800 font-bold">
-                  {{ isCopied ? 'Copied!' : 'Copy' }}
-              </button>
+          <div *ngIf="newRecoveryCode" class="bg-white p-3 rounded border border-gray-300 mb-4">
+            <p class="text-red-700 text-xs mb-2">The legacy recovery wrapper was replaced. Save this new code:</p>
+            <code class="block text-lg font-mono font-bold text-gray-800 select-all break-all">{{ newRecoveryCode }}</code>
+            <button (click)="copyCode()" class="mt-2 text-sm text-blue-600 font-bold">{{ isCopied ? 'Copied!' : 'Copy' }}</button>
           </div>
-
           <div class="flex justify-center">
               <button (click)="finish()" class="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-6 rounded">
-                  I have saved this code
+                  {{ newRecoveryCode ? 'I have saved this code' : 'Return to Login' }}
               </button>
           </div>
         </div>
@@ -53,45 +49,15 @@ import { AuthService } from '../../services/auth.service';
               [disabled]="isLoading"
               autofocus
             >
-            <p class="text-xs text-gray-500 mt-1">Enter the code provided during setup.</p>
-          </div>
-
-          <!-- New Password -->
-          <div class="mb-4">
-            <label class="block text-gray-400 text-sm font-bold mb-2">
-              New Master Password
-            </label>
-            <input
-              type="password"
-              [(ngModel)]="newPassword"
-              name="newPassword"
-              class="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded text-white focus:outline-none focus:border-red-500 transition-colors"
-              placeholder="Enter new password"
-              [disabled]="isLoading"
-            >
-          </div>
-
-           <!-- Confirm Password -->
-          <div class="mb-6">
-            <label class="block text-gray-400 text-sm font-bold mb-2">
-              Confirm New Password
-            </label>
-            <input
-              type="password"
-              [(ngModel)]="confirmPassword"
-              name="confirmPassword"
-              class="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded text-white focus:outline-none focus:border-red-500 transition-colors"
-              placeholder="Confirm new password"
-              [disabled]="isLoading"
-            >
+            <p class="text-xs text-gray-500 mt-1">Enter the portable vault recovery code provided during setup.</p>
           </div>
           
           <button
             type="submit"
-            [disabled]="isLoading || !recoveryCode || !newPassword || newPassword !== confirmPassword"
+            [disabled]="isLoading || !recoveryCode"
             class="w-full bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {{ isLoading ? 'Recovering...' : 'Reset Password' }}
+            {{ isLoading ? 'Recovering...' : 'Recover Device' }}
           </button>
         </form>
         
@@ -104,13 +70,10 @@ import { AuthService } from '../../services/auth.service';
 })
 export class RecoveryComponent {
   recoveryCode = '';
-  newPassword = '';
-  confirmPassword = '';
   error = '';
   success = false;
   isLoading = false;
-
-  newRecoveryCode: string | null = null;
+  newRecoveryCode = '';
   isCopied = false;
 
   constructor(
@@ -119,24 +82,19 @@ export class RecoveryComponent {
   ) { }
 
   async onRecover() {
-    if (!this.recoveryCode || !this.newPassword) return;
-    if (this.newPassword !== this.confirmPassword) {
-      this.error = 'Passwords do not match';
-      return;
-    }
+    if (!this.recoveryCode) return;
 
     this.isLoading = true;
     this.error = '';
 
     try {
       const result = await this.authService.recover({
-        recoveryCode: this.recoveryCode.trim(),
-        newPassword: this.newPassword
+        recoveryCode: this.recoveryCode.trim()
       });
 
-      if (result.success && result.recoveryCode) {
+      if (result.success) {
         this.success = true;
-        this.newRecoveryCode = result.recoveryCode;
+        this.newRecoveryCode = result.pendingRecoveryCode || '';
         this.isLoading = false;
       } else {
         this.error = result.error || 'Recovery Failed. Check your code.';
@@ -150,15 +108,10 @@ export class RecoveryComponent {
   }
 
   async copyCode() {
-    if (this.newRecoveryCode) {
-      if (window.electron) {
-        await window.electron.clipboard.writeText(this.newRecoveryCode);
-      } else {
-        navigator.clipboard.writeText(this.newRecoveryCode);
-      }
-      this.isCopied = true;
-      setTimeout(() => this.isCopied = false, 2000);
-    }
+    if (!this.newRecoveryCode) return;
+    if (window.electron) await window.electron.clipboard.writeText(this.newRecoveryCode);
+    else await navigator.clipboard.writeText(this.newRecoveryCode);
+    this.isCopied = true;
   }
 
   finish() {

--- a/desktop/src/renderer/app/services/auth.service.spec.ts
+++ b/desktop/src/renderer/app/services/auth.service.spec.ts
@@ -48,9 +48,15 @@ describe('AuthService', () => {
             (window as any).electron = {
                 acknowledgeRecoveryCode: vi.fn().mockResolvedValue({ success: true })
             };
-            await service.acknowledgeRecoveryCode('AAAA-BBBB-CCCC-DDDD');
+            await expect(service.acknowledgeRecoveryCode('AAAA-BBBB-CCCC-DDDD'))
+                .resolves.toEqual({ success: true });
             expect(window.electron.acknowledgeRecoveryCode)
                 .toHaveBeenCalledWith('AAAA-BBBB-CCCC-DDDD');
+        });
+
+        it('fails closed when recovery acknowledgement IPC is unavailable', async () => {
+            await expect(service.acknowledgeRecoveryCode('AAAA-BBBB-CCCC-DDDD'))
+                .resolves.toEqual({ success: false });
         });
 
         it('should handle login failure', async () => {

--- a/desktop/src/renderer/app/services/auth.service.spec.ts
+++ b/desktop/src/renderer/app/services/auth.service.spec.ts
@@ -30,6 +30,29 @@ describe('AuthService', () => {
             expect(window.electron.login).toHaveBeenCalledWith({ username: 'admin', password: 'pass' });
         });
 
+        it('preserves a one-time migration recovery code for acknowledgement', async () => {
+            (window as any).electron = {
+                login: vi.fn().mockResolvedValue({
+                    success: true,
+                    user: { id: 1, role: 'admin' },
+                    pendingRecoveryCode: 'AAAA-BBBB-CCCC-DDDD'
+                })
+            };
+            await expect(service.login('admin', 'legacy')).resolves.toMatchObject({
+                success: true,
+                pendingRecoveryCode: 'AAAA-BBBB-CCCC-DDDD'
+            });
+        });
+
+        it('sends the exact displayed recovery code when acknowledging', async () => {
+            (window as any).electron = {
+                acknowledgeRecoveryCode: vi.fn().mockResolvedValue({ success: true })
+            };
+            await service.acknowledgeRecoveryCode('AAAA-BBBB-CCCC-DDDD');
+            expect(window.electron.acknowledgeRecoveryCode)
+                .toHaveBeenCalledWith('AAAA-BBBB-CCCC-DDDD');
+        });
+
         it('should handle login failure', async () => {
             (window as any).electron = {
                 login: vi.fn().mockResolvedValue({ success: false, error: 'Invalid' })
@@ -48,6 +71,18 @@ describe('AuthService', () => {
             const result = await service.login('a', 'b');
             expect(result.success).toBe(false);
             expect(result.error).toBe('IPC Error');
+        });
+
+        it('never persists a password hash returned by a compromised IPC payload', async () => {
+            (window as any).electron = {
+                login: vi.fn().mockResolvedValue({
+                    success: true,
+                    user: { id: 1, username: 'admin', role: 'admin', name: 'Admin', password: '$argon2id$hash' }
+                })
+            };
+            await service.login('admin', 'pass');
+            expect((service.getUser() as any).password).toBeUndefined();
+            expect(localStorage.getItem('nalamdesk_user')).not.toContain('$argon2id$hash');
         });
     });
 

--- a/desktop/src/renderer/app/services/auth.service.ts
+++ b/desktop/src/renderer/app/services/auth.service.ts
@@ -67,9 +67,9 @@ export class AuthService {
         return { success: false, error: 'Web recovery not supported yet' };
     }
 
-    async acknowledgeRecoveryCode(recoveryCode: string): Promise<void> {
-        if (!window.electron) return;
-        await window.electron.acknowledgeRecoveryCode(recoveryCode);
+    async acknowledgeRecoveryCode(recoveryCode: string): Promise<{ success: boolean }> {
+        if (!window.electron) return { success: false };
+        return await window.electron.acknowledgeRecoveryCode(recoveryCode);
     }
 
     async regenerateRecoveryCode(password: string): Promise<{ success: boolean, recoveryCode?: string, error?: string }> {

--- a/desktop/src/renderer/app/services/auth.service.ts
+++ b/desktop/src/renderer/app/services/auth.service.ts
@@ -9,13 +9,13 @@ export class AuthService {
 
     constructor() { }
 
-    async login(username: string, password: string): Promise<{ success: boolean; error?: string }> {
+    async login(username: string, password: string): Promise<{ success: boolean; error?: string; pendingRecoveryCode?: string }> {
         if (window.electron) {
             try {
                 const result = await window.electron.login({ username, password });
                 if (result.success) {
                     this.setUser(result.user);
-                    return { success: true };
+                    return { success: true, pendingRecoveryCode: result.pendingRecoveryCode };
                 } else {
                     return { success: false, error: result.error };
                 }
@@ -43,7 +43,7 @@ export class AuthService {
         }
     }
 
-    async checkSetup(): Promise<{ isSetup: boolean, hasRecovery: boolean }> {
+    async checkSetup(): Promise<{ isSetup: boolean, hasRecovery: boolean, vaultState?: string, configVersion?: number }> {
         if (window.electron) {
             return await window.electron.checkSetup();
         } else {
@@ -60,11 +60,16 @@ export class AuthService {
         return { success: false, error: 'Web setup not supported yet' };
     }
 
-    async recover(data: any): Promise<{ success: boolean, recoveryCode?: string, error?: string }> {
+    async recover(data: { recoveryCode: string }): Promise<{ success: boolean, pendingRecoveryCode?: string, error?: string }> {
         if (window.electron) {
             return await window.electron.recover(data);
         }
         return { success: false, error: 'Web recovery not supported yet' };
+    }
+
+    async acknowledgeRecoveryCode(recoveryCode: string): Promise<void> {
+        if (!window.electron) return;
+        await window.electron.acknowledgeRecoveryCode(recoveryCode);
     }
 
     async regenerateRecoveryCode(password: string): Promise<{ success: boolean, recoveryCode?: string, error?: string }> {
@@ -99,7 +104,18 @@ export class AuthService {
     }
 
     private setUser(user: any) {
-        localStorage.setItem(this.userKey, JSON.stringify(user));
+        const safeUser = {
+            id: user?.id,
+            username: user?.username,
+            role: user?.role,
+            name: user?.name,
+            ...(user?.specialty ? { specialty: user.specialty } : {}),
+            ...(user?.license_number ? { license_number: user.license_number } : {}),
+            ...(user?.password_reset_required !== undefined
+                ? { password_reset_required: user.password_reset_required }
+                : {})
+        };
+        localStorage.setItem(this.userKey, JSON.stringify(safeUser));
     }
 
     private setToken(token: string) {

--- a/desktop/src/renderer/app/settings/settings.component.html
+++ b/desktop/src/renderer/app/settings/settings.component.html
@@ -587,7 +587,8 @@
         <h3 class="text-xl font-bold mb-4">Generate Recovery Code</h3>
         <div *ngIf="!newRecoveryCode">
             <p class="text-sm text-gray-600 mb-4">Enter the administrator login password to confirm.</p>
-            <input type="password" [(ngModel)]="confirmPassword" class="input input-bordered w-full mb-4"
+            <label for="recovery-admin-password" class="block text-sm font-medium text-gray-700 mb-1">Administrator Password</label>
+            <input id="recovery-admin-password" type="password" [(ngModel)]="confirmPassword" class="input input-bordered w-full mb-4"
                 placeholder="Administrator Password">
             <div class="flex justify-end gap-2">
                 <button (click)="showRecoveryModal = false" class="btn btn-ghost">Cancel</button>

--- a/desktop/src/renderer/app/settings/settings.component.html
+++ b/desktop/src/renderer/app/settings/settings.component.html
@@ -586,9 +586,9 @@
     <div class="bg-white rounded-lg p-6 w-full max-w-md">
         <h3 class="text-xl font-bold mb-4">Generate Recovery Code</h3>
         <div *ngIf="!newRecoveryCode">
-            <p class="text-sm text-gray-600 mb-4">Enter Master Password to confirm.</p>
+            <p class="text-sm text-gray-600 mb-4">Enter the administrator login password to confirm.</p>
             <input type="password" [(ngModel)]="confirmPassword" class="input input-bordered w-full mb-4"
-                placeholder="Master Password">
+                placeholder="Administrator Password">
             <div class="flex justify-end gap-2">
                 <button (click)="showRecoveryModal = false" class="btn btn-ghost">Cancel</button>
                 <button (click)="generateRecoveryCode()" class="btn btn-error"

--- a/desktop/src/renderer/app/setup/setup.component.spec.ts
+++ b/desktop/src/renderer/app/setup/setup.component.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@angular/compiler';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SetupComponent } from './setup.component';
+
+vi.mock('jspdf', () => ({ jsPDF: vi.fn() }));
+
+describe('SetupComponent recovery acknowledgement', () => {
+    let component: SetupComponent;
+    let authService: { login: ReturnType<typeof vi.fn>; acknowledgeRecoveryCode: ReturnType<typeof vi.fn> };
+    let router: { navigate: ReturnType<typeof vi.fn> };
+
+    beforeEach(() => {
+        authService = {
+            login: vi.fn().mockResolvedValue({ success: true }),
+            acknowledgeRecoveryCode: vi.fn()
+        };
+        router = { navigate: vi.fn() };
+        component = new SetupComponent(authService as any, router as any, { run: (fn: () => void) => fn() } as any);
+        component.password = 'admin-password';
+        component.recoveryCode = 'AAAA-BBBB-CCCC-DDDD';
+        vi.spyOn(window, 'alert').mockImplementation(() => undefined);
+    });
+
+    it('stays on setup when recovery acknowledgement fails', async () => {
+        authService.acknowledgeRecoveryCode.mockResolvedValue({ success: false });
+
+        await component.goToDashboard();
+
+        expect(router.navigate).not.toHaveBeenCalled();
+        expect(window.alert).toHaveBeenCalledWith('Could not confirm the recovery code. Please try again.');
+    });
+
+    it('opens the dashboard only after acknowledgement succeeds', async () => {
+        authService.acknowledgeRecoveryCode.mockResolvedValue({ success: true });
+
+        await component.goToDashboard();
+
+        expect(authService.acknowledgeRecoveryCode).toHaveBeenCalledWith('AAAA-BBBB-CCCC-DDDD');
+        expect(router.navigate).toHaveBeenCalledWith(['/dashboard']);
+    });
+});

--- a/desktop/src/renderer/app/setup/setup.component.ts
+++ b/desktop/src/renderer/app/setup/setup.component.ts
@@ -78,9 +78,9 @@ import { jsPDF } from 'jspdf';
                 This setup wizard will help you:
                 </p>
                 <ul class="list-disc list-inside text-gray-400 mb-8 space-y-2">
-                <li>Secure your patient data with a Master Password.</li>
+                <li>Create the administrator login and a device-protected local vault.</li>
                 <li>Configure your Clinic details.</li>
-                <li>Generate a Recovery Code (Essential for password reset).</li>
+                <li>Generate a Recovery Code for restoring the encrypted vault on a new device.</li>
                 </ul>
                 <button (click)="step = 2" class="px-6 py-2 bg-blue-600 hover:bg-blue-700 rounded text-white font-medium">
                 Get Started
@@ -88,17 +88,17 @@ import { jsPDF } from 'jspdf';
             </ng-template>
           </div>
 
-          <!-- Step 2: Master Password -->
+          <!-- Step 2: Administrator password -->
           <div *ngIf="step === 2">
-            <h3 class="text-xl font-semibold mb-4 text-white">Create Master Password</h3>
+            <h3 class="text-xl font-semibold mb-4 text-white">Create Administrator Password</h3>
             <div class="bg-yellow-900/30 border border-yellow-700 text-yellow-200 p-4 rounded mb-6 text-sm">
-              <span class="font-bold">IMPORTANT:</span> This password encrypts your database. 
-              If you lose it, you can ONLY restore access using the Recovery Code generated in Step 4.
+              <span class="font-bold">IMPORTANT:</span> This password signs in the administrator.
+              The local vault is protected by this device, and recovery uses the separate Recovery Code generated in Step 4.
             </div>
 
             <div class="space-y-4">
               <div>
-                <label class="block text-gray-400 text-sm mb-1">Master Password</label>
+                <label class="block text-gray-400 text-sm mb-1">Administrator Password</label>
                 <input type="password" [(ngModel)]="password" class="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white">
               </div>
               <div>
@@ -159,7 +159,7 @@ import { jsPDF } from 'jspdf';
                  {{ recoveryCode }}
                </div>
                <p class="text-red-400 text-xs mt-3">
-                 SAVE THIS CODE! It is the ONLY way to reset your password if lost.
+                 SAVE THIS CODE! It is required to recover the encrypted vault on a new or reset device.
                </p>
             </div>
 
@@ -273,7 +273,7 @@ export class SetupComponent implements OnInit {
 
     doc.setFontSize(12);
     doc.setTextColor(50, 50, 50);
-    doc.text("Keep this document safe. This code allows you to reset your Master Password.", 20, 40);
+    doc.text("Keep this document safe. This code restores access to your encrypted clinic vault.", 20, 40);
 
     doc.setDrawColor(200, 200, 200);
     doc.setFillColor(245, 245, 245);
@@ -292,7 +292,7 @@ export class SetupComponent implements OnInit {
     doc.save("nalamdesk-recovery-code.pdf");
   }
 
-  goToDashboard() {
+  async goToDashboard() {
     // Setup automatically calls ensureAdminUser which sets up DB.
     // But we are not technically "logged in" via session service yet in the Renderer (AuthService).
     // We should probably auto-login or redirect to login page (but nicely).
@@ -300,12 +300,12 @@ export class SetupComponent implements OnInit {
     // OR, since we just made the password, we can auto-login behind the scenes.
 
     // Auto-login attempt
-    this.authService.login('admin', this.password).then(res => {
-      if (res.success) {
-        this.router.navigate(['/dashboard']);
-      } else {
-        this.router.navigate(['/login']);
-      }
-    });
+    const res = await this.authService.login('admin', this.password);
+    if (res.success) {
+      await this.authService.acknowledgeRecoveryCode(this.recoveryCode);
+      this.router.navigate(['/dashboard']);
+    } else {
+      this.router.navigate(['/login']);
+    }
   }
 }

--- a/desktop/src/renderer/app/setup/setup.component.ts
+++ b/desktop/src/renderer/app/setup/setup.component.ts
@@ -302,8 +302,17 @@ export class SetupComponent implements OnInit {
     // Auto-login attempt
     const res = await this.authService.login('admin', this.password);
     if (res.success) {
-      await this.authService.acknowledgeRecoveryCode(this.recoveryCode);
-      this.router.navigate(['/dashboard']);
+      try {
+        const acknowledgement = await this.authService.acknowledgeRecoveryCode(this.recoveryCode);
+        if (acknowledgement.success) {
+          this.router.navigate(['/dashboard']);
+        } else {
+          alert('Could not confirm the recovery code. Please try again.');
+        }
+      } catch (error) {
+        console.error(error);
+        alert('Could not confirm the recovery code. Please try again.');
+      }
     } else {
       this.router.navigate(['/login']);
     }

--- a/desktop/src/renderer/types.d.ts
+++ b/desktop/src/renderer/types.d.ts
@@ -3,12 +3,13 @@ export { };
 declare global {
     interface Window {
         electron: {
-            login: (credentials: { username: string, password: string }) => Promise<{ success: boolean; user?: any; error?: string }>;
-            checkSetup: () => Promise<{ isSetup: boolean; hasRecovery: boolean }>;
+            login: (credentials: { username: string, password: string }) => Promise<{ success: boolean; user?: any; error?: string; pendingRecoveryCode?: string }>;
+            checkSetup: () => Promise<{ isSetup: boolean; hasRecovery: boolean; vaultState?: string; configVersion?: number }>;
             getRecoveryStatus: () => Promise<{ isSetup: boolean; hasRecovery: boolean; hasBackups: boolean; backups?: any[] }>;
             restoreSystemBackup: (path: string) => Promise<void>;
             setup: (data: any) => Promise<{ success: boolean; recoveryCode?: string; error?: string }>;
-            recover: (data: any) => Promise<{ success: boolean; recoveryCode?: string; error?: string }>;
+            recover: (data: { recoveryCode: string }) => Promise<{ success: boolean; pendingRecoveryCode?: string; error?: string }>;
+            acknowledgeRecoveryCode: (recoveryCode: string) => Promise<{ success: boolean }>;
             regenerateRecoveryCode: (password: string) => Promise<{ success: boolean; recoveryCode?: string; error?: string }>;
             db: {
                 getPatients: (query: string) => Promise<any[]>;

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -12704,6 +12704,10 @@ html:has(.drawer-toggle:checked) {
   white-space: pre-line;
 }
 
+.break-all {
+  word-break: break-all;
+}
+
 .rounded {
   border-radius: 0.25rem;
 }
@@ -12782,6 +12786,11 @@ html:has(.drawer-toggle:checked) {
 .border-amber-300 {
   --tw-border-opacity: 1;
   border-color: rgb(252 211 77 / var(--tw-border-opacity, 1));
+}
+
+.border-amber-500 {
+  --tw-border-opacity: 1;
+  border-color: rgb(245 158 11 / var(--tw-border-opacity, 1));
 }
 
 .border-base-200 {
@@ -12926,9 +12935,19 @@ html:has(.drawer-toggle:checked) {
   background-color: rgb(255 251 235 / var(--tw-bg-opacity, 1));
 }
 
+.bg-amber-600 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(217 119 6 / var(--tw-bg-opacity, 1));
+}
+
 .bg-amber-700 {
   --tw-bg-opacity: 1;
   background-color: rgb(180 83 9 / var(--tw-bg-opacity, 1));
+}
+
+.bg-amber-950 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(69 26 3 / var(--tw-bg-opacity, 1));
 }
 
 .bg-base-100 {
@@ -12999,6 +13018,10 @@ html:has(.drawer-toggle:checked) {
   background-color: rgb(30 58 138 / 0.3);
 }
 
+.bg-blue-950\/60 {
+  background-color: rgb(23 37 84 / 0.6);
+}
+
 .bg-current {
   background-color: currentColor;
 }
@@ -13057,6 +13080,11 @@ html:has(.drawer-toggle:checked) {
 .bg-gray-900 {
   --tw-bg-opacity: 1;
   background-color: rgb(17 24 39 / var(--tw-bg-opacity, 1));
+}
+
+.bg-gray-950 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(3 7 18 / var(--tw-bg-opacity, 1));
 }
 
 .bg-green-100 {
@@ -13516,6 +13544,16 @@ html:has(.drawer-toggle:checked) {
   color: rgb(255 255 255 / var(--tw-text-opacity, 1)) !important;
 }
 
+.text-amber-100 {
+  --tw-text-opacity: 1;
+  color: rgb(254 243 199 / var(--tw-text-opacity, 1));
+}
+
+.text-amber-300 {
+  --tw-text-opacity: 1;
+  color: rgb(252 211 77 / var(--tw-text-opacity, 1));
+}
+
 .text-amber-900 {
   --tw-text-opacity: 1;
   color: rgb(120 53 15 / var(--tw-text-opacity, 1));
@@ -13702,6 +13740,11 @@ html:has(.drawer-toggle:checked) {
 .text-red-600 {
   --tw-text-opacity: 1;
   color: rgb(220 38 38 / var(--tw-text-opacity, 1));
+}
+
+.text-red-700 {
+  --tw-text-opacity: 1;
+  color: rgb(185 28 28 / var(--tw-text-opacity, 1));
 }
 
 .text-secondary {
@@ -14201,6 +14244,11 @@ h6 {
 
 .hover\:border-sky-500\/20:hover {
   border-color: rgb(14 165 233 / 0.2);
+}
+
+.hover\:bg-amber-700:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(180 83 9 / var(--tw-bg-opacity, 1));
 }
 
 .hover\:bg-amber-800:hover {


### PR DESCRIPTION
## Summary

- separate device/database unlock from individual user authentication
- store the device-bound vault envelope through Electron `safeStorage` and fail closed when secure storage is unavailable
- keep staff/admin login passwords limited to authentication and role assignment
- add portable recovery metadata, recovery-code acknowledgement, and device re-enrollment flows without exposing raw vault keys
- migrate legacy v1/v2 `security.json` installations into the v3 vault model while preserving clinic data
- journal provisioning so interrupted setup can reconcile or roll back safely

Closes #7.

## Migration notes

- Existing legacy security metadata is migrated after the legacy credential is verified.
- The SQLCipher database is not re-created or decrypted during migration; the existing DEK is rewrapped into the v3 device and recovery envelopes.
- Transitional recovery remains available only until the newly displayed recovery code is explicitly acknowledged, after which the legacy transition envelope is removed.
- Config writes are atomic and post-open enrollment failures close the database, zero recovered key material, and restore the exact prior config.

## Security considerations

- No plaintext database key, password, recovery code, token, or portable recovery secret is persisted or returned to the renderer.
- Device unlock is restricted to supported encrypted `safeStorage`; insecure Linux `basic_text` storage is rejected.
- User passwords authenticate database users only and no longer derive the database key.
- Recovery/device envelopes are bound to versioned vault identity and authenticated context.
- Electron main/renderer boundaries and role checks are retained.

## Validation

- Main tests: 118 passed; 14 intentional host-specific skips
- Renderer tests: 165 passed
- Real Electron/SQLCipher security integration: 14/14 passed
- Focused security tests: 42/42 passed after the Windows durability correction
- Independent final review: no actionable findings
- Main TypeScript build passed
- Production build passed (existing Browserslist/CommonJS warnings only)

## Smoke evidence

- cold-start authentication succeeds for provisioned staff roles after device unlock
- missing/unsupported device credentials fail closed and enter the explicit recovery path
- legacy migration, portable recovery, recovery acknowledgement, new-device enrollment, and interrupted provisioning paths are covered by tests

## Rollback

- Before merge: close this PR; no production state changes have occurred.
- After merge but before migration: install the previous application build.
- After a completed metadata migration: retain the v3 `security.json` and database together; do not restore only one of them. Use the recovery path or a matched backup bundle to re-enroll a device.
- An interrupted config/provisioning write restores the prior atomic config or removes the uncommitted new config.

## Dependency

- This is the security foundation for stacked PRs #6 and #8.
- Do not merge without explicit owner approval.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added device-bound vault protection using secure operating-system storage.
  * Added device recovery using recovery codes, including recovery-code display, copying, and acknowledgement.
  * Added support for migrating legacy encrypted vaults with rollback protection.
  * Added clearer setup, login, recovery, and vault-status messaging.
  * Administrator login credentials are now kept separate from vault encryption.

* **Bug Fixes**
  * Prevented sensitive credential data from being retained in sessions or login responses.
  * Improved handling of vault setup, migration, recovery, and device replacement failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR separates device-bound database unlocking from user authentication and introduces recovery, legacy migration, and journaled provisioning.
- Protects the database key with Electron secure storage and a portable recovery envelope.
- Migrates legacy security metadata while retaining the existing encrypted database.
- Restricts authentication responses and pending recovery data by authenticated role.
- Adds rollback and reconciliation behavior for interrupted setup and enrollment.
- Updates renderer setup, login, and recovery flows for the new vault lifecycle.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains in the eligible follow-up-review scope.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| desktop/src/main/services/SecurityService.ts | Implements versioned vault envelopes, device unlocking, recovery, legacy migration, atomic configuration updates, and provisioning reconciliation. |
| desktop/src/main/services/DeviceKeyStore.ts | Adds the Electron safeStorage boundary and rejects unavailable encryption or Linux basic_text storage. |
| desktop/src/main/services/ProvisioningService.ts | Coordinates vault creation, schema migration, settings, and administrator creation with commit-or-abort behavior. |
| desktop/src/main/main.ts | Rewires authentication IPC around device unlock, user-password verification, recovery enrollment, and recovery-code acknowledgement. |
| desktop/src/main/services/AuthResult.ts | Allowlists user fields crossing IPC and limits pending recovery-code disclosure to authenticated administrators. |
| desktop/src/renderer/app/login/recovery/recovery.component.ts | Updates the renderer recovery workflow for device re-enrollment and pending recovery-code acknowledgement. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Renderer
    participant Main as Electron Main
    participant Vault as SecurityService
    participant Store as safeStorage
    participant DB as SQLCipher Database

    UI->>Main: Login(username, password)
    Main->>Vault: Initialize device
    Vault->>Store: Unprotect device envelope
    Store-->>Vault: Device wrapping key
    Vault->>DB: Open with recovered DEK
    DB-->>Vault: Validate vault binding
    Vault-->>Main: Database unlocked
    Main->>DB: Verify user password and role
    DB-->>Main: Authenticated user
    Main-->>UI: Allowlisted login result

    alt Device credential unavailable
        Vault-->>Main: Recovery required
        Main-->>UI: Enter recovery flow
        UI->>Main: Recovery code
        Main->>Vault: Re-enroll device
        Vault->>Store: Protect new device key
        Vault-->>Main: Recovery status
        Main-->>UI: Continue to user login
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(desktop): address vault review findi..."](https://github.com/sankara-sabapathy/nalamdesk/commit/92ccb19bf5a1c9e2c436c63ff113e705274fae1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56142388)</sub>

<!-- /greptile_comment -->