### PR TITLE
fix(desktop): create recoverable encrypted backup bundles

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -24,6 +24,7 @@
     "watch": "ng build --watch --configuration development",
     "test": "npm run test:main && npm run test:renderer",
     "test:main": "vitest run -c vitest.config.main.js",
+    "test:security:electron": "node scripts/run-security-integration.js",
     "test:renderer": "vitest run -c vitest.config.renderer.mjs",
     "test:coverage": "vitest run -c vitest.config.main.js --coverage && vitest run -c vitest.config.renderer.mjs --coverage",
     "e2e": "playwright test",

--- a/desktop/scripts/run-security-integration.js
+++ b/desktop/scripts/run-security-integration.js
@@ -9,6 +9,7 @@ const result = spawnSync(electron, [
     '-c',
     'vitest.config.main.js',
     'src/main/services/SecurityService.integration.spec.ts',
+    'src/main/services/BackupService.integration.spec.ts',
     '--reporter=default'
 ], {
     cwd: process.cwd(),

--- a/desktop/scripts/run-security-integration.js
+++ b/desktop/scripts/run-security-integration.js
@@ -1,0 +1,20 @@
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+const electron = require('electron');
+const vitest = path.join(path.dirname(require.resolve('vitest/package.json')), 'vitest.mjs');
+
+const result = spawnSync(electron, [
+    vitest,
+    'run',
+    '-c',
+    'vitest.config.main.js',
+    'src/main/services/SecurityService.integration.spec.ts',
+    '--reporter=default'
+], {
+    cwd: process.cwd(),
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+    stdio: 'inherit'
+});
+
+if (result.error) throw result.error;
+process.exit(result.status ?? 1);

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -5,6 +5,8 @@ import log from 'electron-log';
 
 import { SessionService } from './services/SessionService';
 import { BackupService } from './services/BackupService';
+import { selectRestoreBundle } from './services/BackupFileSelection';
+import { requireExistingRestoreAuthorization } from './services/RestoreAuthorization';
 import { CrashService } from './services/CrashService';
 import { SecurityService } from './services/SecurityService';
 import { ElectronSafeStorageDeviceKeyStore } from './services/DeviceKeyStore';
@@ -124,7 +126,13 @@ const apiServer = new ApiServer(
     isDev ? getDevUiProxyUrl() : undefined
 );
 const sessionService = new SessionService();
-const backupService = new BackupService(databaseService, googleDriveService, securityService, userDataPath);
+const backupService = new BackupService(databaseService, googleDriveService, securityService, userDataPath, {
+    appVersion: app.getVersion(),
+    // Restore validation must not reconfigure or close the live vault.
+    createIsolatedSecurityService: () => new SecurityService(new ElectronSafeStorageDeviceKeyStore()),
+    onRestoreCommitted: () => sessionService.clearSession()
+});
+const authorizedRestorePaths = new Set<string>();
 
 // ... (cloud sync init logic)
 // DB init happens via IPC. ApiServer will report 503 if DB not ready (guarded in handler).
@@ -794,6 +802,21 @@ ipcMain.handle('backup:selectPath', async () => {
     return result.filePaths[0];
 });
 
+ipcMain.handle('backup:selectRestoreBundle', async () => {
+    if (!mainWindow) return null;
+    const selected = await selectRestoreBundle(() => dialog.showOpenDialog(mainWindow!, {
+        properties: ['openFile'],
+        title: 'Select NalamDesk Backup',
+        buttonLabel: 'Select Backup',
+        filters: [
+            { name: 'NalamDesk recoverable backup', extensions: ['ndbackup'] },
+            { name: 'Legacy database backup', extensions: ['db'] }
+        ]
+    }));
+    if (selected) authorizedRestorePaths.add(path.resolve(selected.path));
+    return selected;
+});
+
 ipcMain.handle('backup:useDefaultPath', async () => {
     const defaultPath = path.join(app.getPath('userData'), 'backups');
     // Ensure it exists?
@@ -823,6 +846,7 @@ ipcMain.handle('auth:getRecoveryStatus', async () => {
 
     if (!isSetup) {
         backups = await backupService.listSystemBackups();
+        for (const backup of backups) authorizedRestorePaths.add(path.resolve(backup.path));
         hasBackups = backups.length > 0;
     }
 
@@ -834,18 +858,30 @@ ipcMain.handle('auth:getRecoveryStatus', async () => {
     };
 });
 
-ipcMain.handle('auth:restoreSystemBackup', async (_, backupPath) => {
+ipcMain.handle('auth:restoreSystemBackup', async (_, request: {
+    path: string; recoveryCode: string; currentAdminPassword?: string
+}) => {
     try {
-        console.log('[Main] System Restore Triggered for:', backupPath);
-        await backupService.restoreLocalBackup(backupPath);
-
-        // After restore, we should probably restart the app to ensure clean state?
-        // Or just return success and let the frontend reload?
-        // Ideally, relaunch to reload DB connection fresh.
-        app.relaunch();
-        app.exit(0);
-
-        return { success: true };
+        if (!request || typeof request.path !== 'string' ||
+            !authorizedRestorePaths.has(path.resolve(request.path))) throw new Error('BACKUP_PATH_NOT_AUTHORIZED');
+        const liveDbPath = getDatabasePath(userDataPath,
+            process.env['NODE_ENV'] === 'test' ? 'nalamdesk-test.db' : 'nalamdesk.db');
+        const hasDatabase = fs.existsSync(liveDbPath);
+        const hasConfig = fs.existsSync(path.join(userDataPath, 'security.json'));
+        await requireExistingRestoreAuthorization({
+            hasDatabase,
+            hasConfig,
+            databaseOpen: !!securityService.getDb(),
+            sessionUser: sessionService.getUser(),
+            persistedAdmin: securityService.getDb()
+                ? await databaseService.getUserByUsername('admin')
+                : null,
+            currentAdminPassword: request.currentAdminPassword
+        });
+        const result = await backupService.restoreLocalBackup(request.path, request.recoveryCode);
+        authorizedRestorePaths.delete(path.resolve(request.path));
+        setTimeout(() => { app.relaunch(); app.exit(0); }, 500);
+        return result;
     } catch (e: any) {
         console.error('[Main] System Restore Failed:', e);
         return { success: false, error: e.message };

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -7,9 +7,12 @@ import { SessionService } from './services/SessionService';
 import { BackupService } from './services/BackupService';
 import { CrashService } from './services/CrashService';
 import { SecurityService } from './services/SecurityService';
+import { ElectronSafeStorageDeviceKeyStore } from './services/DeviceKeyStore';
 import { DatabaseService } from './services/DatabaseService';
 import { GoogleDriveService } from './services/GoogleDriveService';
 import { CloudSyncService } from './services/CloudSyncService';
+import { buildAuthenticatedLoginResult } from './services/AuthResult';
+import { ProvisioningService } from './services/ProvisioningService';
 import { ApiServer } from '../server/app';
 import {
     DEV_APP_NAME,
@@ -97,8 +100,9 @@ ipcMain.handle('utils:getRuntimeInfo', () => ({
 }));
 
 // Services
-const securityService = new SecurityService();
+const securityService = new SecurityService(new ElectronSafeStorageDeviceKeyStore());
 const databaseService = new DatabaseService();
+const provisioningService = new ProvisioningService(securityService, databaseService);
 const googleDriveService = new GoogleDriveService();
 const cloudSyncService = new CloudSyncService(databaseService);
 
@@ -282,6 +286,8 @@ app.on('before-quit', async (e) => {
 // IPC Handlers
 ipcMain.handle('auth:checkSetup', () => {
     const userDataPath = app.getPath('userData');
+    const dbName = process.env['NODE_ENV'] === 'test' ? 'nalamdesk-test.db' : 'nalamdesk.db';
+    securityService.reconcileProvisioning(getDatabasePath(userDataPath, dbName), userDataPath);
     return securityService.isSetup(userDataPath);
 });
 
@@ -292,22 +298,11 @@ ipcMain.handle('auth:setup', async (event, { password, clinicDetails, adminDetai
         const dbName = process.env['NODE_ENV'] === 'test' ? 'nalamdesk-test.db' : 'nalamdesk.db';
         const dbPath = getDatabasePath(userDataPath, dbName);
 
-        // 1. Setup Security (Generates DEK + Recovery Code)
-        const recoveryCode = await securityService.setup(password, dbPath, userDataPath);
-
-        // 2. Set DB Service
-        databaseService.setDb(securityService.getDb());
-
-        // 3. Migrate DB Schema
-        await databaseService.migrate();
-
-        // 4. Save Settings
-        databaseService.saveSettings(clinicDetails);
-
-        // 5. Create Admin User
-        // We pass password here, but remember, Auth is now decoupled from DB Key.
-        // The Admin Password is the same as the Master Password for simplicity in V1/V2 transition.
-        await databaseService.ensureAdminUser(password);
+        // One durable transaction covers vault creation, schema, clinic settings,
+        // and the administrator credential. The password never wraps the DEK.
+        const recoveryCode = await provisioningService.provision(
+            password, clinicDetails, dbPath, userDataPath
+        );
 
         console.log('[Auth] Setup Complete.');
         return { success: true, recoveryCode };
@@ -317,26 +312,25 @@ ipcMain.handle('auth:setup', async (event, { password, clinicDetails, adminDetai
     }
 });
 
-ipcMain.handle('auth:recover', async (event, { recoveryCode, newPassword }) => {
+ipcMain.handle('auth:recover', async (event, { recoveryCode }) => {
     try {
         console.log('[Auth] Starting Recovery...');
         const userDataPath = app.getPath('userData');
         const dbName = process.env['NODE_ENV'] === 'test' ? 'nalamdesk-test.db' : 'nalamdesk.db';
         const dbPath = getDatabasePath(userDataPath, dbName);
 
-        // 1. Recover Vault
-        const newRecoveryCode = await securityService.recover(recoveryCode, newPassword, userDataPath, dbPath);
+        // Recovery re-enrols this device. Account password recovery is a
+        // separate workflow owned by issue #6.
+        await securityService.recoverDevice(recoveryCode, userDataPath, dbPath);
 
         // 2. Set DB
         databaseService.setDb(securityService.getDb());
 
-        // 3. Update Admin Password in DB (since we reset it)
-        // Note: We need a way to find the admin user and update their password hash.
-        // DatabaseService needs a method for this.
-        // For now, let's assume 'admin' user exists.
-        await databaseService.updateUserPassword('admin', newPassword);
-
-        return { success: true, recoveryCode: newRecoveryCode };
+        await databaseService.migrate();
+        return {
+            success: true,
+            pendingRecoveryCode: securityService.getPendingRecoveryCode() || undefined
+        };
     } catch (e: any) {
         console.error('[Auth] Recovery failed:', e);
         return { success: false, error: e.message };
@@ -347,9 +341,12 @@ ipcMain.handle('auth:regenerateRecoveryCode', async (event, { password }) => {
     try {
         const user = sessionService.getUser();
         if (!user || user.role !== 'admin') throw new Error('Forbidden');
+        const argon2 = await import('argon2');
+        const admin = await databaseService.getUserByUsername('admin');
+        if (!admin || !password || !await argon2.verify(admin.password, password)) throw new Error('INVALID_CREDENTIALS');
 
         console.log('[Auth] Regenerating Recovery Code...');
-        const recoveryCode = await securityService.regenerateRecoveryCode(password);
+        const recoveryCode = await securityService.regenerateRecoveryCode();
         return { success: true, recoveryCode };
     } catch (e: any) {
         console.error('[Auth] Regenerate Recovery Code failed:', e);
@@ -357,32 +354,50 @@ ipcMain.handle('auth:regenerateRecoveryCode', async (event, { password }) => {
     }
 });
 
+ipcMain.handle('auth:acknowledgeRecoveryCode', (_event, { recoveryCode }) => {
+    const user = sessionService.getUser();
+    if (!user || user.role !== 'admin') throw new Error('Forbidden');
+    securityService.acknowledgePendingRecoveryCode(recoveryCode);
+    return { success: true };
+});
+
 ipcMain.handle('clipboard:writeText', (event, text) => {
     clipboard.writeText(text);
     return true;
 });
 
-async function tryUnlockDatabase(password: string): Promise<string | null> {
-    if (securityService.getDb()) return null; // Already open
+async function tryUnlockDatabase(legacySecret: string): Promise<{ error?: string; migrated?: boolean }> {
+    if (securityService.getDb()) return {};
 
     try {
         const userDataPath = app.getPath('userData');
         const dbName = process.env['NODE_ENV'] === 'test' ? 'nalamdesk-test.db' : 'nalamdesk.db';
         const dbPath = getDatabasePath(userDataPath, dbName);
 
-        // This handles Unlock OR V1->V2 Migration
-        await securityService.initialize(password, dbPath, userDataPath);
+        let result;
+        try {
+            result = await securityService.initializeDevice(dbPath, userDataPath);
+        } catch (error: any) {
+            if (error.message !== 'LEGACY_MIGRATION_REQUIRED') throw error;
+            // The submitted password is used only for this one-time legacy
+            // migration. It is not part of the v3 device unlock contract.
+            result = await securityService.migrateLegacy(legacySecret, dbPath, userDataPath);
+        }
         databaseService.setDb(securityService.getDb());
 
         // Ensure schema is up to date (safe idempotent)
         await databaseService.migrate();
-        return null;
+        return { migrated: result.migrated };
     } catch (e: any) {
-        if (e.message === 'NOT_SETUP') return 'SETUP_REQUIRED';
-        if (e.message === 'INVALID_PASSWORD') return 'INVALID_PASSWORD';
+        if (e.message === 'NOT_SETUP') return { error: 'SETUP_REQUIRED' };
+        if (e.message === 'INVALID_LEGACY_CREDENTIAL') return { error: 'INVALID_CREDENTIALS' };
+        if (['ENCRYPTION_UNAVAILABLE', 'INSECURE_LINUX_BACKEND', 'DEVICE_UNLOCK_FAILED'].includes(e.message)) {
+            return { error: 'RECOVERY_REQUIRED' };
+        }
+        if (e.message === 'VAULT_BINDING_MISMATCH') return { error: 'VAULT_BINDING_MISMATCH' };
 
         console.error('DB Init failed:', e);
-        return 'SYSTEM_ERROR';
+        return { error: 'SYSTEM_ERROR' };
     }
 }
 
@@ -411,7 +426,7 @@ async function handleAdminLogin(password: string): Promise<{ success: boolean; u
 
     sessionService.setUser(user);
     initializeServices(databaseService.getSettings());
-    return { success: true, user };
+    return buildAuthenticatedLoginResult(sessionService.getUser()!, securityService);
 }
 
 ipcMain.handle('auth:login', async (event, credentials) => {
@@ -420,8 +435,7 @@ ipcMain.handle('auth:login', async (event, credentials) => {
 
         // 1. Initialize / Unlock DB
         const unlockResult = await tryUnlockDatabase(password);
-        if (unlockResult === 'SETUP_REQUIRED') return { success: false, error: 'SETUP_REQUIRED' };
-        if (unlockResult === 'SYSTEM_ERROR') return { success: false, error: 'SYSTEM_ERROR' };
+        if (unlockResult.error) return { success: false, error: unlockResult.error };
 
         // 2. Check if DB is open
         const db = securityService.getDb();
@@ -436,7 +450,9 @@ ipcMain.handle('auth:login', async (event, credentials) => {
         // 3. Admin fast path
         if (username === 'admin') {
             const adminResult = await handleAdminLogin(password);
-            if (adminResult) return adminResult;
+            if (adminResult) {
+                return adminResult;
+            }
             // Fallthrough to standard validation if admin user missing from DB
         }
 
@@ -447,7 +463,7 @@ ipcMain.handle('auth:login', async (event, credentials) => {
         if (result.success && result.user) {
             sessionService.setUser(result.user);
             initializeServices(databaseService.getSettings());
-            return { success: true, user: result.user };
+            return buildAuthenticatedLoginResult(sessionService.getUser()!, securityService);
         }
 
         return { success: false, error: 'INVALID_CREDENTIALS' };
@@ -835,6 +851,3 @@ ipcMain.handle('auth:restoreSystemBackup', async (_, backupPath) => {
         return { success: false, error: e.message };
     }
 });
-
-
-

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -5,7 +5,7 @@ contextBridge.exposeInMainWorld('electron', {
     login: (password: string) => ipcRenderer.invoke('auth:login', password),
     checkSetup: () => ipcRenderer.invoke('auth:checkSetup'),
     getRecoveryStatus: () => ipcRenderer.invoke('auth:getRecoveryStatus'),
-    restoreSystemBackup: (path: string) => ipcRenderer.invoke('auth:restoreSystemBackup', path),
+    restoreSystemBackup: (request: { path: string; recoveryCode: string; currentAdminPassword?: string }) => ipcRenderer.invoke('auth:restoreSystemBackup', request),
     setup: (data: any) => ipcRenderer.invoke('auth:setup', data),
     recover: (data: any) => ipcRenderer.invoke('auth:recover', data),
     acknowledgeRecoveryCode: (recoveryCode: string) => ipcRenderer.invoke('auth:acknowledgeRecoveryCode', { recoveryCode }),
@@ -13,6 +13,7 @@ contextBridge.exposeInMainWorld('electron', {
     // ...
     backup: {
         selectPath: () => ipcRenderer.invoke('backup:selectPath'),
+        selectRestoreBundle: () => ipcRenderer.invoke('backup:selectRestoreBundle'),
         useDefaultPath: () => ipcRenderer.invoke('backup:useDefaultPath'),
         runNow: () => ipcRenderer.invoke('backup:runNow'),
         listSystemBackups: () => ipcRenderer.invoke('backup:listSystemBackups')

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -8,6 +8,7 @@ contextBridge.exposeInMainWorld('electron', {
     restoreSystemBackup: (path: string) => ipcRenderer.invoke('auth:restoreSystemBackup', path),
     setup: (data: any) => ipcRenderer.invoke('auth:setup', data),
     recover: (data: any) => ipcRenderer.invoke('auth:recover', data),
+    acknowledgeRecoveryCode: (recoveryCode: string) => ipcRenderer.invoke('auth:acknowledgeRecoveryCode', { recoveryCode }),
     regenerateRecoveryCode: (password: string) => ipcRenderer.invoke('auth:regenerateRecoveryCode', { password }),
     // ...
     backup: {

--- a/desktop/src/main/services/AuthResult.spec.ts
+++ b/desktop/src/main/services/AuthResult.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildAuthenticatedLoginResult } from './AuthResult';
+
+const user = (role: string) => ({ id: 1, username: role, role, name: role, sessionId: 'private-session-id' });
+
+describe('buildAuthenticatedLoginResult', () => {
+    it('discloses a pending recovery code only to an authenticated admin', () => {
+        const recovery = { getPendingRecoveryCode: vi.fn(() => 'NEW-RECOVERY-CODE') };
+        expect(buildAuthenticatedLoginResult(user('admin'), recovery)).toMatchObject({
+            success: true,
+            pendingRecoveryCode: 'NEW-RECOVERY-CODE'
+        });
+        expect(recovery.getPendingRecoveryCode).toHaveBeenCalledOnce();
+    });
+
+    it.each(['doctor', 'nurse', 'receptionist'])('never reads or returns pending recovery for %s', role => {
+        const recovery = { getPendingRecoveryCode: vi.fn(() => 'NEW-RECOVERY-CODE') };
+        const result = buildAuthenticatedLoginResult(user(role), recovery) as any;
+        expect(result.pendingRecoveryCode).toBeUndefined();
+        expect(recovery.getPendingRecoveryCode).not.toHaveBeenCalled();
+    });
+
+    it('allowlists IPC user fields and excludes session or credential internals', () => {
+        const result = buildAuthenticatedLoginResult({
+            ...user('admin'),
+            password: '$argon2id$hash'
+        } as any, { getPendingRecoveryCode: () => null }) as any;
+        expect(result.user.password).toBeUndefined();
+        expect(result.user.sessionId).toBeUndefined();
+    });
+});

--- a/desktop/src/main/services/AuthResult.ts
+++ b/desktop/src/main/services/AuthResult.ts
@@ -1,0 +1,25 @@
+import type { UserSession } from './SessionService';
+
+export interface PendingRecoveryReader { getPendingRecoveryCode(): string | null }
+
+/** Builds the only user object allowed across the authentication IPC boundary. */
+export function buildAuthenticatedLoginResult(user: UserSession, recovery: PendingRecoveryReader) {
+    const publicUser = {
+        id: user.id,
+        username: user.username,
+        role: user.role,
+        name: user.name,
+        ...(user.specialty ? { specialty: user.specialty } : {}),
+        ...(user.license_number ? { license_number: user.license_number } : {}),
+        ...(user.password_reset_required !== undefined
+            ? { password_reset_required: user.password_reset_required }
+            : {})
+    };
+    return {
+        success: true as const,
+        user: publicUser,
+        ...(user.role === 'admin'
+            ? { pendingRecoveryCode: recovery.getPendingRecoveryCode() || undefined }
+            : {})
+    };
+}

--- a/desktop/src/main/services/BackupFileSelection.spec.ts
+++ b/desktop/src/main/services/BackupFileSelection.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest';
+import { selectRestoreBundle } from './BackupFileSelection';
+
+describe('selectRestoreBundle', () => {
+    it('returns null when the sandboxed picker is cancelled', async () => {
+        await expect(selectRestoreBundle(vi.fn(async () => ({ canceled: true, filePaths: [] })))).resolves.toBeNull();
+    });
+
+    it('returns only the selected path and display name for a supported bundle', async () => {
+        await expect(selectRestoreBundle(vi.fn(async () => ({
+            canceled: false, filePaths: ['/external/clinic.ndbackup']
+        })))).resolves.toEqual({ path: '/external/clinic.ndbackup', name: 'clinic.ndbackup' });
+    });
+
+    it('allows legacy DB selection so restore can report its precise limitation', async () => {
+        await expect(selectRestoreBundle(vi.fn(async () => ({
+            canceled: false, filePaths: ['/external/old.db']
+        })))).resolves.toEqual({ path: '/external/old.db', name: 'old.db' });
+    });
+
+    it('rejects a path outside the file types enforced by the dialog', async () => {
+        await expect(selectRestoreBundle(vi.fn(async () => ({
+            canceled: false, filePaths: ['/external/not-a-backup.txt']
+        })))).rejects.toThrow('UNSUPPORTED_BACKUP_FILE');
+    });
+});

--- a/desktop/src/main/services/BackupFileSelection.ts
+++ b/desktop/src/main/services/BackupFileSelection.ts
@@ -1,0 +1,15 @@
+import * as path from 'path';
+
+export interface RestoreBundleSelection { path: string; name: string }
+
+/** Narrow adapter around Electron's dialog; renderer never receives filesystem APIs. */
+export async function selectRestoreBundle(
+    showDialog: () => Promise<{ canceled: boolean; filePaths: string[] }>
+): Promise<RestoreBundleSelection | null> {
+    const result = await showDialog();
+    if (result.canceled || result.filePaths.length === 0) return null;
+    const selected = result.filePaths[0];
+    const extension = path.extname(selected).toLowerCase();
+    if (extension !== '.ndbackup' && extension !== '.db') throw new Error('UNSUPPORTED_BACKUP_FILE');
+    return { path: selected, name: path.basename(selected) };
+}

--- a/desktop/src/main/services/BackupService.integration.spec.ts
+++ b/desktop/src/main/services/BackupService.integration.spec.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import type { DeviceKeyStore } from './DeviceKeyStore';
+import { SecurityService } from './SecurityService';
+import { DatabaseService } from './DatabaseService';
+import { BackupService } from './BackupService';
+import type { GoogleDriveService } from './GoogleDriveService';
+
+class BackupIntegrationStore implements DeviceKeyStore {
+    constructor(private mask: number) { }
+    status() { return { available: true, provider: 'backup-integration-store' }; }
+    protect(value: Buffer) { return Buffer.from(value.map(byte => byte ^ this.mask)); }
+    unprotect(value: Buffer) { return this.protect(value); }
+}
+
+describe.skipIf(!process.versions.electron)('BackupService SQLCipher integration', () => {
+    let root: string;
+    let bundle: string;
+    const drive = { isAuthenticated: vi.fn(() => false), uploadFile: vi.fn() } as unknown as GoogleDriveService;
+
+    beforeEach(() => {
+        root = fs.mkdtempSync(path.join(os.tmpdir(), 'nalamdesk-backup-integration-'));
+        bundle = path.join(root, 'external.ndbackup');
+    });
+    afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+    async function vault(directory: string, store: DeviceKeyStore, value: string) {
+        fs.mkdirSync(directory, { recursive: true });
+        const dbPath = path.join(directory, 'nalamdesk-test.db');
+        const security = new SecurityService(store);
+        const recoveryCode = await security.setup('login-only', dbPath, directory);
+        security.getDb().exec(`CREATE TABLE clinical_backup_test (value TEXT); INSERT INTO clinical_backup_test VALUES ('${value}')`);
+        security.completeProvisioning();
+        const database = new DatabaseService(); database.setDb(security.getDb());
+        return { directory, dbPath, security, database, recoveryCode };
+    }
+
+    async function makeBundle(source: Awaited<ReturnType<typeof vault>>) {
+        await new BackupService(source.database, drive, source.security, source.directory, { appVersion: 'integration' })
+            .createBackupBundle(bundle);
+    }
+
+    function stable(value: any): string {
+        if (Array.isArray(value)) return `[${value.map(stable).join(',')}]`;
+        if (value && typeof value === 'object') return `{${Object.keys(value).sort()
+            .map(key => `${JSON.stringify(key)}:${stable(value[key])}`).join(',')}}`;
+        return JSON.stringify(value);
+    }
+
+    function corruptEncryptedDataPageAndRehash(filePath: string) {
+        const bytes = fs.readFileSync(filePath);
+        const magicLength = Buffer.byteLength('NALAMDESK-BACKUP\n');
+        const manifestLength = bytes.readUInt32BE(magicLength);
+        const manifestStart = magicLength + 4;
+        const databaseStart = manifestStart + manifestLength;
+        const manifest = JSON.parse(bytes.subarray(manifestStart, databaseStart).toString('utf8'));
+        // The test creates a large unqueried overflow area. Corrupt its final
+        // authenticated page while leaving schema/vault-binding pages readable.
+        bytes[bytes.length - 100] ^= 0xff;
+        manifest.database.sha256 = crypto.createHash('sha256').update(bytes.subarray(databaseStart)).digest('hex');
+        const { integrity: _old, ...body } = manifest;
+        manifest.integrity.manifestSha256 = crypto.createHash('sha256').update(stable(body)).digest('hex');
+        const updated = Buffer.from(JSON.stringify(manifest));
+        expect(updated.length).toBe(manifestLength);
+        updated.copy(bytes, manifestStart);
+        fs.writeFileSync(filePath, bytes);
+    }
+
+    it('restores a real SQLCipher vault on a clean machine and cold-starts with the new device envelope', async () => {
+        const source = await vault(path.join(root, 'source'), new BackupIntegrationStore(0x11), 'preserved');
+        await makeBundle(source); source.security.closeDb();
+
+        const targetDirectory = path.join(root, 'target'); fs.mkdirSync(targetDirectory);
+        const targetStore = new BackupIntegrationStore(0x72);
+        const targetSecurity = new SecurityService(targetStore);
+        const targetDatabase = new DatabaseService();
+        const service = new BackupService(targetDatabase, drive, targetSecurity, targetDirectory, {
+            createIsolatedSecurityService: () => new SecurityService(targetStore), onRestoreCommitted: vi.fn()
+        });
+        await service.restoreLocalBackup(bundle, source.recoveryCode);
+        expect(targetSecurity.getDb().prepare('SELECT value FROM clinical_backup_test').get()).toEqual({ value: 'preserved' });
+        targetSecurity.closeDb();
+
+        const coldStart = new SecurityService(targetStore);
+        await coldStart.initializeDevice(path.join(targetDirectory, 'nalamdesk-test.db'), targetDirectory);
+        expect(coldStart.getDb().prepare('SELECT value FROM clinical_backup_test').get()).toEqual({ value: 'preserved' });
+        coldStart.closeDb();
+    });
+
+    it('rejects the wrong recovery code before creating live DB or security files', async () => {
+        const source = await vault(path.join(root, 'source'), new BackupIntegrationStore(0x21), 'preserved');
+        await makeBundle(source); source.security.closeDb();
+        const targetDirectory = path.join(root, 'target'); fs.mkdirSync(targetDirectory);
+        const targetStore = new BackupIntegrationStore(0x44);
+        const service = new BackupService(new DatabaseService(), drive, new SecurityService(targetStore), targetDirectory, {
+            createIsolatedSecurityService: () => new SecurityService(targetStore), onRestoreCommitted: vi.fn()
+        });
+        await expect(service.restoreLocalBackup(bundle, 'WRONG-CODE')).rejects.toThrow('INVALID_RECOVERY_CODE');
+        expect(fs.existsSync(path.join(targetDirectory, 'nalamdesk-test.db'))).toBe(false);
+        expect(fs.existsSync(path.join(targetDirectory, 'security.json'))).toBe(false);
+    });
+
+    it('rejects a rehashed bundle with a corrupt unread SQLCipher page before live mutation', async () => {
+        const source = await vault(path.join(root, 'source'), new BackupIntegrationStore(0x25), 'incoming');
+        source.security.getDb().exec('CREATE TABLE unread_backup_pages (payload BLOB); INSERT INTO unread_backup_pages VALUES (zeroblob(1048576))');
+        await makeBundle(source); source.security.closeDb();
+        corruptEncryptedDataPageAndRehash(bundle);
+
+        const targetStore = new BackupIntegrationStore(0x26);
+        const current = await vault(path.join(root, 'target'), targetStore, 'current-preserved');
+        const oldDatabase = fs.readFileSync(current.dbPath);
+        const oldConfig = fs.readFileSync(path.join(current.directory, 'security.json'));
+        const service = new BackupService(current.database, drive, current.security, current.directory, {
+            createIsolatedSecurityService: () => new SecurityService(targetStore), onRestoreCommitted: vi.fn()
+        });
+        await expect(service.restoreLocalBackup(bundle, source.recoveryCode)).rejects
+            .toThrow(/BACKUP_(CIPHER|DATABASE)_INTEGRITY_FAILED/);
+        expect(fs.readFileSync(current.dbPath)).toEqual(oldDatabase);
+        expect(fs.readFileSync(path.join(current.directory, 'security.json'))).toEqual(oldConfig);
+        current.security.closeDb();
+    });
+
+    it('rejects recovery metadata from a different vault despite valid SQLCipher bytes', async () => {
+        const second = await vault(path.join(root, 'second'), new BackupIntegrationStore(0x32), 'second');
+        const wrongVaultId = '00000000-0000-4000-8000-000000000000';
+        const wrongEnvelope = await (second.security as any).createRecoveryEnvelope(
+            (second.security as any).dek, second.recoveryCode, wrongVaultId, 1
+        );
+        const mismatchedSecurity = {
+            getPortableVaultMetadata: () => ({
+                ...second.security.getPortableVaultMetadata(), vaultId: wrongVaultId, recovery: wrongEnvelope
+            }),
+            getDb: () => second.security.getDb(), getDbPath: () => second.dbPath
+        } as unknown as SecurityService;
+        await new BackupService(second.database, drive, mismatchedSecurity, second.directory).createBackupBundle(bundle);
+        const targetDirectory = path.join(root, 'target'); fs.mkdirSync(targetDirectory);
+        const targetStore = new BackupIntegrationStore(0x50);
+        const service = new BackupService(new DatabaseService(), drive, new SecurityService(targetStore), targetDirectory, {
+            createIsolatedSecurityService: () => new SecurityService(targetStore), onRestoreCommitted: vi.fn()
+        });
+        await expect(service.restoreLocalBackup(bundle, second.recoveryCode)).rejects.toThrow('VAULT_BINDING_MISMATCH');
+        expect(fs.existsSync(path.join(targetDirectory, 'security.json'))).toBe(false);
+        second.security.closeDb();
+    });
+
+    it('restores the prior real vault after interruption and retains a recoverable pre-restore snapshot', async () => {
+        const incoming = await vault(path.join(root, 'incoming'), new BackupIntegrationStore(0x61), 'incoming');
+        await makeBundle(incoming); incoming.security.closeDb();
+        const targetStore = new BackupIntegrationStore(0x62);
+        const current = await vault(path.join(root, 'target'), targetStore, 'current');
+        const service = new BackupService(current.database, drive, current.security, current.directory, {
+            createIsolatedSecurityService: () => new SecurityService(targetStore),
+            onRestoreCommitted: vi.fn(),
+            onStep: step => { if (step === 'restore-after-config-replace') throw new Error('forced interruption'); }
+        });
+        await expect(service.restoreLocalBackup(bundle, incoming.recoveryCode)).rejects.toThrow('forced interruption');
+        expect(current.security.getDb().prepare('SELECT value FROM clinical_backup_test').get()).toEqual({ value: 'current' });
+        const snapshots = fs.readdirSync(path.join(current.directory, 'backups')).filter(name => name.includes('pre-restore'));
+        expect(snapshots).toHaveLength(1);
+        current.security.closeDb();
+
+        const recoveryDirectory = path.join(root, 'snapshot-recovery'); fs.mkdirSync(recoveryDirectory);
+        const recoveryStore = new BackupIntegrationStore(0x73);
+        const recoverySecurity = new SecurityService(recoveryStore);
+        const recoveryDatabase = new DatabaseService();
+        await new BackupService(recoveryDatabase, drive, recoverySecurity, recoveryDirectory, {
+            createIsolatedSecurityService: () => new SecurityService(recoveryStore), onRestoreCommitted: vi.fn()
+        }).restoreLocalBackup(path.join(current.directory, 'backups', snapshots[0]), current.recoveryCode);
+        expect(recoverySecurity.getDb().prepare('SELECT value FROM clinical_backup_test').get()).toEqual({ value: 'current' });
+        recoverySecurity.closeDb();
+    });
+});

--- a/desktop/src/main/services/BackupService.spec.ts
+++ b/desktop/src/main/services/BackupService.spec.ts
@@ -1,144 +1,321 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { BackupService } from './BackupService';
-import { DatabaseService } from './DatabaseService';
-import { GoogleDriveService } from './GoogleDriveService';
-import { SecurityService } from './SecurityService';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { BackupService, type BackupStep } from './BackupService';
+import { CronJob } from 'cron';
+import type { DatabaseService } from './DatabaseService';
+import type { GoogleDriveService } from './GoogleDriveService';
+import type { SecurityService, SecurityConfigV3 } from './SecurityService';
+import { MIGRATIONS } from '../schema/migrations';
 
-// Mock dependencies
-const mockDbService = {
-    logAudit: vi.fn(),
-    backupDatabase: vi.fn(),
-    getSettings: vi.fn()
-} as unknown as DatabaseService;
+const cron = vi.hoisted(() => ({ start: vi.fn(), stop: vi.fn() }));
+vi.mock('cron', () => ({ CronJob: vi.fn(function CronJob() { return { start: cron.start, stop: cron.stop }; }) }));
 
-const mockDriveService = {
-    isAuthenticated: vi.fn(),
-    uploadFile: vi.fn()
-} as unknown as GoogleDriveService;
-
-const mockSecurityService = {
-    getDbPath: vi.fn()
-} as unknown as SecurityService;
-
-// Define mocks for CronJob instance methods
-const mockStart = vi.fn();
-const mockStop = vi.fn();
-
-// Mock cron
-vi.mock('cron', () => {
-    return {
-        CronJob: vi.fn().mockImplementation(function (time, task) {
-            return {
-                start: mockStart,
-                stop: mockStop
-            };
-        })
-    };
+const envelope = {
+    algorithm: 'aes-256-gcm' as const, kdf: 'argon2id' as const,
+    kdfParams: { timeCost: 3, memoryCost: 65536, parallelism: 1, hashLength: 32 },
+    salt: '11'.repeat(16), iv: '22'.repeat(12), wrappedKey: '33'.repeat(48), aadVersion: 1 as const
+};
+const portable = { version: 3 as const, vaultId: 'vault-source', keyVersion: 1, recovery: envelope };
+const liveConfig = (): SecurityConfigV3 => ({
+    ...portable, device: { provider: 'test', protectedPayload: 'device-only' }
 });
 
-vi.mock('fs', () => ({
-    existsSync: vi.fn().mockReturnValue(true),
-    mkdirSync: vi.fn(),
-    readdirSync: vi.fn().mockReturnValue([]),
-    statSync: vi.fn().mockReturnValue({ mtimeMs: Date.now(), size: 1024 }),
-    unlinkSync: vi.fn(),
-    copyFileSync: vi.fn()
-}));
-
-// Import CronJob to check constructor calls if needed, OR just rely on instance method checks
-import { CronJob } from 'cron';
-
-describe('BackupService', () => {
-    let service: BackupService;
+describe('BackupService recoverable bundles', () => {
+    let root: string;
+    let sourceUserData: string;
+    let sourceDb: string;
+    let bundle: string;
 
     beforeEach(() => {
-        vi.clearAllMocks();
-        service = new BackupService(mockDbService, mockDriveService, mockSecurityService, '/mock/user/data');
+        root = fs.mkdtempSync(path.join(os.tmpdir(), 'nalamdesk-backup-'));
+        sourceUserData = path.join(root, 'source');
+        sourceDb = path.join(sourceUserData, 'nalamdesk-test.db');
+        bundle = path.join(root, 'portable.ndbackup');
+        fs.mkdirSync(sourceUserData, { recursive: true });
+        fs.writeFileSync(sourceDb, Buffer.from('encrypted-sqlcipher-source-data'));
+    });
+    afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+    function drive(): GoogleDriveService {
+        return { isAuthenticated: vi.fn(() => false), uploadFile: vi.fn() } as unknown as GoogleDriveService;
+    }
+
+    it('preserves default scheduling and stops replaced jobs', () => {
+        const db = database(sourceDb);
+        (db.getSettings as any).mockReturnValue(null);
+        const service = new BackupService(db, drive(), sourceSecurity(), sourceUserData);
+        service.initAutomatedBackup();
+        expect(CronJob).toHaveBeenCalledWith('0 00 13 * * *', expect.any(Function));
+        expect(cron.start).toHaveBeenCalledTimes(2);
+        service.scheduleLocalBackup('14:00');
+        service.scheduleCloudBackup('15:00');
+        expect(cron.stop).toHaveBeenCalledTimes(2);
     });
 
-    describe('Scheduling', () => {
-        it('should schedule local and cloud backups on init', () => {
-            vi.mocked(mockDbService.getSettings).mockReturnValue({
-                backup_schedule: '14:00',
-                cloud_backup_schedule: '15:00'
-            } as any);
-
-            service.initAutomatedBackup();
-
-            // Check if CronJob constructor was called twice
-            expect(CronJob).toHaveBeenCalledTimes(2);
-            // Check if start was called twice
-            expect(mockStart).toHaveBeenCalledTimes(2);
-        });
-
-        it('should use default times if settings missing', () => {
-            vi.mocked(mockDbService.getSettings).mockReturnValue(null);
-
-            service.initAutomatedBackup();
-
-            expect(CronJob).toHaveBeenCalledTimes(2);
-            // Verify default cron patterns (13:00 -> 0 0 13 * * *)
-            // Note: convertToCron transforms '13:00' to '0 0 13 * * *'
-            // We can check the arguments passed to CronJob if we want to be strict, 
-            // but mocking behaviors is usually enough.
-        });
-
-        it('should stop existing local job before scheduling new one', () => {
-            service.scheduleLocalBackup('12:00');
-            service.scheduleLocalBackup('13:00');
-            expect(mockStop).toHaveBeenCalled();
-        });
-
-        it('should stop existing cloud job before scheduling new one', () => {
-            service.scheduleCloudBackup('12:00');
-            service.scheduleCloudBackup('13:00');
-            expect(mockStop).toHaveBeenCalled();
-        });
+    it('preserves configured local/cloud schedules', () => {
+        const db = database(sourceDb);
+        (db.getSettings as any).mockReturnValue({ backup_schedule: '02:30', cloud_backup_schedule: '03:45' });
+        new BackupService(db, drive(), sourceSecurity(), sourceUserData).initAutomatedBackup();
+        expect(CronJob).toHaveBeenCalledWith('0 30 02 * * *', expect.any(Function));
+        expect(CronJob).toHaveBeenCalledWith('0 45 03 * * *', expect.any(Function));
     });
 
-    describe('performBackup (Manual)', () => {
-        it('should run both local and cloud backups if configured', async () => {
-            // Mock Local Path
-            service.setLocalBackupPath('/mock/backups');
-            // Mock Drive Auth
-            vi.mocked(mockDriveService.isAuthenticated).mockReturnValue(true);
-            vi.mocked(mockSecurityService.getDbPath).mockReturnValue('/path/to/db.db');
-
-            await service.performBackup();
-
-            // Check Local Backup (DB Backup called)
-            expect(mockDbService.backupDatabase).toHaveBeenCalledWith(expect.stringContaining('nalamdesk-auto-backup'));
-
-            // Check Cloud Backup (Upload called)
-            expect(mockDriveService.uploadFile).toHaveBeenCalledWith('/path/to/db.db', expect.stringContaining('nalamdesk-cloud-backup'));
-        });
-
-        it('should skip cloud backup if not authenticated', async () => {
-            // Mock Local Path
-            service.setLocalBackupPath('/mock/backups');
-            // Mock Drive Auth False
-            vi.mocked(mockDriveService.isAuthenticated).mockReturnValue(false);
-
-            await service.performBackup();
-
-            // Check Local Backup
-            expect(mockDbService.backupDatabase).toHaveBeenCalled();
-            // Check Cloud Backup Skipped
-            expect(mockDriveService.uploadFile).not.toHaveBeenCalled();
-        });
+    it('uploads cloud independently when local bundle creation fails', async () => {
+        const db = database(sourceDb);
+        (db.backupDatabase as any).mockRejectedValue(new Error('local disk full'));
+        const cloud = { isAuthenticated: vi.fn(() => true), uploadFile: vi.fn(async () => undefined) } as unknown as GoogleDriveService;
+        const security = sourceSecurity();
+        const service = new BackupService(db, cloud, security, sourceUserData);
+        await expect(service.performBackup()).rejects.toThrow('local disk full');
+        expect(cloud.uploadFile).toHaveBeenCalledWith(sourceDb, expect.stringContaining('nalamdesk-cloud-backup-'));
     });
 
-    describe('performBackupOnQuit', () => {
-        it('should attempt both backups', async () => {
-            // Mock Local Path
-            service.setLocalBackupPath('/mock/backups');
-            vi.mocked(mockDriveService.isAuthenticated).mockReturnValue(true);
-            vi.mocked(mockSecurityService.getDbPath).mockReturnValue('/path/to/db.db');
-
-            await service.performBackupOnQuit();
-
-            expect(mockDbService.backupDatabase).toHaveBeenCalled();
-            expect(mockDriveService.uploadFile).toHaveBeenCalled();
+    it('skips cloud when unauthenticated and attempts it on quit when authenticated', async () => {
+        const db = database(sourceDb);
+        const cloud = { isAuthenticated: vi.fn(() => false), uploadFile: vi.fn(async () => undefined) } as unknown as GoogleDriveService;
+        const service = new BackupService(db, cloud, sourceSecurity(), sourceUserData);
+        await service.performBackup();
+        expect(cloud.uploadFile).not.toHaveBeenCalled();
+        (cloud.isAuthenticated as any).mockReturnValue(true);
+        await service.performBackupOnQuit();
+        expect(cloud.uploadFile).toHaveBeenCalledOnce();
+    });
+    function database(snapshotSource: string): DatabaseService {
+        return {
+            backupDatabase: vi.fn(async (destination: string) => fs.copyFileSync(snapshotSource, destination)),
+            logAudit: vi.fn(), getSettings: vi.fn(() => null), setDb: vi.fn()
+        } as unknown as DatabaseService;
+    }
+    function sourceSecurity(): SecurityService {
+        return {
+            getPortableVaultMetadata: vi.fn(() => portable),
+            getDb: vi.fn(() => ({ pragma: vi.fn(() => 6) })), getDbPath: vi.fn(() => sourceDb)
+        } as unknown as SecurityService;
+    }
+    function validator(expectedCode = 'correct-code', error?: string, schemaVersion = 6): SecurityService {
+        return {
+            installPortableVaultMetadata: vi.fn(async (metadata: any, code: string, _db: string, userData: string) => {
+                if (error || code !== expectedCode) throw new Error(error || 'INVALID_RECOVERY_CODE');
+                fs.writeFileSync(path.join(userData, 'security.json'), JSON.stringify({
+                    ...metadata, device: { provider: 'test', protectedPayload: 'new-device' }
+                }));
+            }), getDb: vi.fn(() => ({ pragma: vi.fn((name: string) => {
+                if (name === 'cipher_integrity_check') return [];
+                if (name === 'integrity_check') return [{ integrity_check: 'ok' }];
+                return schemaVersion;
+            }) })), closeDb: vi.fn()
+        } as unknown as SecurityService;
+    }
+    async function createBundle() {
+        const service = new BackupService(database(sourceDb), drive(), sourceSecurity(), sourceUserData, { appVersion: 'test' });
+        await service.createBackupBundle(bundle);
+    }
+    function targetService(options: { existing?: boolean; validatorError?: string; validatorSchema?: number; failAt?: BackupStep } = {}) {
+        const userData = path.join(root, 'target');
+        const dbPath = path.join(userData, 'nalamdesk-test.db');
+        fs.mkdirSync(userData, { recursive: true });
+        if (options.existing) {
+            fs.writeFileSync(dbPath, 'encrypted-old-live-data');
+            fs.writeFileSync(path.join(userData, 'security.json'), JSON.stringify(liveConfig()));
+        }
+        const live = {
+            getDbPath: vi.fn(() => dbPath), getDb: vi.fn(() => null), closeDb: vi.fn(),
+            initializeDevice: vi.fn(async () => ({}))
+        } as unknown as SecurityService;
+        const db = database(dbPath);
+        const committed = vi.fn();
+        const service = new BackupService(db, drive(), live, userData, {
+            createIsolatedSecurityService: () => validator('correct-code', options.validatorError, options.validatorSchema ?? 6),
+            onStep: step => { if (step === options.failAt) throw new Error(`INTERRUPTED_${step}`); },
+            onRestoreCommitted: committed
         });
+        return { service, userData, dbPath, live, db, committed };
+    }
+
+    it('writes a versioned bundle with encrypted DB, portable metadata, and no device or plaintext fields', async () => {
+        await createBundle();
+        const bytes = fs.readFileSync(bundle);
+        expect(bytes.subarray(0, 17).toString()).toBe('NALAMDESK-BACKUP\n');
+        const text = bytes.toString('utf8');
+        expect(text).toContain('nalamdesk-offline-backup');
+        expect(text).toContain('vault-source');
+        expect(text).not.toContain('device-only');
+        expect(text).not.toContain('password');
+        expect(text).not.toContain('recoveryCode');
+        expect(text).not.toContain('token');
+    });
+
+    it.each([
+        ['nested recovery secret', { ...portable, recovery: { ...envelope, recoveryCode: 'plaintext' } }],
+        ['device envelope', { ...portable, device: { protectedPayload: 'device' } }],
+        ['nested KDF plaintext', { ...portable, recovery: { ...envelope, kdfParams: { ...envelope.kdfParams, password: 'secret' } } }]
+    ])('refuses creation metadata containing a forbidden %s field', async (_label, injected) => {
+        const security = { ...sourceSecurity(), getPortableVaultMetadata: vi.fn(() => injected) } as unknown as SecurityService;
+        await expect(new BackupService(database(sourceDb), drive(), security, sourceUserData)
+            .createBackupBundle(bundle)).rejects.toThrow('BACKUP_CONTAINS_FORBIDDEN_METADATA');
+        expect(fs.existsSync(bundle)).toBe(false);
+    });
+
+    it('validates an optional transition envelope even when primary recovery metadata is valid', async () => {
+        const security = { ...sourceSecurity(), getPortableVaultMetadata: vi.fn(() => ({
+            ...portable, transitionRecovery: { ...envelope, purpose: 'wrong-purpose' }
+        })) } as unknown as SecurityService;
+        await expect(new BackupService(database(sourceDb), drive(), security, sourceUserData)
+            .createBackupBundle(bundle)).rejects.toThrow('INVALID_PORTABLE_RECOVERY_ENVELOPE');
+    });
+
+    it('restores onto a clean machine only after isolated recoverability validation', async () => {
+        await createBundle();
+        const { service, dbPath, userData, live, db, committed } = targetService();
+        const result = await service.restoreLocalBackup(bundle, 'correct-code');
+        expect(result).toMatchObject({ success: true, restartRequired: true });
+        expect(fs.readFileSync(dbPath).toString()).toBe('encrypted-sqlcipher-source-data');
+        expect(JSON.parse(fs.readFileSync(path.join(userData, 'security.json'), 'utf8')).device.protectedPayload).toBe('new-device');
+        expect(live.initializeDevice).toHaveBeenCalledOnce();
+        expect(db.setDb).toHaveBeenCalledOnce();
+        expect(committed).toHaveBeenCalledOnce();
+    });
+
+    it('rejects an incorrect recovery code without touching live files', async () => {
+        await createBundle();
+        const { service, dbPath, userData, live } = targetService({ existing: true });
+        const oldDb = fs.readFileSync(dbPath); const oldConfig = fs.readFileSync(path.join(userData, 'security.json'));
+        await expect(service.restoreLocalBackup(bundle, 'wrong')).rejects.toThrow('INVALID_RECOVERY_CODE');
+        expect(fs.readFileSync(dbPath)).toEqual(oldDb);
+        expect(fs.readFileSync(path.join(userData, 'security.json'))).toEqual(oldConfig);
+        expect(live.closeDb).not.toHaveBeenCalled();
+    });
+
+    it('rejects corruption before isolated SQLCipher validation or live mutation', async () => {
+        await createBundle();
+        const fd = fs.openSync(bundle, 'r+');
+        try { const last = fs.statSync(bundle).size - 1; fs.writeSync(fd, Buffer.from([0xff]), 0, 1, last); } finally { fs.closeSync(fd); }
+        const { service, dbPath, userData, live } = targetService({ existing: true });
+        const oldDb = fs.readFileSync(dbPath); const oldConfig = fs.readFileSync(path.join(userData, 'security.json'));
+        await expect(service.restoreLocalBackup(bundle, 'correct-code')).rejects.toThrow('BACKUP_DATABASE_CHECKSUM_MISMATCH');
+        expect(fs.readFileSync(dbPath)).toEqual(oldDb); expect(fs.readFileSync(path.join(userData, 'security.json'))).toEqual(oldConfig);
+        expect(live.closeDb).not.toHaveBeenCalled();
+    });
+
+    it('rejects vault/key metadata mismatch before replacing the live pair', async () => {
+        await createBundle();
+        const { service, dbPath, userData } = targetService({ existing: true, validatorError: 'VAULT_BINDING_MISMATCH' });
+        const oldDb = fs.readFileSync(dbPath); const oldConfig = fs.readFileSync(path.join(userData, 'security.json'));
+        await expect(service.restoreLocalBackup(bundle, 'correct-code')).rejects.toThrow('VAULT_BINDING_MISMATCH');
+        expect(fs.readFileSync(dbPath)).toEqual(oldDb); expect(fs.readFileSync(path.join(userData, 'security.json'))).toEqual(oldConfig);
+    });
+
+    it.each([
+        ['cipher_integrity_check', [{ cipher_integrity_check: 'HMAC verification failed' }], 'BACKUP_CIPHER_INTEGRITY_FAILED'],
+        ['integrity_check', [{ integrity_check: 'row missing' }], 'BACKUP_DATABASE_INTEGRITY_FAILED']
+    ])('rejects failed keyed %s before replacing live files', async (pragma, result, error) => {
+        await createBundle();
+        const { service, dbPath, userData, live } = targetService({ existing: true });
+        const isolated = validator();
+        (isolated.getDb as any).mockReturnValue({ pragma: vi.fn((name: string) =>
+            name === pragma ? result : name === 'cipher_integrity_check' ? [] :
+                name === 'integrity_check' ? [{ integrity_check: 'ok' }] : 6) });
+        (service as any).options.createIsolatedSecurityService = () => isolated;
+        const oldDb = fs.readFileSync(dbPath); const oldConfig = fs.readFileSync(path.join(userData, 'security.json'));
+        await expect(service.restoreLocalBackup(bundle, 'correct-code')).rejects.toThrow(error);
+        expect(fs.readFileSync(dbPath)).toEqual(oldDb); expect(fs.readFileSync(path.join(userData, 'security.json'))).toEqual(oldConfig);
+        expect(live.closeDb).not.toHaveBeenCalled();
+    });
+
+    it('rejects a manifest schema that disagrees with the unlocked staged database', async () => {
+        await createBundle();
+        const { service, dbPath, userData } = targetService({ existing: true, validatorSchema: 5 });
+        const oldDb = fs.readFileSync(dbPath); const oldConfig = fs.readFileSync(path.join(userData, 'security.json'));
+        await expect(service.restoreLocalBackup(bundle, 'correct-code')).rejects.toThrow('BACKUP_DATABASE_SCHEMA_MISMATCH');
+        expect(fs.readFileSync(dbPath)).toEqual(oldDb); expect(fs.readFileSync(path.join(userData, 'security.json'))).toEqual(oldConfig);
+    });
+
+    it('rejects an unlocked database newer than this application supports', async () => {
+        const future = Math.max(...MIGRATIONS.map(item => item.version)) + 1;
+        const futureSecurity = { ...sourceSecurity(), getDb: vi.fn(() => ({ pragma: vi.fn(() => future) })) } as SecurityService;
+        await new BackupService(database(sourceDb), drive(), futureSecurity, sourceUserData).createBackupBundle(bundle);
+        const { service } = targetService({ validatorSchema: future });
+        await expect(service.restoreLocalBackup(bundle, 'correct-code')).rejects.toThrow('BACKUP_SCHEMA_VERSION_UNSUPPORTED');
+    });
+
+    it.each(['restore-after-database-replace', 'restore-after-config-replace'] as BackupStep[])(
+        'rolls back the exact DB/config pair after interruption at %s', async failAt => {
+            await createBundle();
+            const { service, dbPath, userData } = targetService({ existing: true, failAt });
+            const oldDb = fs.readFileSync(dbPath); const oldConfig = fs.readFileSync(path.join(userData, 'security.json'));
+            await expect(service.restoreLocalBackup(bundle, 'correct-code')).rejects.toThrow('INTERRUPTED');
+            expect(fs.readFileSync(dbPath)).toEqual(oldDb); expect(fs.readFileSync(path.join(userData, 'security.json'))).toEqual(oldConfig);
+            const snapshots = fs.readdirSync(path.join(userData, 'backups')).filter(file => file.includes('pre-restore'));
+            expect(snapshots).toHaveLength(1);
+        }
+    );
+
+    it('removes a partially installed pair when clean-machine restore is interrupted', async () => {
+        await createBundle();
+        const { service, dbPath, userData } = targetService({ failAt: 'restore-after-config-replace' });
+        await expect(service.restoreLocalBackup(bundle, 'correct-code')).rejects.toThrow('INTERRUPTED');
+        expect(fs.existsSync(dbPath)).toBe(false); expect(fs.existsSync(path.join(userData, 'security.json'))).toBe(false);
+    });
+
+    it('returns committed success and invalidates the old session when post-activation cleanup fails', async () => {
+        await createBundle();
+        const { service, dbPath, committed } = targetService({ existing: true, failAt: 'restore-after-activation' });
+        await expect(service.restoreLocalBackup(bundle, 'correct-code')).resolves.toMatchObject({ success: true, restartRequired: true });
+        expect(committed).toHaveBeenCalledOnce();
+        expect(fs.readFileSync(dbPath).toString()).toBe('encrypted-sqlcipher-source-data');
+    });
+
+    it('detects legacy database-only backups and reports why they are not recoverable', async () => {
+        const userData = path.join(root, 'legacy'); const backups = path.join(userData, 'backups');
+        fs.mkdirSync(backups, { recursive: true }); fs.writeFileSync(path.join(backups, 'nalamdesk-auto-backup-old.db'), 'legacy');
+        const service = new BackupService(database(sourceDb), drive(), sourceSecurity(), userData);
+        const listed = await service.listSystemBackups();
+        expect(listed[0]).toMatchObject({ format: 'legacy-database-only', recoverable: false });
+        expect(listed[0].warning).toContain('wrapped-key metadata');
+        await expect(service.restoreLocalBackup(listed[0].path, 'code')).rejects.toThrow('LEGACY_DATABASE_ONLY_BACKUP');
+    });
+
+    it('rejects a journal whose mutable JSON points outside userData', () => {
+        const userData = path.join(root, 'journal'); fs.mkdirSync(userData);
+        fs.writeFileSync(path.join(userData, 'backup-restore.json'), JSON.stringify({
+            version: 1, phase: 'live-files-replacing', stageDirectory: '/tmp/attacker',
+            targetDatabase: '/tmp/attacker.db', liveConfig: '/tmp/security.json',
+            databaseRollback: '/tmp/a', configRollback: '/tmp/b', hadDatabase: true, hadConfig: true
+        }));
+        expect(() => new BackupService(database(sourceDb), drive(), sourceSecurity(), userData)).toThrow('RESTORE_JOURNAL_PATH_MISMATCH');
+    });
+
+    it('propagates regular-file fsync failures so rollback copies are never assumed durable', () => {
+        const service = new BackupService(database(sourceDb), drive(), sourceSecurity(), sourceUserData, { fsync: () => {
+            const error: any = new Error('disk I/O failure'); error.code = 'EIO'; throw error;
+        } }) as any;
+        expect(() => service.copyDurable(sourceDb, path.join(root, 'copy.db'))).toThrow('disk I/O failure');
+    });
+
+    it('ignores only unsupported Windows directory fsync and propagates Windows EIO', () => {
+        const unsupported: any = new Error('unsupported'); unsupported.code = 'EPERM';
+        const unsupportedService = new BackupService(database(sourceDb), drive(), sourceSecurity(), sourceUserData, {
+            platform: 'win32', fsync: () => { throw unsupported; }
+        }) as any;
+        expect(() => unsupportedService.fsyncDirectory(sourceUserData)).not.toThrow();
+        const io: any = new Error('I/O'); io.code = 'EIO';
+        const ioService = new BackupService(database(sourceDb), drive(), sourceSecurity(), sourceUserData, {
+            platform: 'win32', fsync: () => { throw io; }
+        }) as any;
+        expect(() => ioService.fsyncDirectory(sourceUserData)).toThrow('I/O');
+    });
+
+    it('refuses to replace a closed legacy vault when no portable snapshot metadata exists', async () => {
+        await createBundle();
+        const { service, dbPath, userData, live } = targetService({ existing: true });
+        fs.writeFileSync(path.join(userData, 'security.json'), JSON.stringify({
+            version: 2, salt: '11'.repeat(16), iv: '22'.repeat(12), wrappedKey: '33'.repeat(48)
+        }));
+        const oldDb = fs.readFileSync(dbPath); const oldConfig = fs.readFileSync(path.join(userData, 'security.json'));
+        await expect(service.restoreLocalBackup(bundle, 'correct-code')).rejects.toThrow('INVALID_BACKUP_MANIFEST');
+        expect(fs.readFileSync(dbPath)).toEqual(oldDb); expect(fs.readFileSync(path.join(userData, 'security.json'))).toEqual(oldConfig);
+        expect(live.closeDb).not.toHaveBeenCalled();
     });
 });

--- a/desktop/src/main/services/BackupService.ts
+++ b/desktop/src/main/services/BackupService.ts
@@ -1,235 +1,550 @@
 import { CronJob } from 'cron';
 import { DatabaseService } from './DatabaseService';
 import { GoogleDriveService } from './GoogleDriveService';
-import { SecurityService } from './SecurityService';
+import { SecurityService, type SecurityConfigV3 } from './SecurityService';
+import { MIGRATIONS } from '../schema/migrations';
+import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 
+const MAGIC = Buffer.from('NALAMDESK-BACKUP\n', 'ascii');
+const FORMAT = 'nalamdesk-offline-backup';
+const MAX_MANIFEST = 1024 * 1024;
+const RESTORE_JOURNAL = 'backup-restore.json';
+const SECURITY_CONFIG = 'security.json';
+const MAX_SUPPORTED_SCHEMA = Math.max(0, ...MIGRATIONS.map(migration => migration.version));
+type PortableMetadata = Pick<SecurityConfigV3, 'version' | 'vaultId' | 'keyVersion' | 'recovery' | 'transitionRecovery'>;
+
+interface ManifestBody {
+    format: typeof FORMAT; version: 1; createdAt: string; appVersion: string;
+    database: { fileName: 'vault.db'; size: number; sha256: string; schemaVersion: number };
+    vault: PortableMetadata;
+}
+interface Manifest extends ManifestBody {
+    integrity: { algorithm: 'sha256'; manifestSha256: string };
+}
+type RestorePhase = 'staged-validated' | 'snapshot-created' | 'live-files-replacing' |
+    'live-files-replaced' | 'activated' | 'rollback-restored';
+interface RestoreJournal {
+    version: 1; phase: RestorePhase; startedAt: string; stageDirectory: string;
+    targetDatabase: string; liveConfig: string; databaseRollback: string; configRollback: string;
+    hadDatabase: boolean; hadConfig: boolean; preRestoreSnapshot?: string;
+}
+export interface SystemBackupInfo {
+    name: string; path: string; createdTime: Date; size: number;
+    format: 'bundle-v1' | 'legacy-database-only' | 'invalid-bundle'; recoverable: boolean; warning?: string;
+}
+export interface RestoreResult { success: true; restartRequired: true; preRestoreSnapshot?: string }
+export type BackupStep = 'restore-after-stage-validation' | 'restore-after-snapshot' |
+    'restore-after-journal' | 'restore-after-database-replace' |
+    'restore-after-config-replace' | 'restore-after-activation';
+export interface BackupServiceOptions {
+    createIsolatedSecurityService?: () => SecurityService;
+    appVersion?: string;
+    onStep?: (step: BackupStep) => void;
+    /** Test seams for platform-specific durability behavior. */
+    fsync?: (fd: number) => void;
+    platform?: NodeJS.Platform;
+    /** Required restore commit boundary: invalidate every pre-restore session. */
+    onRestoreCommitted?: () => void;
+}
+
+/** Offline bundle checksums detect corruption. Authenticity/recoverability is
+ * established by recovery AEAD unwrap, SQLCipher open, and DB vault binding. */
 export class BackupService {
     private localJob: CronJob | null = null;
     private cloudJob: CronJob | null = null;
-    private localBackupPath: string = '';
+    private localBackupPath: string;
 
     constructor(
         private dbService: DatabaseService,
         private driveService: GoogleDriveService,
         private securityService: SecurityService,
-        private userDataPath: string
+        private userDataPath: string,
+        private readonly options: BackupServiceOptions = {}
     ) {
-        // Default to 'backups' folder in AppData
-        this.localBackupPath = path.join(this.userDataPath, 'backups');
+        this.localBackupPath = path.join(userDataPath, 'backups');
+        this.reconcileInterruptedRestore();
     }
 
-    setLocalBackupPath(path: string) {
-        this.localBackupPath = path;
-    }
-
+    setLocalBackupPath(backupPath: string) { this.localBackupPath = backupPath; }
     initAutomatedBackup() {
         const settings = this.dbService.getSettings();
-        const localTime = settings?.backup_schedule || '13:00';
-        const cloudTime = settings?.cloud_backup_schedule || '13:00';
-
-        console.log(`[Backup] Initializing schedules - Local: ${localTime}, Cloud: ${cloudTime}`);
-        this.scheduleLocalBackup(localTime);
-        this.scheduleCloudBackup(cloudTime);
+        this.scheduleLocalBackup(settings?.backup_schedule || '13:00');
+        this.scheduleCloudBackup(settings?.cloud_backup_schedule || '13:00');
     }
-
     private convertToCron(time: string): string {
-        // If it looks like HH:MM, convert to cron. Otherwise return as is.
-        if (/^\d{2}:\d{2}$/.test(time)) {
-            const [hours, minutes] = time.split(':');
-            return `0 ${minutes} ${hours} * * *`;
-        }
-        return time; // Assume valid cron or default
+        if (!/^\d{2}:\d{2}$/.test(time)) return time;
+        const [hours, minutes] = time.split(':');
+        return `0 ${minutes} ${hours} * * *`;
     }
-
     scheduleLocalBackup(time: string) {
-        if (this.localJob) this.localJob.stop();
-        try {
-            const cronTime = this.convertToCron(time);
-            console.log(`[Backup] Scheduling LOCAL backup for ${cronTime}`);
-            this.localJob = new CronJob(cronTime, () => this.performLocalBackup());
-            this.localJob.start();
-        } catch (e) {
-            console.error('[Backup] Failed to schedule local backup:', e);
-        }
+        this.localJob?.stop();
+        try { this.localJob = new CronJob(this.convertToCron(time), () => void this.performLocalBackup().catch(error =>
+            console.error('[Backup] Scheduled local backup failed:', error))); this.localJob.start(); }
+        catch (error) { console.error('[Backup] Failed to schedule local backup:', error); }
     }
-
     scheduleCloudBackup(time: string) {
-        if (this.cloudJob) this.cloudJob.stop();
-        try {
-            const cronTime = this.convertToCron(time);
-            console.log(`[Backup] Scheduling CLOUD backup for ${cronTime}`);
-            this.cloudJob = new CronJob(cronTime, () => this.performCloudBackup());
-            this.cloudJob.start();
-        } catch (e) {
-            console.error('[Backup] Failed to schedule cloud backup:', e);
-        }
+        this.cloudJob?.stop();
+        try { this.cloudJob = new CronJob(this.convertToCron(time), () => void this.performCloudBackup()); this.cloudJob.start(); }
+        catch (error) { console.error('[Backup] Failed to schedule cloud backup:', error); }
     }
-
-
     updateSchedule(type: 'local' | 'cloud', time: string) {
-        if (type === 'local') this.scheduleLocalBackup(time);
-        else if (type === 'cloud') this.scheduleCloudBackup(time);
+        type === 'local' ? this.scheduleLocalBackup(time) : this.scheduleCloudBackup(time);
     }
-
     async performBackupOnQuit() {
-        console.log('[Backup] Performing backup on quit...');
-        try {
-            await this.performLocalBackup();
-            if (this.driveService.isAuthenticated()) {
-                await this.performCloudBackup();
-            }
-        } catch (e) {
-            console.error('[Backup] Backup on quit failed', e);
-        }
+        try { await this.performBackup(); }
+        catch (error) { console.error('[Backup] Backup on quit failed', error); }
     }
-
     async performBackup() {
-        // ... (lines 45-59 unchanged, implied for context if needed, but I'm replacing scheduleDailyBackup and performLocalBackup header)
-        console.log('[Backup] Starting automated backup sequence...');
+        let localError: unknown;
         if (this.localBackupPath) {
-            await this.performLocalBackup();
-        } else {
-            console.warn('[Backup] Local backup skipped: No path configured.');
+            try { await this.performLocalBackup(); }
+            catch (error) { localError = error; }
         }
-
-        if (this.driveService.isAuthenticated()) {
-            await this.performCloudBackup();
-        }
+        // Cloud remains an independent attempt if local bundle creation fails.
+        if (this.driveService.isAuthenticated()) await this.performCloudBackup();
+        if (localError) throw localError;
     }
 
-    private async performLocalBackup() {
+    async createBackupBundle(destination: string): Promise<string> {
+        const databaseTemp = `${destination}.database.tmp`;
+        const bundleTemp = `${destination}.tmp`;
+        fs.mkdirSync(path.dirname(destination), { recursive: true });
+        this.remove(databaseTemp); this.remove(bundleTemp);
         try {
-            if (!fs.existsSync(this.localBackupPath)) {
-                fs.mkdirSync(this.localBackupPath, { recursive: true });
-            }
-
-            const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-            const fileName = `nalamdesk-auto-backup-${timestamp}.db`;
-            const destPath = path.join(this.localBackupPath, fileName);
-
-            console.log(`[Backup] Creating local backup: ${destPath}`);
-            await this.dbService.backupDatabase(destPath);
-
-            // Prune old backups
-            this.pruneLocalBackups();
-
-            this.dbService.logAudit('BACKUP_LOCAL', 'system', 0, 0, `Created local backup: ${fileName}`);
-        } catch (e: any) {
-            console.error('[Backup] Local backup failed:', e);
-            this.dbService.logAudit('BACKUP_ERROR', 'system', 0, 0, `Local backup failed: ${e.message}`);
-        }
+            await this.dbService.backupDatabase(databaseTemp);
+            // No await is permitted between reading the metadata and writing the
+            // bundle, so a recovery rotation cannot interleave with this pair.
+            const metadata = this.securityService.getPortableVaultMetadata();
+            return this.writePortableBundle(destination, databaseTemp, metadata,
+                Number(this.securityService.getDb()?.pragma('user_version', { simple: true }) || 0));
+        } finally { this.remove(databaseTemp); this.remove(bundleTemp); }
     }
 
+    private writePortableBundle(
+        destination: string, databasePath: string, metadata: PortableMetadata, schemaVersion: number
+    ): string {
+        const bundleTemp = `${destination}.tmp`;
+        this.remove(bundleTemp);
+        try {
+            const body: ManifestBody = {
+                format: FORMAT, version: 1, createdAt: new Date().toISOString(),
+                appVersion: this.options.appVersion || 'unknown',
+                database: {
+                    fileName: 'vault.db', size: fs.statSync(databasePath).size,
+                    sha256: this.hashFile(databasePath), schemaVersion
+                },
+                vault: this.sanitizePortableMetadata(metadata)
+            };
+            const manifest: Manifest = { ...body, integrity: { algorithm: 'sha256', manifestSha256: this.hashText(this.stable(body)) } };
+            this.writeBundle(bundleTemp, manifest, databasePath);
+            fs.renameSync(bundleTemp, destination);
+            this.fsyncDirectory(path.dirname(destination));
+            return destination;
+        } finally { this.remove(bundleTemp); }
+    }
+
+    private async performLocalBackup(): Promise<void> {
+        try {
+            fs.mkdirSync(this.localBackupPath, { recursive: true });
+            const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+            const name = `nalamdesk-auto-backup-${stamp}.ndbackup`;
+            await this.createBackupBundle(path.join(this.localBackupPath, name));
+            this.pruneLocalBackups();
+            this.dbService.logAudit('BACKUP_LOCAL', 'system', 0, 0, `Created recoverable local backup: ${name}`);
+        } catch (error: any) {
+            console.error('[Backup] Local backup failed:', error);
+            this.dbService.logAudit('BACKUP_ERROR', 'system', 0, 0, `Local backup failed: ${error.message}`);
+            throw error;
+        }
+    }
     private pruneLocalBackups() {
         try {
-            const retentionDays = 30;
-            const now = Date.now();
-            const retentionMs = retentionDays * 24 * 60 * 60 * 1000;
-
-            const files = fs.readdirSync(this.localBackupPath);
-            let deletedCount = 0;
-
-            for (const file of files) {
-                if (!file.startsWith('nalamdesk-auto-backup-') || !file.endsWith('.db')) continue;
-
-                const filePath = path.join(this.localBackupPath, file);
-                const stats = fs.statSync(filePath);
-
-                if (now - stats.mtimeMs > retentionMs) {
-                    fs.unlinkSync(filePath);
-                    deletedCount++;
-                }
+            const retention = 30 * 24 * 60 * 60 * 1000;
+            for (const file of fs.readdirSync(this.localBackupPath)) {
+                if (!file.startsWith('nalamdesk-auto-backup-') || (!file.endsWith('.ndbackup') && !file.endsWith('.db'))) continue;
+                const target = path.join(this.localBackupPath, file);
+                if (Date.now() - fs.statSync(target).mtimeMs > retention) fs.unlinkSync(target);
             }
-
-            if (deletedCount > 0) {
-                console.log(`[Backup] Pruned ${deletedCount} old backup(s).`);
-            }
-        } catch (e) {
-            console.error('[Backup] Failed to prune old backups:', e);
-        }
+        } catch (error) { console.error('[Backup] Failed to prune old backups:', error); }
     }
 
+    // Cloud backup remains outside this offline-only change.
     private async performCloudBackup() {
         try {
             const dbPath = this.securityService.getDbPath();
-            if (!dbPath || !fs.existsSync(dbPath)) {
-                console.error('[Backup] Cloud backup skipped: DB file access error.');
-                return;
-            }
-
-            const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-            const fileName = `nalamdesk-cloud-backup-${timestamp}.db`;
-
-            console.log(`[Backup] Uploading to Google Drive: ${fileName}`);
-            await this.driveService.uploadFile(dbPath, fileName);
-            console.log(`[Backup] Cloud upload success: ${fileName}`);
-
-            this.dbService.logAudit('BACKUP_CLOUD', 'system', 0, 0, `Uploaded cloud backup: ${fileName}`);
-        } catch (e: any) {
-            console.error('[Backup] Cloud backup failed:', e);
-            this.dbService.logAudit('BACKUP_ERROR', 'system', 0, 0, `Cloud backup failed: ${e.message}`);
+            if (!dbPath || !fs.existsSync(dbPath)) return;
+            const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+            const name = `nalamdesk-cloud-backup-${stamp}.db`;
+            await this.driveService.uploadFile(dbPath, name);
+            this.dbService.logAudit('BACKUP_CLOUD', 'system', 0, 0, `Uploaded cloud backup: ${name}`);
+        } catch (error: any) {
+            console.error('[Backup] Cloud backup failed:', error);
+            this.dbService.logAudit('BACKUP_ERROR', 'system', 0, 0, `Cloud backup failed: ${error.message}`);
         }
     }
-    async listSystemBackups(): Promise<any[]> {
+
+    async listSystemBackups(): Promise<SystemBackupInfo[]> {
         try {
             if (!fs.existsSync(this.localBackupPath)) return [];
-
-            const files = fs.readdirSync(this.localBackupPath)
-                .filter(f => f.endsWith('.db') && f.includes('backup'))
-                .map(f => {
-                    const filePath = path.join(this.localBackupPath, f);
-                    const stats = fs.statSync(filePath);
-                    return {
-                        name: f,
-                        path: filePath,
-                        createdTime: stats.mtime,
-                        size: stats.size
-                    };
-                })
+            return fs.readdirSync(this.localBackupPath)
+                .filter(file => file.includes('backup') && (file.endsWith('.ndbackup') || file.endsWith('.db')))
+                .map(file => this.describe(path.join(this.localBackupPath, file)))
                 .sort((a, b) => b.createdTime.getTime() - a.createdTime.getTime());
-
-            return files;
-        } catch (e) {
-            console.error('[Backup] Failed to list system backups:', e);
-            return [];
-        }
+        } catch (error) { console.error('[Backup] Failed to list system backups:', error); return []; }
+    }
+    private describe(filePath: string): SystemBackupInfo {
+        const stats = fs.statSync(filePath);
+        const common = { name: path.basename(filePath), path: filePath, createdTime: stats.mtime, size: stats.size };
+        if (!this.hasMagic(filePath)) return { ...common, format: 'legacy-database-only', recoverable: false,
+            warning: 'Legacy database-only backup: wrapped-key metadata is missing; clean-machine recovery is unavailable.' };
+        try { this.readManifest(filePath); return { ...common, format: 'bundle-v1', recoverable: true }; }
+        catch (error: any) { return { ...common, format: 'invalid-bundle', recoverable: false, warning: error.message }; }
     }
 
-    async restoreLocalBackup(backupFilePath: string): Promise<boolean> {
+    async restoreLocalBackup(backupPath: string, recoveryCode: string): Promise<RestoreResult> {
+        if (!fs.existsSync(backupPath)) throw new Error('BACKUP_NOT_FOUND');
+        if (!this.hasMagic(backupPath)) throw new Error('LEGACY_DATABASE_ONLY_BACKUP');
+        if (!recoveryCode) throw new Error('RECOVERY_CODE_REQUIRED');
+        if (!this.options.createIsolatedSecurityService) throw new Error('RESTORE_VALIDATOR_UNAVAILABLE');
+        if (!this.options.onRestoreCommitted) throw new Error('RESTORE_COMMIT_CALLBACK_REQUIRED');
+
+        const targetDatabase = this.securityService.getDbPath() || path.join(this.userDataPath,
+            process.env['NODE_ENV'] === 'test' ? 'nalamdesk-test.db' : 'nalamdesk.db');
+        const liveConfig = path.join(this.userDataPath, SECURITY_CONFIG);
+        const stageDirectory = path.join(this.userDataPath, `.backup-restore-stage-${crypto.randomUUID()}`);
+        const stagedDatabase = path.join(stageDirectory, 'vault.db');
+        const stagedConfig = path.join(stageDirectory, SECURITY_CONFIG);
+        const journal: RestoreJournal = {
+            version: 1, phase: 'staged-validated', startedAt: new Date().toISOString(), stageDirectory,
+            targetDatabase, liveConfig, databaseRollback: path.join(stageDirectory, 'live-database.rollback'),
+            configRollback: path.join(stageDirectory, 'live-security.rollback'),
+            hadDatabase: fs.existsSync(targetDatabase), hadConfig: fs.existsSync(liveConfig)
+        };
+        fs.mkdirSync(stageDirectory, { recursive: true });
+        let validator: SecurityService | undefined;
         try {
-            if (!fs.existsSync(backupFilePath)) {
-                throw new Error('Backup file not found');
+            const manifest = this.extractAndValidate(backupPath, stagedDatabase);
+            validator = this.options.createIsolatedSecurityService();
+            await validator.installPortableVaultMetadata(manifest.vault, recoveryCode, stagedDatabase, stageDirectory);
+            const stagedDb = validator.getDb();
+            this.runKeyedIntegrityChecks(stagedDb);
+            const stagedSchema = Number(stagedDb?.pragma('user_version', { simple: true }));
+            if (!Number.isInteger(stagedSchema) || stagedSchema < 0) throw new Error('BACKUP_DATABASE_SCHEMA_INVALID');
+            if (manifest.database.schemaVersion !== 0 && manifest.database.schemaVersion !== stagedSchema) {
+                throw new Error('BACKUP_DATABASE_SCHEMA_MISMATCH');
             }
+            if (stagedSchema > MAX_SUPPORTED_SCHEMA) throw new Error('BACKUP_SCHEMA_VERSION_UNSUPPORTED');
+            validator.closeDb(); validator = undefined;
+            if (!fs.existsSync(stagedConfig)) throw new Error('STAGED_SECURITY_CONFIG_MISSING');
+            this.step('restore-after-stage-validation');
+            this.saveJournal(journal);
 
-            console.log(`[Backup] Restoring from local backup: ${backupFilePath}`);
+            if (journal.hadDatabase && journal.hadConfig) {
+                fs.mkdirSync(this.localBackupPath, { recursive: true });
+                const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+                const snapshot = path.join(this.localBackupPath, `nalamdesk-pre-restore-${stamp}.ndbackup`);
+                if (this.securityService.getDb()) {
+                    journal.preRestoreSnapshot = await this.createBackupBundle(snapshot);
+                } else {
+                    // A closed vault is quiescent. Snapshot the encrypted bytes
+                    // with a strictly sanitized copy of its portable metadata.
+                    journal.preRestoreSnapshot = this.writePortableBundle(
+                        snapshot, targetDatabase, this.readPortableMetadata(liveConfig), 0
+                    );
+                }
+            }
+            journal.phase = 'snapshot-created'; this.saveJournal(journal); this.step('restore-after-snapshot');
+            if (journal.hadDatabase) this.copyDurable(targetDatabase, journal.databaseRollback);
+            if (journal.hadConfig) this.copyDurable(liveConfig, journal.configRollback);
+            this.fsyncDirectory(stageDirectory);
+            journal.phase = 'live-files-replacing'; this.saveJournal(journal); this.step('restore-after-journal');
 
-            // 1. Close current DB connection
             this.securityService.closeDb();
-
-            // 2. Determine Target DB Path
-            // If DB was open, we use that path. If not, we construct default path.
-            let targetPath = this.securityService.getDbPath();
-            if (!targetPath) {
-                // Fallback to default path logic (similar to main.ts)
-                const dbName = process.env['NODE_ENV'] === 'test' ? 'nalamdesk-test.db' : 'nalamdesk.db';
-                // We need to know if packaged or not, but usually this service runs in Main which knows.
-                // However, securityService usually has the path if initialized.
-                // If not initialized (Setup Screen), we assume default userdata path.
-                targetPath = path.join(this.userDataPath, dbName);
-            }
-
-            console.log(`[Backup] Target DB Path: ${targetPath}`);
-
-            // 3. Copy Backup to Target
-            fs.copyFileSync(backupFilePath, targetPath);
-
-            console.log('[Backup] Restore successful.');
-            return true;
-        } catch (e) {
-            console.error('[Backup] Restore failed:', e);
-            throw e;
+            this.removeSidecars(targetDatabase);
+            this.replaceAtomic(stagedDatabase, targetDatabase); this.step('restore-after-database-replace');
+            this.replaceAtomic(stagedConfig, liveConfig); this.step('restore-after-config-replace');
+            journal.phase = 'live-files-replaced'; this.saveJournal(journal);
+            await this.securityService.initializeDevice(targetDatabase, this.userDataPath);
+            this.dbService.setDb(this.securityService.getDb());
+            this.options.onRestoreCommitted();
+            journal.phase = 'activated'; this.saveJournal(journal);
+            try { this.step('restore-after-activation'); this.cleanup(journal); }
+            catch (error) { console.error('[Backup] Restore committed; cleanup deferred to restart reconciliation.', error); }
+            return { success: true, restartRequired: true, preRestoreSnapshot: journal.preRestoreSnapshot };
+        } catch (error) {
+            validator?.closeDb();
+            const persisted = this.loadJournal();
+            if (persisted && ['live-files-replacing', 'live-files-replaced'].includes(persisted.phase)) await this.rollback(persisted);
+            else if (persisted) this.cleanup(persisted);
+            else this.cleanupStage(stageDirectory);
+            throw error;
         }
     }
+
+    reconcileInterruptedRestore(): void {
+        const journal = this.loadJournal();
+        if (!journal) return;
+        this.assertJournalPaths(journal);
+        if (['live-files-replacing', 'live-files-replaced'].includes(journal.phase)) {
+            this.restorePair(journal); journal.phase = 'rollback-restored'; this.saveJournal(journal);
+        }
+        this.cleanup(journal);
+    }
+    private async rollback(journal: RestoreJournal) {
+        this.assertJournalPaths(journal);
+        this.securityService.closeDb(); this.restorePair(journal);
+        journal.phase = 'rollback-restored'; this.saveJournal(journal);
+        if (journal.hadDatabase && journal.hadConfig) {
+            await this.securityService.initializeDevice(journal.targetDatabase, this.userDataPath);
+            this.dbService.setDb(this.securityService.getDb());
+        }
+        this.cleanup(journal);
+    }
+    private restorePair(journal: RestoreJournal) {
+        this.assertJournalPaths(journal);
+        this.removeSidecars(journal.targetDatabase);
+        if (journal.hadDatabase) {
+            if (!fs.existsSync(journal.databaseRollback)) throw new Error('RESTORE_ROLLBACK_MISSING');
+            this.replaceAtomic(journal.databaseRollback, journal.targetDatabase);
+        } else this.remove(journal.targetDatabase);
+        if (journal.hadConfig) {
+            if (!fs.existsSync(journal.configRollback)) throw new Error('RESTORE_ROLLBACK_MISSING');
+            this.replaceAtomic(journal.configRollback, journal.liveConfig);
+        } else this.remove(journal.liveConfig);
+    }
+
+    private extractAndValidate(bundlePath: string, destination: string): Manifest {
+        const { manifest, databaseOffset } = this.readManifest(bundlePath);
+        const body: ManifestBody = { format: manifest.format, version: manifest.version, createdAt: manifest.createdAt,
+            appVersion: manifest.appVersion, database: manifest.database, vault: manifest.vault };
+        if (this.hashText(this.stable(body)) !== manifest.integrity.manifestSha256) throw new Error('BACKUP_MANIFEST_CHECKSUM_MISMATCH');
+        const total = fs.statSync(bundlePath).size;
+        if (total - databaseOffset !== manifest.database.size) throw new Error('BACKUP_DATABASE_SIZE_MISMATCH');
+        const source = fs.openSync(bundlePath, 'r'); const target = fs.openSync(destination, 'w', 0o600);
+        const hash = crypto.createHash('sha256'); const buffer = Buffer.allocUnsafe(1024 * 1024); let position = databaseOffset;
+        try {
+            while (position < total) {
+                const bytes = fs.readSync(source, buffer, 0, Math.min(buffer.length, total - position), position);
+                if (!bytes) throw new Error('BACKUP_TRUNCATED');
+                fs.writeSync(target, buffer, 0, bytes); hash.update(buffer.subarray(0, bytes)); position += bytes;
+            }
+            fs.fsyncSync(target);
+        } finally { fs.closeSync(source); fs.closeSync(target); }
+        if (hash.digest('hex') !== manifest.database.sha256) { this.remove(destination); throw new Error('BACKUP_DATABASE_CHECKSUM_MISMATCH'); }
+        return manifest;
+    }
+    private readManifest(bundlePath: string): { manifest: Manifest; databaseOffset: number } {
+        const fd = fs.openSync(bundlePath, 'r');
+        try {
+            const prefix = Buffer.alloc(MAGIC.length + 4);
+            if (fs.readSync(fd, prefix, 0, prefix.length, 0) !== prefix.length || !prefix.subarray(0, MAGIC.length).equals(MAGIC)) throw new Error('INVALID_BACKUP_MAGIC');
+            const length = prefix.readUInt32BE(MAGIC.length);
+            if (length < 2 || length > MAX_MANIFEST) throw new Error('INVALID_BACKUP_MANIFEST_LENGTH');
+            const bytes = Buffer.alloc(length);
+            if (fs.readSync(fd, bytes, 0, length, prefix.length) !== length) throw new Error('BACKUP_TRUNCATED');
+            const manifest = JSON.parse(bytes.toString('utf8')) as Manifest; this.validateManifest(manifest);
+            return { manifest, databaseOffset: prefix.length + length };
+        } catch (error) { if (error instanceof SyntaxError) throw new Error('INVALID_BACKUP_MANIFEST'); throw error; }
+        finally { fs.closeSync(fd); }
+    }
+    private validateManifest(value: Manifest) {
+        const hash = (input: unknown) => typeof input === 'string' && /^[0-9a-f]{64}$/i.test(input);
+        if (value?.format !== FORMAT || value?.version !== 1 || typeof value.createdAt !== 'string' || typeof value.appVersion !== 'string' ||
+            value.database?.fileName !== 'vault.db' || !Number.isSafeInteger(value.database?.size) || value.database.size < 1 ||
+            !hash(value.database.sha256) || !Number.isInteger(value.database.schemaVersion) || value.database.schemaVersion < 0 ||
+            value.vault?.version !== 3 || !value.vault.vaultId || !Number.isInteger(value.vault.keyVersion) || value.vault.keyVersion < 1 ||
+            !value.vault.recovery || value.integrity?.algorithm !== 'sha256' || !hash(value.integrity.manifestSha256)) throw new Error('INVALID_BACKUP_MANIFEST');
+        this.sanitizePortableMetadata(value.vault);
+        this.assertExactKeys(value, ['format', 'version', 'createdAt', 'appVersion', 'database', 'vault', 'integrity']);
+        this.assertExactKeys(value.database, ['fileName', 'size', 'sha256', 'schemaVersion']);
+        this.assertExactKeys(value.integrity, ['algorithm', 'manifestSha256']);
+        this.assertEnvelopeKeys(value.vault.recovery, false);
+        if (value.vault.transitionRecovery) this.assertEnvelopeKeys(value.vault.transitionRecovery, true);
+    }
+    private writeBundle(target: string, manifest: Manifest, database: string) {
+        const bytes = Buffer.from(JSON.stringify(manifest), 'utf8');
+        if (bytes.length > MAX_MANIFEST) throw new Error('BACKUP_MANIFEST_TOO_LARGE');
+        const output = fs.openSync(target, 'w', 0o600); const input = fs.openSync(database, 'r');
+        try {
+            fs.writeSync(output, MAGIC); const length = Buffer.alloc(4); length.writeUInt32BE(bytes.length);
+            fs.writeSync(output, length); fs.writeSync(output, bytes);
+            const buffer = Buffer.allocUnsafe(1024 * 1024); let read: number;
+            while ((read = fs.readSync(input, buffer, 0, buffer.length, null)) > 0) fs.writeSync(output, buffer, 0, read);
+            fs.fsyncSync(output);
+        } finally { fs.closeSync(input); fs.closeSync(output); }
+    }
+    private hasMagic(filePath: string): boolean {
+        try { const fd = fs.openSync(filePath, 'r'); try { const bytes = Buffer.alloc(MAGIC.length); return fs.readSync(fd, bytes, 0, bytes.length, 0) === bytes.length && bytes.equals(MAGIC); } finally { fs.closeSync(fd); } }
+        catch { return false; }
+    }
+    private hashFile(filePath: string): string {
+        const hash = crypto.createHash('sha256'); const fd = fs.openSync(filePath, 'r'); const buffer = Buffer.allocUnsafe(1024 * 1024);
+        try { let bytes: number; while ((bytes = fs.readSync(fd, buffer, 0, buffer.length, null)) > 0) hash.update(buffer.subarray(0, bytes)); }
+        finally { fs.closeSync(fd); } return hash.digest('hex');
+    }
+    private hashText(value: string) { return crypto.createHash('sha256').update(value).digest('hex'); }
+    private stable(value: any): string {
+        if (Array.isArray(value)) return `[${value.map(item => this.stable(item)).join(',')}]`;
+        if (value && typeof value === 'object') return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${this.stable(value[key])}`).join(',')}}`;
+        return JSON.stringify(value);
+    }
+    private replaceAtomic(source: string, destination: string) {
+        fs.mkdirSync(path.dirname(destination), { recursive: true }); const temporary = `${destination}.restore.tmp`;
+        this.remove(temporary); this.copyDurable(source, temporary); fs.renameSync(temporary, destination); this.fsyncDirectory(path.dirname(destination));
+    }
+    private copyDurable(source: string, destination: string) {
+        fs.copyFileSync(source, destination);
+        const fd = fs.openSync(destination, 'r+');
+        try { (this.options.fsync || fs.fsyncSync)(fd); } finally { fs.closeSync(fd); }
+    }
+    private removeSidecars(database: string) { for (const suffix of ['-wal', '-shm']) this.remove(`${database}${suffix}`); }
+    private journalPath() { return path.join(this.userDataPath, RESTORE_JOURNAL); }
+    private saveJournal(journal: RestoreJournal) {
+        const target = this.journalPath(); const temporary = `${target}.tmp`; fs.mkdirSync(this.userDataPath, { recursive: true });
+        const fd = fs.openSync(temporary, 'w', 0o600); try { fs.writeFileSync(fd, JSON.stringify(journal, null, 2), 'utf8'); fs.fsyncSync(fd); } finally { fs.closeSync(fd); }
+        fs.renameSync(temporary, target); this.fsyncDirectory(this.userDataPath);
+    }
+    private loadJournal(): RestoreJournal | null {
+        const target = this.journalPath(); if (!fs.existsSync(target)) return null;
+        const value = JSON.parse(fs.readFileSync(target, 'utf8')) as RestoreJournal;
+        if (value.version !== 1 || !value.stageDirectory || !value.targetDatabase || !value.liveConfig) throw new Error('RESTORE_JOURNAL_CORRUPT');
+        this.assertJournalPaths(value);
+        return value;
+    }
+
+    private assertJournalPaths(journal: RestoreJournal) {
+        const expectedDatabase = path.resolve(path.join(this.userDataPath,
+            process.env['NODE_ENV'] === 'test' ? 'nalamdesk-test.db' : 'nalamdesk.db'));
+        const expectedConfig = path.resolve(path.join(this.userDataPath, SECURITY_CONFIG));
+        const stage = path.resolve(journal.stageDirectory);
+        if (path.resolve(journal.targetDatabase) !== expectedDatabase || path.resolve(journal.liveConfig) !== expectedConfig ||
+            path.dirname(stage) !== path.resolve(this.userDataPath) || !path.basename(stage).startsWith('.backup-restore-stage-') ||
+            path.resolve(journal.databaseRollback) !== path.join(stage, 'live-database.rollback') ||
+            path.resolve(journal.configRollback) !== path.join(stage, 'live-security.rollback')) throw new Error('RESTORE_JOURNAL_PATH_MISMATCH');
+    }
+
+    private readPortableMetadata(configPath: string): PortableMetadata {
+        const value = JSON.parse(fs.readFileSync(configPath, 'utf8')) as SecurityConfigV3;
+        const metadata: PortableMetadata = {
+            version: value.version, vaultId: value.vaultId, keyVersion: value.keyVersion,
+            recovery: value.recovery,
+            ...(value.transitionRecovery ? { transitionRecovery: value.transitionRecovery } : {})
+        };
+        // Apply the same strict no-extra-fields checks used for imported bundles.
+        this.validatePortableMetadata(metadata);
+        return metadata;
+    }
+
+    private validatePortableMetadata(metadata: PortableMetadata) {
+        const probe = {
+            format: FORMAT, version: 1, createdAt: new Date().toISOString(), appVersion: '',
+            database: { fileName: 'vault.db', size: 1, sha256: '0'.repeat(64), schemaVersion: 0 },
+            vault: metadata, integrity: { algorithm: 'sha256', manifestSha256: '0'.repeat(64) }
+        } as Manifest;
+        this.validateManifest(probe);
+    }
+
+    private sanitizePortableMetadata(value: PortableMetadata): PortableMetadata {
+        const allowed = ['version', 'vaultId', 'keyVersion', 'recovery', 'transitionRecovery'];
+        this.assertExactKeys(value, allowed);
+        if (value.version !== 3 || typeof value.vaultId !== 'string' || !value.vaultId ||
+            !Number.isInteger(value.keyVersion) || value.keyVersion < 1) throw new Error('INVALID_PORTABLE_VAULT_METADATA');
+        const recovery = this.sanitizeEnvelope(value.recovery, false);
+        const transitionRecovery = value.transitionRecovery
+            ? this.sanitizeEnvelope(value.transitionRecovery, true) as SecurityConfigV3['transitionRecovery']
+            : undefined;
+        return {
+            version: 3, vaultId: value.vaultId, keyVersion: value.keyVersion, recovery,
+            ...(transitionRecovery ? { transitionRecovery } : {})
+        };
+    }
+
+    private sanitizeEnvelope(envelope: any, transition: boolean): SecurityConfigV3['recovery'] {
+        this.assertEnvelopeKeys(envelope, transition);
+        const params = envelope.kdfParams;
+        const hex = (input: unknown, bytes: number) => typeof input === 'string' &&
+            input.length === bytes * 2 && /^[0-9a-f]+$/i.test(input);
+        if (envelope.algorithm !== 'aes-256-gcm' || envelope.kdf !== 'argon2id' || envelope.aadVersion !== 1 ||
+            !hex(envelope.salt, 16) || !hex(envelope.iv, 12) || !hex(envelope.wrappedKey, 48) ||
+            !Number.isInteger(params.timeCost) || params.timeCost < 1 || params.timeCost > 10 ||
+            !Number.isInteger(params.memoryCost) || params.memoryCost < 8192 || params.memoryCost > 1048576 ||
+            !Number.isInteger(params.parallelism) || params.parallelism < 1 || params.parallelism > 16 ||
+            params.hashLength !== 32 || (transition && envelope.purpose !== 'legacy-transition')) {
+            throw new Error('INVALID_PORTABLE_RECOVERY_ENVELOPE');
+        }
+        return {
+            algorithm: 'aes-256-gcm', kdf: 'argon2id', aadVersion: 1,
+            salt: envelope.salt, iv: envelope.iv, wrappedKey: envelope.wrappedKey,
+            kdfParams: {
+                timeCost: params.timeCost, memoryCost: params.memoryCost,
+                parallelism: params.parallelism, hashLength: 32
+            },
+            ...(transition ? { purpose: 'legacy-transition' } : {})
+        } as SecurityConfigV3['recovery'];
+    }
+
+    private resultStrings(value: unknown): string[] | null {
+        if (!Array.isArray(value)) return null;
+        const strings: string[] = [];
+        for (const row of value) {
+            if (typeof row === 'string') strings.push(row);
+            else if (row && typeof row === 'object') {
+                const values = Object.values(row as Record<string, unknown>);
+                if (values.length !== 1 || typeof values[0] !== 'string') return null;
+                strings.push(values[0]);
+            } else return null;
+        }
+        return strings;
+    }
+    private assertCipherIntegrity(value: unknown) {
+        const results = this.resultStrings(value);
+        // SQLCipher documents zero rows on success; some driver builds expose "ok".
+        if (!results || (results.length !== 0 && !(results.length === 1 && results[0] === 'ok'))) {
+            throw new Error('BACKUP_CIPHER_INTEGRITY_FAILED');
+        }
+    }
+    private assertSqliteIntegrity(value: unknown) {
+        const results = this.resultStrings(value);
+        if (!results || results.length !== 1 || results[0] !== 'ok') throw new Error('BACKUP_DATABASE_INTEGRITY_FAILED');
+    }
+    private runKeyedIntegrityChecks(database: any) {
+        try { this.assertCipherIntegrity(database?.pragma('cipher_integrity_check')); }
+        catch { throw new Error('BACKUP_CIPHER_INTEGRITY_FAILED'); }
+        try { this.assertSqliteIntegrity(database?.pragma('integrity_check')); }
+        catch { throw new Error('BACKUP_DATABASE_INTEGRITY_FAILED'); }
+    }
+
+    private assertEnvelopeKeys(envelope: any, transition: boolean) {
+        this.assertExactKeys(envelope, transition
+            ? ['algorithm', 'kdf', 'kdfParams', 'salt', 'iv', 'wrappedKey', 'aadVersion', 'purpose']
+            : ['algorithm', 'kdf', 'kdfParams', 'salt', 'iv', 'wrappedKey', 'aadVersion']);
+        this.assertExactKeys(envelope.kdfParams, ['timeCost', 'memoryCost', 'parallelism', 'hashLength']);
+    }
+    private assertExactKeys(value: any, allowed: string[]) {
+        if (!value || typeof value !== 'object' || Object.keys(value).some(key => !allowed.includes(key))) {
+            throw new Error('BACKUP_CONTAINS_FORBIDDEN_METADATA');
+        }
+    }
+    private cleanup(journal: RestoreJournal) { this.cleanupStage(journal.stageDirectory); this.remove(this.journalPath()); this.remove(`${this.journalPath()}.tmp`); this.fsyncDirectory(this.userDataPath); }
+    private cleanupStage(directory: string) {
+        const resolved = path.resolve(directory);
+        if (path.dirname(resolved) !== path.resolve(this.userDataPath) || !path.basename(resolved).startsWith('.backup-restore-stage-')) throw new Error('UNSAFE_RESTORE_STAGE_PATH');
+        if (fs.existsSync(resolved)) fs.rmSync(resolved, { recursive: true, force: true });
+    }
+    private remove(target: string) { if (fs.existsSync(target)) fs.unlinkSync(target); }
+    private fsyncDirectory(directory: string) {
+        try {
+            const fd = fs.openSync(directory, 'r');
+            try { (this.options.fsync || fs.fsyncSync)(fd); } finally { fs.closeSync(fd); }
+        } catch (error: any) {
+            // Windows does not support fsync on directory handles. Only those
+            // documented capability errors are ignorable; real I/O errors fail.
+            const unsupported = ['EPERM', 'EINVAL', 'EBADF', 'ENOTSUP'].includes(error?.code);
+            if ((this.options.platform || process.platform) === 'win32' && unsupported) return;
+            throw error;
+        }
+    }
+    private step(step: BackupStep) { this.options.onStep?.(step); }
 }

--- a/desktop/src/main/services/DatabaseService.ts
+++ b/desktop/src/main/services/DatabaseService.ts
@@ -34,15 +34,17 @@ export class DatabaseService {
         }
     }
 
-    async migrate() {
+    async migrate(options: { skipBackup?: boolean } = {}) {
         if (!this.db) throw new Error('DB not initialized');
 
         // Safety: Backup before migrating
-        try {
-            await this.createBackup(this.db.name);
-        } catch (e) {
-            console.error('[DB] Backup failed! Proceeding with caution...', e);
-            // Optional: Throw if backup is critical? For now, log and proceed (or user can't login).
+        if (!options.skipBackup) {
+            try {
+                await this.createBackup(this.db.name);
+            } catch (e) {
+                console.error('[DB] Backup failed! Proceeding with caution...', e);
+                // Optional: Throw if backup is critical? For now, log and proceed (or user can't login).
+            }
         }
 
         // Check Version
@@ -698,4 +700,3 @@ export class DatabaseService {
         }
     }
 }
-

--- a/desktop/src/main/services/DeviceKeyStore.spec.ts
+++ b/desktop/src/main/services/DeviceKeyStore.spec.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const safeStorage = {
+    isEncryptionAvailable: vi.fn(),
+    getSelectedStorageBackend: vi.fn(),
+    encryptString: vi.fn(),
+    decryptString: vi.fn()
+};
+
+vi.mock('electron', () => ({ safeStorage }));
+
+describe('ElectronSafeStorageDeviceKeyStore', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.clearAllMocks();
+        safeStorage.isEncryptionAvailable.mockReturnValue(true);
+        safeStorage.getSelectedStorageBackend.mockReturnValue('keychain');
+    });
+
+    it('round-trips a 32-byte key without exposing plaintext to the config', async () => {
+        const key = Buffer.alloc(32, 7);
+        safeStorage.encryptString.mockReturnValue(Buffer.from('ciphertext'));
+        safeStorage.decryptString.mockReturnValue(key.toString('base64'));
+        const { ElectronSafeStorageDeviceKeyStore } = await import('./DeviceKeyStore');
+        const store = new ElectronSafeStorageDeviceKeyStore();
+        expect(store.protect(key)).toEqual(Buffer.from('ciphertext'));
+        expect(safeStorage.encryptString).toHaveBeenCalledWith(key.toString('base64'));
+        expect(store.unprotect(Buffer.from('ciphertext'))).toEqual(key);
+    });
+
+    it('fails when Electron reports encryption unavailable', async () => {
+        safeStorage.isEncryptionAvailable.mockReturnValue(false);
+        const { ElectronSafeStorageDeviceKeyStore } = await import('./DeviceKeyStore');
+        const store = new ElectronSafeStorageDeviceKeyStore();
+        expect(store.status()).toMatchObject({ available: false, reason: 'ENCRYPTION_UNAVAILABLE' });
+        expect(() => store.protect(Buffer.alloc(32))).toThrow('ENCRYPTION_UNAVAILABLE');
+    });
+
+    it('rejects Linux basic_text instead of silently weakening protection', async () => {
+        const originalPlatform = process.platform;
+        Object.defineProperty(process, 'platform', { value: 'linux' });
+        safeStorage.getSelectedStorageBackend.mockReturnValue('basic_text');
+        try {
+            const { ElectronSafeStorageDeviceKeyStore } = await import('./DeviceKeyStore');
+            expect(new ElectronSafeStorageDeviceKeyStore().status()).toMatchObject({
+                available: false,
+                reason: 'INSECURE_LINUX_BACKEND'
+            });
+        } finally {
+            Object.defineProperty(process, 'platform', { value: originalPlatform });
+        }
+    });
+});

--- a/desktop/src/main/services/DeviceKeyStore.ts
+++ b/desktop/src/main/services/DeviceKeyStore.ts
@@ -1,0 +1,41 @@
+import { safeStorage } from 'electron';
+
+export interface DeviceKeyStoreStatus {
+    available: boolean;
+    provider: string;
+    reason?: 'ENCRYPTION_UNAVAILABLE' | 'INSECURE_LINUX_BACKEND';
+}
+
+/** Device-bound wrapping boundary; injectable for tests and future platforms. */
+export interface DeviceKeyStore {
+    status(): DeviceKeyStoreStatus;
+    protect(value: Buffer): Buffer;
+    unprotect(value: Buffer): Buffer;
+}
+
+export class ElectronSafeStorageDeviceKeyStore implements DeviceKeyStore {
+    status(): DeviceKeyStoreStatus {
+        if (!safeStorage.isEncryptionAvailable()) {
+            return { available: false, provider: 'electron-safe-storage', reason: 'ENCRYPTION_UNAVAILABLE' };
+        }
+        if (process.platform === 'linux' && safeStorage.getSelectedStorageBackend() === 'basic_text') {
+            return { available: false, provider: 'electron-safe-storage', reason: 'INSECURE_LINUX_BACKEND' };
+        }
+        return { available: true, provider: 'electron-safe-storage' };
+    }
+
+    protect(value: Buffer): Buffer {
+        this.assertAvailable();
+        return safeStorage.encryptString(value.toString('base64'));
+    }
+
+    unprotect(value: Buffer): Buffer {
+        this.assertAvailable();
+        return Buffer.from(safeStorage.decryptString(value), 'base64');
+    }
+
+    private assertAvailable(): void {
+        const current = this.status();
+        if (!current.available) throw new Error(current.reason || 'DEVICE_KEY_UNAVAILABLE');
+    }
+}

--- a/desktop/src/main/services/ProvisioningService.spec.ts
+++ b/desktop/src/main/services/ProvisioningService.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ProvisioningService } from './ProvisioningService';
+
+describe('ProvisioningService', () => {
+    it.each(['migration', 'settings', 'admin'] as const)(
+        'aborts the durable fresh provisioning transaction when %s fails',
+        async failure => {
+            const security = {
+                setup: vi.fn().mockResolvedValue('RECOVERY'),
+                getDb: vi.fn().mockReturnValue({}),
+                completeProvisioning: vi.fn(),
+                abortProvisioning: vi.fn()
+            };
+            const database = {
+                setDb: vi.fn(),
+                migrate: failure === 'migration'
+                    ? vi.fn().mockRejectedValue(new Error('migration failed'))
+                    : vi.fn().mockResolvedValue(undefined),
+                saveSettings: failure === 'settings'
+                    ? vi.fn(() => { throw new Error('settings failed'); })
+                    : vi.fn(),
+                ensureAdminUser: failure === 'admin'
+                    ? vi.fn().mockRejectedValue(new Error('admin failed'))
+                    : vi.fn().mockResolvedValue(undefined)
+            };
+
+            await expect(new ProvisioningService(security, database).provision(
+                'admin-password', {}, '/db', '/data'
+            )).rejects.toThrow(`${failure} failed`);
+            expect(security.abortProvisioning).toHaveBeenCalledOnce();
+            expect(security.completeProvisioning).not.toHaveBeenCalled();
+        }
+    );
+
+    it('commits only after schema, settings, and administrator creation succeed', async () => {
+        const calls: string[] = [];
+        const security = {
+            setup: vi.fn(async () => { calls.push('setup'); return 'RECOVERY'; }),
+            getDb: vi.fn(() => ({})),
+            completeProvisioning: vi.fn(() => calls.push('complete')),
+            abortProvisioning: vi.fn()
+        };
+        const database = {
+            setDb: vi.fn(() => calls.push('set-db')),
+            migrate: vi.fn(async () => { calls.push('migrate'); }),
+            saveSettings: vi.fn(() => calls.push('settings')),
+            ensureAdminUser: vi.fn(async () => { calls.push('admin'); })
+        };
+        await expect(new ProvisioningService(security, database).provision(
+            'admin-password', {}, '/db', '/data'
+        )).resolves.toBe('RECOVERY');
+        expect(calls).toEqual(['setup', 'set-db', 'migrate', 'settings', 'admin', 'complete']);
+        expect(database.migrate).toHaveBeenCalledWith({ skipBackup: true });
+        expect(security.abortProvisioning).not.toHaveBeenCalled();
+    });
+});

--- a/desktop/src/main/services/ProvisioningService.ts
+++ b/desktop/src/main/services/ProvisioningService.ts
@@ -1,0 +1,42 @@
+export interface VaultProvisioner {
+    setup(adminPassword: string, dbPath: string, userDataPath: string): Promise<string>;
+    getDb(): any;
+    completeProvisioning(): void;
+    abortProvisioning(): void;
+}
+
+export interface ProvisioningDatabase {
+    setDb(db: any): void;
+    migrate(options?: { skipBackup?: boolean }): Promise<void>;
+    saveSettings(settings: any): unknown;
+    ensureAdminUser(password: string): Promise<void>;
+}
+
+/** Coordinates the full fresh-install transaction across vault and application data. */
+export class ProvisioningService {
+    constructor(
+        private readonly security: VaultProvisioner,
+        private readonly database: ProvisioningDatabase
+    ) { }
+
+    async provision(
+        adminPassword: string,
+        clinicDetails: any,
+        dbPath: string,
+        userDataPath: string
+    ): Promise<string> {
+        try {
+            const recoveryCode = await this.security.setup(adminPassword, dbPath, userDataPath);
+            this.database.setDb(this.security.getDb());
+            await this.database.migrate({ skipBackup: true });
+            this.database.saveSettings(clinicDetails);
+            await this.database.ensureAdminUser(adminPassword);
+            this.security.completeProvisioning();
+            return recoveryCode;
+        } catch (error) {
+            this.security.abortProvisioning();
+            this.database.setDb(null);
+            throw error;
+        }
+    }
+}

--- a/desktop/src/main/services/RestoreAuthorization.spec.ts
+++ b/desktop/src/main/services/RestoreAuthorization.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import { requireExistingRestoreAuthorization } from './RestoreAuthorization';
+
+const active = { id: 1, username: 'admin', role: 'admin', active: 1, password: 'persisted-hash' };
+const session = { id: 1, username: 'admin', role: 'admin' };
+
+describe('restore authorization', () => {
+    it('allows a truly clean machine to recover with the bundle recovery code alone', async () => {
+        await expect(requireExistingRestoreAuthorization({
+            hasDatabase: false, hasConfig: false, databaseOpen: false,
+            sessionUser: null, persistedAdmin: null
+        })).resolves.toBeUndefined();
+    });
+
+    it('fails closed for an incomplete or locked existing vault', async () => {
+        await expect(requireExistingRestoreAuthorization({
+            hasDatabase: true, hasConfig: false, databaseOpen: false,
+            sessionUser: null, persistedAdmin: null
+        })).rejects.toThrow('LIVE_VAULT_INCOMPLETE');
+        await expect(requireExistingRestoreAuthorization({
+            hasDatabase: true, hasConfig: true, databaseOpen: false,
+            sessionUser: session, persistedAdmin: active, currentAdminPassword: 'fresh'
+        })).rejects.toThrow('LIVE_VAULT_RECOVERY_REQUIRED');
+    });
+
+    it.each([
+        ['cached admin whose persisted account is inactive', session, { ...active, active: 0 }],
+        ['stale session for a replaced admin row', session, { ...active, id: 2 }],
+        ['non-admin session', { ...session, role: 'doctor' }, active]
+    ])('rejects a %s', async (_label, sessionUser, persistedAdmin) => {
+        await expect(requireExistingRestoreAuthorization({
+            hasDatabase: true, hasConfig: true, databaseOpen: true,
+            sessionUser, persistedAdmin, currentAdminPassword: 'fresh'
+        }, vi.fn(async () => true))).rejects.toThrow('RESTORE_ADMIN_AUTHORIZATION_REQUIRED');
+    });
+
+    it('requires a fresh password verification against the persisted active admin', async () => {
+        const verify = vi.fn(async (_hash: string, password: string) => password === 'fresh');
+        await expect(requireExistingRestoreAuthorization({
+            hasDatabase: true, hasConfig: true, databaseOpen: true,
+            sessionUser: session, persistedAdmin: active, currentAdminPassword: 'stale'
+        }, verify)).rejects.toThrow('INVALID_ADMIN_CREDENTIAL');
+        await expect(requireExistingRestoreAuthorization({
+            hasDatabase: true, hasConfig: true, databaseOpen: true,
+            sessionUser: session, persistedAdmin: active, currentAdminPassword: 'fresh'
+        }, verify)).resolves.toBeUndefined();
+        expect(verify).toHaveBeenLastCalledWith('persisted-hash', 'fresh');
+    });
+});

--- a/desktop/src/main/services/RestoreAuthorization.ts
+++ b/desktop/src/main/services/RestoreAuthorization.ts
@@ -1,0 +1,30 @@
+import * as argon2 from 'argon2';
+
+export interface ExistingRestoreAuthorizationInput {
+    hasDatabase: boolean;
+    hasConfig: boolean;
+    databaseOpen: boolean;
+    sessionUser: { id?: number; username?: string; role?: string } | null;
+    persistedAdmin: { id: number; username: string; role: string; active: number; password: string } | null;
+    currentAdminPassword?: string;
+}
+
+/** Clean targets need only bundle recovery. Replacing a live pair additionally
+ * requires a freshly verified active persisted admin, never a cached role. */
+export async function requireExistingRestoreAuthorization(
+    input: ExistingRestoreAuthorizationInput,
+    verify: (hash: string, password: string) => Promise<boolean> = argon2.verify
+): Promise<void> {
+    if (!input.hasDatabase && !input.hasConfig) return;
+    if (!input.hasDatabase || !input.hasConfig) throw new Error('LIVE_VAULT_INCOMPLETE');
+    if (!input.databaseOpen) throw new Error('LIVE_VAULT_RECOVERY_REQUIRED');
+    const session = input.sessionUser;
+    const admin = input.persistedAdmin;
+    if (!session || session.role !== 'admin' || session.username !== 'admin' || !admin ||
+        admin.active !== 1 || admin.role !== 'admin' || admin.username !== 'admin' || session.id !== admin.id) {
+        throw new Error('RESTORE_ADMIN_AUTHORIZATION_REQUIRED');
+    }
+    if (!input.currentAdminPassword || !await verify(admin.password, input.currentAdminPassword)) {
+        throw new Error('INVALID_ADMIN_CREDENTIAL');
+    }
+}

--- a/desktop/src/main/services/SecurityService.integration.spec.ts
+++ b/desktop/src/main/services/SecurityService.integration.spec.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import * as argon2 from 'argon2';
+// @ts-ignore native SQLCipher module
+import Database from 'better-sqlite3-multiple-ciphers';
+import type { DeviceKeyStore } from './DeviceKeyStore';
+import { SecurityService } from './SecurityService';
+import { DatabaseService } from './DatabaseService';
+import { ProvisioningService } from './ProvisioningService';
+
+class IntegrationDeviceStore implements DeviceKeyStore {
+    constructor(private readonly mask: number) { }
+    status() { return { available: true, provider: 'integration-device-store' }; }
+    protect(value: Buffer) { return Buffer.from(value.map(byte => byte ^ this.mask)); }
+    unprotect(value: Buffer) { return this.protect(value); }
+}
+
+// The native SQLCipher module is rebuilt for Electron by postinstall, so these
+// run under Electron's Node mode rather than the host Node ABI.
+describe.skipIf(!process.versions.electron)('SecurityService SQLCipher integration', () => {
+    let directory: string;
+    let dbPath: string;
+
+    beforeEach(() => {
+        directory = fs.mkdtempSync(path.join(os.tmpdir(), 'nalamdesk-vault-integration-'));
+        dbPath = path.join(directory, 'nalamdesk.db');
+    });
+    afterEach(() => fs.rmSync(directory, { recursive: true, force: true }));
+
+    const createEncryptedDb = (key: Buffer, value = 'legacy-preserved') => {
+        const db = new Database(dbPath);
+        db.pragma(`key = "x'${key.toString('hex')}'"`);
+        db.exec(`CREATE TABLE clinical_data (value TEXT); INSERT INTO clinical_data VALUES ('${value}')`);
+        db.close();
+    };
+    const wrapLegacyV2 = (dek: Buffer, kek: Buffer) => {
+        const iv = crypto.randomBytes(16);
+        const cipher = crypto.createCipheriv('aes-256-gcm', kek, iv);
+        const ciphertext = Buffer.concat([cipher.update(dek), cipher.final()]);
+        return {
+            iv: iv.toString('hex'),
+            wrappedKey: Buffer.concat([cipher.getAuthTag(), ciphertext]).toString('hex')
+        };
+    };
+
+    it('cold-starts the same encrypted database using only the device envelope', async () => {
+        const store = new IntegrationDeviceStore(0x42);
+        const first = new SecurityService(store);
+        await first.setup('admin-login-only', dbPath, directory);
+        first.getDb().exec('CREATE TABLE clinical_data (value TEXT); INSERT INTO clinical_data VALUES (\'preserved\')');
+        first.completeProvisioning();
+        first.closeDb();
+
+        const coldStart = new SecurityService(store);
+        await coldStart.initializeDevice(dbPath, directory);
+        expect(coldStart.getDb().prepare('SELECT value FROM clinical_data').get()).toEqual({ value: 'preserved' });
+        coldStart.closeDb();
+    });
+
+    it.each(['migration', 'settings', 'admin'] as const)(
+        'rolls back real fresh provisioning after a %s failure and succeeds on retry',
+        async failure => {
+            const store = new IntegrationDeviceStore(0x44);
+            const security = new SecurityService(store);
+            const database = new DatabaseService();
+            if (failure === 'migration') {
+                vi.spyOn(database, 'migrate').mockRejectedValueOnce(new Error('forced migration failure'));
+            } else if (failure === 'settings') {
+                vi.spyOn(database, 'saveSettings').mockImplementationOnce(() => {
+                    throw new Error('forced settings failure');
+                });
+            } else {
+                vi.spyOn(database, 'ensureAdminUser').mockRejectedValueOnce(new Error('forced admin failure'));
+            }
+            await expect(new ProvisioningService(security, database).provision(
+                'admin-password', { clinic_name: 'Test Clinic' }, dbPath, directory
+            )).rejects.toThrow(`forced ${failure} failure`);
+            expect(fs.existsSync(dbPath)).toBe(false);
+            expect(fs.existsSync(path.join(directory, 'security.json'))).toBe(false);
+            expect(fs.existsSync(path.join(directory, 'security-setup.json'))).toBe(false);
+
+            const retrySecurity = new SecurityService(store);
+            const retryDatabase = new DatabaseService();
+            const code = await new ProvisioningService(retrySecurity, retryDatabase).provision(
+                'admin-password', { clinic_name: 'Test Clinic' }, dbPath, directory
+            );
+            expect(retrySecurity.getPendingRecoveryCode()).toBe(code);
+            expect(await retryDatabase.validateUser('admin', 'admin-password')).toMatchObject({ success: true });
+            retrySecurity.closeDb();
+            await expect(new SecurityService(store).initializeDevice(dbPath, directory))
+                .resolves.toEqual({ migrated: false });
+        }
+    );
+
+    it('re-enrols a new device through the recovery envelope', async () => {
+        const original = new SecurityService(new IntegrationDeviceStore(0x11));
+        const code = await original.setup('admin-login-only', dbPath, directory);
+        original.completeProvisioning();
+        original.closeDb();
+
+        const replacementStore = new IntegrationDeviceStore(0x77);
+        const replacement = new SecurityService(replacementStore);
+        await expect(replacement.recoverDevice(code, directory, dbPath)).resolves.toEqual({ migrated: false });
+        replacement.closeDb();
+        await expect(new SecurityService(replacementStore).initializeDevice(dbPath, directory)).resolves.toEqual({ migrated: false });
+    });
+
+    it('rejects valid key material paired with a different vault identity', async () => {
+        const store = new IntegrationDeviceStore(0x42);
+        const service = new SecurityService(store);
+        await service.setup('admin-login-only', dbPath, directory);
+        service.completeProvisioning();
+        service.closeDb();
+        const configPath = path.join(directory, 'security.json');
+        const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+        config.vaultId = '00000000-0000-4000-8000-000000000000';
+        fs.writeFileSync(configPath, JSON.stringify(config));
+
+        await expect(new SecurityService(store).initializeDevice(dbPath, directory)).rejects.toThrow('VAULT_BINDING_MISMATCH');
+    });
+
+    it('allows admin, doctor, nurse, and receptionist to be first login after separate cold starts', async () => {
+        const store = new IntegrationDeviceStore(0x24);
+        const setup = new SecurityService(store);
+        await setup.setup('admin-password', dbPath, directory);
+        setup.getDb().exec(`CREATE TABLE users (
+            id INTEGER PRIMARY KEY, username TEXT, password TEXT, role TEXT, name TEXT,
+            active INTEGER DEFAULT 1, password_reset_required INTEGER DEFAULT 0
+        )`);
+        const insert = setup.getDb().prepare('INSERT INTO users (id, username, password, role, name) VALUES (?, ?, ?, ?, ?)');
+        const roles = ['admin', 'doctor', 'nurse', 'receptionist'];
+        for (const [index, role] of roles.entries()) {
+            insert.run(index + 1, role, await argon2.hash(`${role}-password`), role, role);
+        }
+        setup.completeProvisioning();
+        setup.closeDb();
+
+        for (const role of roles) {
+            const coldStart = new SecurityService(store);
+            await coldStart.initializeDevice(dbPath, directory);
+            const database = new DatabaseService();
+            database.setDb(coldStart.getDb());
+            await expect(database.validateUser(role, `${role}-password`)).resolves.toMatchObject({
+                success: true,
+                user: { role }
+            });
+            coldStart.closeDb();
+        }
+    });
+
+    it('migrates a real v2 SQLCipher database and preserves data across restart', async () => {
+        const store = new IntegrationDeviceStore(0x31);
+        const builder = new SecurityService(store) as any;
+        const dek = crypto.randomBytes(32);
+        createEncryptedDb(dek);
+        const salt = crypto.randomBytes(16);
+        const wrapped = wrapLegacyV2(dek, await builder.deriveLegacyKey('legacy-master', salt));
+        fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+            version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
+        }));
+
+        const migrated = new SecurityService(store);
+        await expect(migrated.migrateLegacy('legacy-master', dbPath, directory)).resolves.toEqual({ migrated: true });
+        expect(migrated.getDb().prepare('SELECT value FROM clinical_data').get()).toEqual({ value: 'legacy-preserved' });
+        expect(migrated.getPendingRecoveryCode()).toBeTruthy();
+        migrated.closeDb();
+        await expect(new SecurityService(store).initializeDevice(dbPath, directory)).resolves.toEqual({ migrated: false });
+    });
+
+    it('migrates and rekeys a real v1 SQLCipher database', async () => {
+        const store = new IntegrationDeviceStore(0x17);
+        const builder = new SecurityService(store) as any;
+        const salt = crypto.randomBytes(16);
+        fs.writeFileSync(path.join(directory, 'salt.bin'), salt);
+        const legacyKey = await builder.deriveLegacyKey('legacy-master', salt);
+        createEncryptedDb(legacyKey);
+
+        const migrated = new SecurityService(store);
+        await migrated.migrateLegacy('legacy-master', dbPath, directory);
+        expect(migrated.getDb().prepare('SELECT value FROM clinical_data').get()).toEqual({ value: 'legacy-preserved' });
+        expect(fs.existsSync(path.join(directory, 'salt.bin.migrated'))).toBe(true);
+    });
+
+    it('restores the real v1 database and old key when migration fails after rekey', async () => {
+        const store = new IntegrationDeviceStore(0x61);
+        const builder = new SecurityService(store) as any;
+        const salt = crypto.randomBytes(16);
+        fs.writeFileSync(path.join(directory, 'salt.bin'), salt);
+        const legacyKey = await builder.deriveLegacyKey('legacy-master', salt);
+        createEncryptedDb(legacyKey, 'rollback-preserved');
+        const failing = new SecurityService(store, {
+            onStep: step => { if (step === 'migration-after-rekey') throw new Error('forced crash'); }
+        });
+
+        await expect(failing.migrateLegacy('legacy-master', dbPath, directory)).rejects.toThrow('forced crash');
+        const restored = new Database(dbPath);
+        restored.pragma(`key = "x'${legacyKey.toString('hex')}'"`);
+        expect(restored.prepare('SELECT value FROM clinical_data').get()).toEqual({ value: 'rollback-preserved' });
+        restored.close();
+    });
+
+    it.each([
+        { version: 1 as const, path: 'final' as const },
+        { version: 1 as const, path: 'transition' as const },
+        { version: 2 as const, path: 'final' as const },
+        { version: 2 as const, path: 'transition' as const }
+    ])('survives v$version device loss before acknowledgement through the $path recovery path', async ({ version, path: recoveryPath }) => {
+        const legacySecret = `legacy-v${version}`;
+        const oldStore = new IntegrationDeviceStore(0x21);
+        const builder = new SecurityService(oldStore) as any;
+        if (version === 1) {
+            const salt = crypto.randomBytes(16);
+            fs.writeFileSync(path.join(directory, 'salt.bin'), salt);
+            createEncryptedDb(await builder.deriveLegacyKey(legacySecret, salt), 'device-loss-preserved');
+        } else {
+            const dek = crypto.randomBytes(32);
+            createEncryptedDb(dek, 'device-loss-preserved');
+            const salt = crypto.randomBytes(16);
+            const wrapped = wrapLegacyV2(dek, await builder.deriveLegacyKey(legacySecret, salt));
+            fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+                version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
+            }));
+        }
+
+        const migrated = new SecurityService(oldStore);
+        await migrated.migrateLegacy(legacySecret, dbPath, directory);
+        const pendingFinalCode = migrated.getPendingRecoveryCode()!;
+        migrated.closeDb();
+
+        const newStore = new IntegrationDeviceStore(0x72);
+        const recovered = new SecurityService(newStore);
+        await recovered.recoverDevice(
+            recoveryPath === 'final' ? pendingFinalCode : legacySecret,
+            directory,
+            dbPath
+        );
+        expect(recovered.getDb().prepare('SELECT value FROM clinical_data').get())
+            .toEqual({ value: 'device-loss-preserved' });
+        if (recoveryPath === 'final') {
+            expect(recovered.getPendingRecoveryCode()).toBeNull();
+        } else {
+            const rotatedCode = recovered.getPendingRecoveryCode();
+            expect(rotatedCode).toBeTruthy();
+            recovered.acknowledgePendingRecoveryCode(rotatedCode!);
+        }
+        recovered.closeDb();
+        await expect(new SecurityService(newStore).initializeDevice(dbPath, directory))
+            .resolves.toEqual({ migrated: false });
+        await expect(new SecurityService(oldStore).initializeDevice(dbPath, directory))
+            .rejects.toThrow('DEVICE_UNLOCK_FAILED');
+    });
+});

--- a/desktop/src/main/services/SecurityService.spec.ts
+++ b/desktop/src/main/services/SecurityService.spec.ts
@@ -1,107 +1,697 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { DeviceKeyStore } from './DeviceKeyStore';
 import { SecurityService } from './SecurityService';
 
-// Mock dependencies
 vi.mock('argon2', () => ({
-    hash: vi.fn(),
-    argon2id: 2
+    argon2id: 2,
+    hash: vi.fn(async (secret: string, options: { salt: Buffer }) =>
+        crypto.createHash('sha256').update(options.salt).update(secret).digest())
 }));
 
-// Mock better-sqlite3-multiple-ciphers (used in app)
-const mockPragma = vi.fn();
-const mockPrepare = vi.fn();
-const mockGet = vi.fn();
-const mockClose = vi.fn();
+interface DbState { vault?: { vault_id: string; key_version: number } }
+const databases = new Map<string, DbState>();
+let rejectOpen = false;
+let failInsert = false;
 
-mockPrepare.mockReturnValue({ get: mockGet });
-
-vi.mock('better-sqlite3-multiple-ciphers', () => {
-    return {
-        default: class {
-            pragma: any;
-            prepare: any;
-            close: any;
-            constructor() {
-                this.pragma = mockPragma;
-                this.prepare = mockPrepare;
-                this.close = mockClose;
-            }
+vi.mock('better-sqlite3-multiple-ciphers', () => ({
+    default: class MockDatabase {
+        private state: DbState;
+        constructor(private file: string) {
+            this.state = databases.get(file) || {};
+            databases.set(file, this.state);
         }
-    };
-});
+        pragma(statement: string) {
+            if (rejectOpen && statement.startsWith('key =')) throw new Error('file is not a database');
+        }
+        exec() { }
+        prepare(sql: string) {
+            if (sql.includes('count(*)')) return { get: () => ({ count: 1 }) };
+            if (sql.startsWith('SELECT vault_id')) return { get: () => this.state.vault };
+            if (sql.startsWith('INSERT INTO')) return {
+                run: (vaultId: string, keyVersion: number) => {
+                    if (failInsert) throw new Error('forced binding failure');
+                    this.state.vault = { vault_id: vaultId, key_version: keyVersion };
+                }
+            };
+            throw new Error(`Unexpected SQL: ${sql}`);
+        }
+        close() { }
+    }
+}));
 
+class MemoryDeviceKeyStore implements DeviceKeyStore {
+    available = true;
+    private maskByte = 0x5a;
+    status() {
+        return this.available
+            ? { available: true, provider: 'test-device-store' }
+            : { available: false, provider: 'test-device-store', reason: 'ENCRYPTION_UNAVAILABLE' as const };
+    }
+    protect(value: Buffer): Buffer { return Buffer.from(value.map(byte => byte ^ this.maskByte)); }
+    unprotect(value: Buffer): Buffer { return this.protect(value); }
+}
 
-describe('SecurityService', () => {
-    let service: SecurityService;
-    let argon2: any;
+describe('SecurityService v3', () => {
+    let directory: string;
+    let dbPath: string;
+    let store: MemoryDeviceKeyStore;
 
-    beforeEach(async () => {
-        vi.clearAllMocks();
-        argon2 = await import('argon2');
-        service = new SecurityService();
-
-        // Default mock behaviors
-        argon2.hash.mockResolvedValue(Buffer.from('mocked-hash-key'));
-        mockGet.mockReturnValue({ 'count(*)': 1 }); // Success by default
+    beforeEach(() => {
+        directory = fs.mkdtempSync(path.join(os.tmpdir(), 'nalamdesk-security-'));
+        dbPath = path.join(directory, 'nalamdesk.db');
+        fs.writeFileSync(dbPath, '');
+        databases.clear();
+        rejectOpen = false;
+        failInsert = false;
+        store = new MemoryDeviceKeyStore();
     });
 
-    describe('deriveKey', () => {
-        it('should derive a 32-byte key using argon2id', async () => {
-            const password = 'my-secret-password';
-            const salt = Buffer.alloc(16, 'a');
-            const result = await service.deriveKey(password, salt);
+    afterEach(() => fs.rmSync(directory, { recursive: true, force: true }));
 
-            expect(argon2.hash).toHaveBeenCalledWith(password, expect.objectContaining({
-                type: 2, // argon2id
-                raw: true,
-                salt: salt // Ensuring salt is passed
+    it('creates a v3 config without the admin password or plaintext DEK', async () => {
+        const service = new SecurityService(store);
+        const code = await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        const text = fs.readFileSync(path.join(directory, 'security.json'), 'utf8');
+        const config = JSON.parse(text);
+
+        expect(config.version).toBe(3);
+        expect(config.vaultId).toMatch(/^[0-9a-f-]{36}$/);
+        expect(config.keyVersion).toBe(1);
+        expect(config.device.provider).toBe('test-device-store');
+        expect(config.recovery.kdf).toBe('argon2id');
+        expect(text).not.toContain('admin-secret');
+        expect(code).toMatch(/^[A-F0-9]{8}(?:-[A-F0-9]{8}){3}$/);
+    });
+
+    it('unlocks after a cold start without receiving any user password', async () => {
+        const first = new SecurityService(store);
+        await first.setup('admin-secret', dbPath, directory);
+        first.completeProvisioning();
+        first.closeDb();
+
+        const coldStart = new SecurityService(store);
+        await expect(coldStart.initializeDevice(dbPath, directory)).resolves.toEqual({ migrated: false });
+        expect(coldStart.getDb()).toBeTruthy();
+    });
+
+    it('fails closed when device encryption is unavailable', async () => {
+        store.available = false;
+        const service = new SecurityService(store);
+        await expect(service.setup('irrelevant', dbPath, directory)).rejects.toThrow('ENCRYPTION_UNAVAILABLE');
+    });
+
+    it('rolls back a newly-created database when setup fails after binding and permits retry', async () => {
+        const failing = new SecurityService(store);
+        vi.spyOn(failing as any, 'saveConfigAtomic').mockImplementation(() => { throw new Error('forced config failure'); });
+        await expect(failing.setup('admin-secret', dbPath, directory)).rejects.toThrow('forced config failure');
+        expect(fs.existsSync(dbPath)).toBe(false);
+        expect(fs.existsSync(path.join(directory, 'security.json'))).toBe(false);
+        expect(fs.existsSync(path.join(directory, 'security-setup.json'))).toBe(false);
+
+        databases.delete(dbPath);
+        const retry = new SecurityService(store);
+        await expect(retry.setup('admin-secret', dbPath, directory)).resolves.toBeTruthy();
+        retry.completeProvisioning();
+    });
+
+    it('rolls back an interrupted full provisioning on restart and permits retry', async () => {
+        const interrupted = new SecurityService(store);
+        await interrupted.setup('admin-secret', dbPath, directory);
+        expect(fs.existsSync(path.join(directory, 'security-setup.json'))).toBe(true);
+        interrupted.closeDb();
+
+        const restarted = new SecurityService(store);
+        restarted.reconcileProvisioning(dbPath, directory);
+        expect(fs.existsSync(dbPath)).toBe(false);
+        expect(fs.existsSync(path.join(directory, 'security.json'))).toBe(false);
+        expect(fs.existsSync(path.join(directory, 'security-setup.json'))).toBe(false);
+
+        databases.delete(dbPath);
+        const code = await restarted.setup('admin-secret', dbPath, directory);
+        restarted.completeProvisioning();
+        expect(code).toBe(restarted.getPendingRecoveryCode());
+    });
+
+    it('keeps a fresh recovery code device-encrypted until exact acknowledgement', async () => {
+        const service = new SecurityService(store);
+        const code = await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        const configText = fs.readFileSync(path.join(directory, 'security.json'), 'utf8');
+        expect(configText).not.toContain(code);
+        service.closeDb();
+
+        const restarted = new SecurityService(store);
+        await restarted.initializeDevice(dbPath, directory);
+        expect(restarted.getPendingRecoveryCode()).toBe(code);
+        expect(() => restarted.acknowledgePendingRecoveryCode(`${code}X`)).toThrow('INVALID_RECOVERY_ACK');
+        restarted.acknowledgePendingRecoveryCode(code);
+        expect(restarted.getPendingRecoveryCode()).toBeNull();
+    });
+
+    it('reconciles an already-complete provisioning journal after cleanup interruption', async () => {
+        let failed = false;
+        const service = new SecurityService(store, {
+            onStep: step => {
+                if (step === 'cleanup-setup-journal' && !failed) {
+                    failed = true;
+                    throw new Error('cleanup interrupted');
+                }
+            }
+        });
+        await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        expect(fs.existsSync(path.join(directory, 'security-setup.json'))).toBe(true);
+        service.closeDb();
+
+        const restarted = new SecurityService(store);
+        restarted.reconcileProvisioning(dbPath, directory);
+        expect(fs.existsSync(path.join(directory, 'security-setup.json'))).toBe(false);
+        await expect(restarted.initializeDevice(dbPath, directory)).resolves.toEqual({ migrated: false });
+    });
+
+    it('refuses and preserves an existing unclaimed database during fresh setup', async () => {
+        fs.writeFileSync(dbPath, 'existing clinic data');
+        await expect(new SecurityService(store).setup('admin-secret', dbPath, directory))
+            .rejects.toThrow('UNCLAIMED_DATABASE_PRESENT');
+        expect(fs.readFileSync(dbPath, 'utf8')).toBe('existing clinic data');
+    });
+
+    it('requires recovery when the device envelope cannot be decrypted', async () => {
+        const service = new SecurityService(store);
+        await service.setup('irrelevant', dbPath, directory);
+        service.completeProvisioning();
+        service.closeDb();
+        vi.spyOn(store, 'unprotect').mockImplementation(() => { throw new Error('keychain denied'); });
+
+        await expect(new SecurityService(store).initializeDevice(dbPath, directory)).rejects.toThrow('DEVICE_UNLOCK_FAILED');
+    });
+
+    it('re-enrols a replacement device with the recovery code', async () => {
+        const originalStore = new MemoryDeviceKeyStore();
+        const original = new SecurityService(originalStore);
+        const recoveryCode = await original.setup('admin-secret', dbPath, directory);
+        original.completeProvisioning();
+        original.closeDb();
+
+        const replacementStore = new MemoryDeviceKeyStore();
+        (replacementStore as any).maskByte = 0x33;
+        const replacement = new SecurityService(replacementStore);
+        await expect(replacement.recoverDevice(recoveryCode, directory, dbPath)).resolves.toEqual({ migrated: false });
+        replacement.closeDb();
+        await expect(new SecurityService(replacementStore).initializeDevice(dbPath, directory)).resolves.toEqual({ migrated: false });
+    });
+
+    it('rejects an incorrect recovery code without rewriting config', async () => {
+        const service = new SecurityService(store);
+        await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        service.closeDb();
+        const before = fs.readFileSync(path.join(directory, 'security.json'));
+
+        await expect(service.recoverDevice('WRONG-CODE', directory, dbPath)).rejects.toThrow('INVALID_RECOVERY_CODE');
+        expect(fs.readFileSync(path.join(directory, 'security.json'))).toEqual(before);
+    });
+
+    it('detects a swapped security config using the database vault binding', async () => {
+        const service = new SecurityService(store);
+        await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        service.closeDb();
+        const configPath = path.join(directory, 'security.json');
+        const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+        config.vaultId = crypto.randomUUID();
+        fs.writeFileSync(configPath, JSON.stringify(config));
+
+        await expect(new SecurityService(store).initializeDevice(dbPath, directory)).rejects.toThrow('VAULT_BINDING_MISMATCH');
+    });
+
+    it('migrates v2 to v3 and durably protects the pending recovery acknowledgement', async () => {
+        const legacyBuilder = new SecurityService(store) as any;
+        const salt = crypto.randomBytes(16);
+        const legacyKey = crypto.randomBytes(32);
+        const kek = await legacyBuilder.deriveKey('legacy-master', salt);
+        const wrapped = legacyBuilder.aesEncrypt(legacyKey, kek);
+        fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+            version: 2,
+            salt: salt.toString('hex'),
+            wrappedKey: wrapped.wrappedKey,
+            iv: wrapped.iv
+        }));
+
+        const service = new SecurityService(store);
+        const result = await service.migrateLegacy('legacy-master', dbPath, directory);
+        const migratedText = fs.readFileSync(path.join(directory, 'security.json'), 'utf8');
+        const migrated = JSON.parse(migratedText);
+        expect(result.migrated).toBe(true);
+        const pendingCode = service.getPendingRecoveryCode();
+        expect(pendingCode).toMatch(/^[A-F0-9]{8}(?:-[A-F0-9]{8}){3}$/);
+        expect(migrated.version).toBe(3);
+        expect(migrated.migratedFrom).toBe(2);
+        expect(migratedText).not.toContain('legacy-master');
+        expect(migratedText).not.toContain(pendingCode!);
+        expect(fs.existsSync(`${dbPath}.pre-v3-migration`)).toBe(false);
+        expect(fs.existsSync(path.join(directory, 'security-migration.json'))).toBe(false);
+    });
+
+    it('can migrate v2 through its legacy recovery wrapper when the master password is unavailable', async () => {
+        const legacyBuilder = new SecurityService(store) as any;
+        const legacyKey = crypto.randomBytes(32);
+        const passwordSalt = crypto.randomBytes(16);
+        const recoverySalt = crypto.randomBytes(16);
+        const passwordWrapped = legacyBuilder.aesEncrypt(legacyKey, await legacyBuilder.deriveLegacyKey('old-master', passwordSalt));
+        const recoveryWrapped = legacyBuilder.aesEncrypt(legacyKey, await legacyBuilder.deriveLegacyKey('old-recovery', recoverySalt));
+        fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+            version: 2,
+            salt: passwordSalt.toString('hex'),
+            wrappedKey: passwordWrapped.wrappedKey,
+            iv: passwordWrapped.iv,
+            recovery: {
+                salt: recoverySalt.toString('hex'),
+                wrappedKey: recoveryWrapped.wrappedKey,
+                iv: recoveryWrapped.iv
+            }
+        }));
+
+        const service = new SecurityService(store);
+        const result = await service.recoverDevice('old-recovery', directory, dbPath);
+        expect(result.migrated).toBe(true);
+        expect(service.getPendingRecoveryCode()).toBeTruthy();
+        expect(JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8')).version).toBe(3);
+    });
+
+    it('keeps migration recovery acknowledgement across restart until explicitly cleared', async () => {
+        const legacyBuilder = new SecurityService(store) as any;
+        const salt = crypto.randomBytes(16);
+        const key = crypto.randomBytes(32);
+        const wrapped = legacyBuilder.aesEncrypt(key, await legacyBuilder.deriveLegacyKey('legacy', salt));
+        fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+            version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
+        }));
+        await new SecurityService(store).migrateLegacy('legacy', dbPath, directory);
+
+        const restarted = new SecurityService(store);
+        await restarted.initializeDevice(dbPath, directory);
+        const pending = restarted.getPendingRecoveryCode();
+        expect(pending).toBeTruthy();
+        expect(() => restarted.acknowledgePendingRecoveryCode('WRONG-CODE')).toThrow('INVALID_RECOVERY_ACK');
+        restarted.acknowledgePendingRecoveryCode(pending!);
+        expect(restarted.getPendingRecoveryCode()).toBeNull();
+    });
+
+    it.each([1, 2] as const)(
+        'recovers a migrated v%s vault on a new device with the final pending code and retires transition recovery',
+        async version => {
+            const legacySecret = `legacy-v${version}`;
+            if (version === 1) {
+                fs.writeFileSync(path.join(directory, 'salt.bin'), crypto.randomBytes(16));
+            } else {
+                const builder = new SecurityService(store) as any;
+                const salt = crypto.randomBytes(16);
+                const key = crypto.randomBytes(32);
+                const wrapped = builder.aesEncrypt(key, await builder.deriveLegacyKey(legacySecret, salt));
+                fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+                    version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
+                }));
+            }
+            const migrated = new SecurityService(store);
+            await migrated.migrateLegacy(legacySecret, dbPath, directory);
+            const finalCode = migrated.getPendingRecoveryCode()!;
+            migrated.closeDb();
+
+            const replacementStore = new MemoryDeviceKeyStore();
+            (replacementStore as any).maskByte = 0x33;
+            const replacement = new SecurityService(replacementStore);
+            await replacement.recoverDevice(finalCode, directory, dbPath);
+            expect(replacement.getPendingRecoveryCode()).toBeNull();
+            expect(JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8')).transitionRecovery).toBeUndefined();
+            replacement.closeDb();
+            await expect(new SecurityService(replacementStore).initializeDevice(dbPath, directory))
+                .resolves.toEqual({ migrated: false });
+        }
+    );
+
+    it.each([1, 2] as const)(
+        'recovers a migrated v%s vault on a new device with its transition secret and rotates recovery again',
+        async version => {
+            const legacySecret = `legacy-v${version}`;
+            if (version === 1) {
+                fs.writeFileSync(path.join(directory, 'salt.bin'), crypto.randomBytes(16));
+            } else {
+                const builder = new SecurityService(store) as any;
+                const salt = crypto.randomBytes(16);
+                const key = crypto.randomBytes(32);
+                const wrapped = builder.aesEncrypt(key, await builder.deriveLegacyKey(legacySecret, salt));
+                fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+                    version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
+                }));
+            }
+            const migrated = new SecurityService(store);
+            await migrated.migrateLegacy(legacySecret, dbPath, directory);
+            migrated.closeDb();
+
+            const replacementStore = new MemoryDeviceKeyStore();
+            (replacementStore as any).maskByte = 0x33;
+            const replacement = new SecurityService(replacementStore);
+            await replacement.recoverDevice(legacySecret, directory, dbPath);
+            const rotatedCode = replacement.getPendingRecoveryCode();
+            expect(rotatedCode).toMatch(/^[A-F0-9]{8}(?:-[A-F0-9]{8}){3}$/);
+            const config = JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8'));
+            expect(config.transitionRecovery?.purpose).toBe('legacy-transition');
+            expect(() => replacement.acknowledgePendingRecoveryCode('WRONG')).toThrow('INVALID_RECOVERY_ACK');
+            replacement.acknowledgePendingRecoveryCode(rotatedCode!);
+            replacement.closeDb();
+            await expect(new SecurityService(store).initializeDevice(dbPath, directory))
+                .rejects.toThrow('DEVICE_UNLOCK_FAILED');
+            await expect(new SecurityService(replacementStore).initializeDevice(dbPath, directory))
+                .resolves.toEqual({ migrated: false });
+        }
+    );
+
+    it('migrates a v1 direct-password database with a journaled rekey', async () => {
+        fs.writeFileSync(path.join(directory, 'salt.bin'), crypto.randomBytes(16));
+        const service = new SecurityService(store);
+        const result = await service.migrateLegacy('legacy-master', dbPath, directory);
+        const config = JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8'));
+
+        expect(result).toMatchObject({ migrated: true });
+        expect(config).toMatchObject({ version: 3, migratedFrom: 1 });
+        expect(fs.existsSync(path.join(directory, 'salt.bin'))).toBe(false);
+        expect(fs.existsSync(path.join(directory, 'salt.bin.migrated'))).toBe(true);
+    });
+
+    it('rolls the database back when migration fails after the snapshot', async () => {
+        const legacyBuilder = new SecurityService(store) as any;
+        const salt = crypto.randomBytes(16);
+        const legacyKey = crypto.randomBytes(32);
+        const wrapped = legacyBuilder.aesEncrypt(legacyKey, await legacyBuilder.deriveKey('legacy-master', salt));
+        fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+            version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
+        }));
+        const original = fs.readFileSync(dbPath);
+        const originalConfig = fs.readFileSync(path.join(directory, 'security.json'));
+        failInsert = true;
+
+        await expect(new SecurityService(store).migrateLegacy('legacy-master', dbPath, directory)).rejects.toThrow('forced binding failure');
+        expect(fs.readFileSync(dbPath)).toEqual(original);
+        expect(fs.readFileSync(path.join(directory, 'security.json'))).toEqual(originalConfig);
+    });
+
+    it.each(['cleanup-database-backup', 'cleanup-config-backup', 'cleanup-journal'] as const)(
+        'keeps committed migration authoritative when %s fails and reconciles on restart',
+        async cleanupStep => {
+            const legacyBuilder = new SecurityService(store) as any;
+            const salt = crypto.randomBytes(16);
+            const key = crypto.randomBytes(32);
+            const wrapped = legacyBuilder.aesEncrypt(key, await legacyBuilder.deriveLegacyKey('legacy', salt));
+            fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+                version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
             }));
-            expect(result).toEqual(Buffer.from('mocked-hash-key'));
-        });
+            let failed = false;
+            const service = new SecurityService(store, {
+                onStep: step => {
+                    if (step === cleanupStep && !failed) { failed = true; throw new Error('cleanup failure'); }
+                }
+            });
+            await expect(service.migrateLegacy('legacy', dbPath, directory)).resolves.toEqual({ migrated: true });
+            expect(JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8')).version).toBe(3);
+            service.closeDb();
+            await expect(new SecurityService(store).initializeDevice(dbPath, directory)).resolves.toEqual({ migrated: false });
+            expect(fs.existsSync(path.join(directory, 'security-migration.json'))).toBe(false);
+        }
+    );
 
-        it('should propagate errors from argon2', async () => {
-            argon2.hash.mockRejectedValue(new Error('Argon error'));
-            await expect(service.deriveKey('pass', Buffer.alloc(16))).rejects.toThrow('Argon error');
+    it('never rolls back after the atomic v3 config commit point', async () => {
+        const legacyBuilder = new SecurityService(store) as any;
+        const salt = crypto.randomBytes(16);
+        const key = crypto.randomBytes(32);
+        const wrapped = legacyBuilder.aesEncrypt(key, await legacyBuilder.deriveLegacyKey('legacy', salt));
+        fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+            version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
+        }));
+        const service = new SecurityService(store, {
+            onStep: step => { if (step === 'migration-after-config-commit') throw new Error('post-commit failure'); }
         });
+        await expect(service.migrateLegacy('legacy', dbPath, directory)).resolves.toEqual({ migrated: true });
+        expect(JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8')).version).toBe(3);
     });
 
-    describe('initDb', () => {
-        const mockKey = Buffer.from('test-key');
-        const dbPath = 'test.db';
-
-        it('should initialize database with correct pragma key', () => {
-            (service as any).initDb(dbPath, mockKey);
-
-            expect(mockPragma).toHaveBeenCalledWith(`key = "x'${mockKey.toString('hex')}'"`);
-            expect(mockPrepare).toHaveBeenCalledWith('SELECT count(*) FROM sqlite_master'); // Verification query
-            expect(service.getDb()).toBeDefined();
+    it('reconciles a failed legacy-salt cleanup without rolling back committed v1 migration', async () => {
+        fs.writeFileSync(path.join(directory, 'salt.bin'), crypto.randomBytes(16));
+        let failed = false;
+        const service = new SecurityService(store, {
+            onStep: step => {
+                if (step === 'cleanup-legacy-salt' && !failed) { failed = true; throw new Error('cleanup failure'); }
+            }
         });
-
-        it('should throw INVALID_PASSWORD on sqlite error "file is not a database"', () => {
-            // Simulate wrong password error
-            mockGet.mockImplementation(() => { throw new Error('file is not a database'); });
-
-            expect(() => (service as any).initDb(dbPath, mockKey)).toThrow('INVALID_PASSWORD');
-            expect(service.getDb()).toBeUndefined(); // Should not have set the db
-        });
-
-        it('should rethrow other errors', () => {
-            mockGet.mockImplementation(() => { throw new Error('Disk full'); });
-            expect(() => (service as any).initDb(dbPath, mockKey)).toThrow('Disk full');
-        });
+        await service.migrateLegacy('legacy-master', dbPath, directory);
+        service.closeDb();
+        await expect(new SecurityService(store).initializeDevice(dbPath, directory)).resolves.toEqual({ migrated: false });
+        expect(fs.existsSync(path.join(directory, 'salt.bin.migrated'))).toBe(true);
     });
 
-    describe('closeDb', () => {
-        it('should close the database if open', () => {
-            (service as any).initDb('path', Buffer.from('key'));
-            service.closeDb();
-            expect(mockClose).toHaveBeenCalled();
-            expect(service.getDb()).toBeNull();
-        });
+    it('reconciles an interrupted pre-commit migration by restoring its snapshots', async () => {
+        const configPath = path.join(directory, 'security.json');
+        const backupPath = `${dbPath}.pre-v3-migration`;
+        const configBackup = `${configPath}.pre-v3-migration`;
+        fs.writeFileSync(dbPath, 'partially migrated');
+        fs.writeFileSync(backupPath, 'original database');
+        fs.writeFileSync(configPath, JSON.stringify({ version: 3, incomplete: true }));
+        fs.writeFileSync(configBackup, JSON.stringify({ version: 2, salt: '00', wrappedKey: '00', iv: '00' }));
+        fs.writeFileSync(path.join(directory, 'security-migration.json'), JSON.stringify({
+            version: 1,
+            sourceVersion: 2,
+            phase: 'snapshot-created',
+            databaseBackup: backupPath,
+            configBackup,
+            startedAt: new Date().toISOString()
+        }));
 
-        it('should do nothing if db is not open', () => {
-            service.closeDb();
-            expect(mockClose).not.toHaveBeenCalled();
+        await expect(new SecurityService(store).initializeDevice(dbPath, directory)).rejects.toThrow('LEGACY_MIGRATION_REQUIRED');
+        expect(fs.readFileSync(dbPath, 'utf8')).toBe('original database');
+        expect(JSON.parse(fs.readFileSync(configPath, 'utf8')).version).toBe(2);
+        expect(fs.existsSync(path.join(directory, 'security-migration.json'))).toBe(false);
+    });
+
+    it('records rollback restoration before best-effort cleanup and never needs an already deleted snapshot', async () => {
+        const configPath = path.join(directory, 'security.json');
+        const backupPath = `${dbPath}.pre-v3-migration`;
+        const configBackup = `${configPath}.pre-v3-migration`;
+        fs.writeFileSync(dbPath, 'partially migrated');
+        fs.writeFileSync(backupPath, 'original database');
+        fs.writeFileSync(configPath, JSON.stringify({ version: 3, incomplete: true }));
+        fs.writeFileSync(configBackup, JSON.stringify({ version: 2, salt: '00', wrappedKey: '00', iv: '00' }));
+        fs.writeFileSync(path.join(directory, 'security-migration.json'), JSON.stringify({
+            version: 1,
+            sourceVersion: 2,
+            phase: 'snapshot-created',
+            databaseBackup: backupPath,
+            configBackup,
+            startedAt: new Date().toISOString()
+        }));
+        let failed = false;
+        const firstRestart = new SecurityService(store, {
+            onStep: step => {
+                if (step === 'cleanup-rollback-database-backup' && !failed) {
+                    failed = true;
+                    throw new Error('cleanup interrupted');
+                }
+            }
         });
+        await expect(firstRestart.initializeDevice(dbPath, directory)).rejects.toThrow('LEGACY_MIGRATION_REQUIRED');
+        const journal = JSON.parse(fs.readFileSync(path.join(directory, 'security-migration.json'), 'utf8'));
+        expect(journal.phase).toBe('rollback-restored');
+        // Simulate another cleanup artifact already having disappeared.
+        if (fs.existsSync(configBackup)) fs.unlinkSync(configBackup);
+
+        await expect(new SecurityService(store).initializeDevice(dbPath, directory))
+            .rejects.toThrow('LEGACY_MIGRATION_REQUIRED');
+        expect(fs.readFileSync(dbPath, 'utf8')).toBe('original database');
+        expect(fs.existsSync(path.join(directory, 'security-migration.json'))).toBe(false);
+    });
+
+    it('exposes only portable recovery metadata for backup consumers', async () => {
+        const service = new SecurityService(store);
+        await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        const metadata = service.getPortableVaultMetadata() as any;
+        expect(metadata.device).toBeUndefined();
+        expect(Object.keys(metadata).sort()).toEqual(['keyVersion', 'recovery', 'vaultId', 'version']);
+    });
+
+    it('installs portable metadata only after recovery and vault-binding validation', async () => {
+        const source = new SecurityService(store);
+        const recoveryCode = await source.setup('admin-secret', dbPath, directory);
+        source.completeProvisioning();
+        const metadata = source.getPortableVaultMetadata();
+        source.closeDb();
+
+        const restoreDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'nalamdesk-security-restore-'));
+        const restoreDbPath = path.join(restoreDirectory, 'nalamdesk.db');
+        fs.copyFileSync(dbPath, restoreDbPath);
+        databases.set(restoreDbPath, { vault: { ...databases.get(dbPath)!.vault! } });
+        try {
+            const restored = new SecurityService(store);
+            await restored.installPortableVaultMetadata(metadata, recoveryCode, restoreDbPath, restoreDirectory);
+            expect(JSON.parse(fs.readFileSync(path.join(restoreDirectory, 'security.json'), 'utf8'))).toMatchObject({
+                version: 3,
+                vaultId: metadata.vaultId
+            });
+        } finally {
+            fs.rmSync(restoreDirectory, { recursive: true, force: true });
+        }
+    });
+
+    it('retires transition recovery when portable metadata is installed with the primary code', async () => {
+        const legacySecret = 'legacy-portable-secret';
+        const builder = new SecurityService(store) as any;
+        const salt = crypto.randomBytes(16);
+        const key = crypto.randomBytes(32);
+        const wrapped = builder.aesEncrypt(key, await builder.deriveLegacyKey(legacySecret, salt));
+        fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+            version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
+        }));
+        const migrated = new SecurityService(store);
+        await migrated.migrateLegacy(legacySecret, dbPath, directory);
+        const finalCode = migrated.getPendingRecoveryCode()!;
+        const metadata = migrated.getPortableVaultMetadata();
+        expect(metadata.transitionRecovery).toBeTruthy();
+        migrated.closeDb();
+
+        const restoreDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'nalamdesk-security-transition-'));
+        const restoreDbPath = path.join(restoreDirectory, 'nalamdesk.db');
+        fs.copyFileSync(dbPath, restoreDbPath);
+        databases.set(restoreDbPath, { vault: { ...databases.get(dbPath)!.vault! } });
+        try {
+            const restored = new SecurityService(store);
+            await restored.installPortableVaultMetadata(metadata, finalCode, restoreDbPath, restoreDirectory);
+            const installed = JSON.parse(fs.readFileSync(path.join(restoreDirectory, 'security.json'), 'utf8'));
+            expect(installed.transitionRecovery).toBeUndefined();
+            expect(installed.pendingRecoveryAck).toBeUndefined();
+            restored.closeDb();
+            await expect(new SecurityService(store).recoverDevice(
+                legacySecret, restoreDirectory, restoreDbPath
+            )).rejects.toThrow('INVALID_RECOVERY_CODE');
+        } finally {
+            fs.rmSync(restoreDirectory, { recursive: true, force: true });
+        }
+    });
+
+    it('closes the database and restores the prior config when device recovery commit fails', async () => {
+        const source = new SecurityService(store);
+        const recoveryCode = await source.setup('admin-secret', dbPath, directory);
+        source.completeProvisioning();
+        source.closeDb();
+        const configPath = path.join(directory, 'security.json');
+        const before = fs.readFileSync(configPath, 'utf8');
+
+        const replacement = new SecurityService(store);
+        const save = (replacement as any).saveConfigAtomic.bind(replacement);
+        vi.spyOn(replacement as any, 'saveConfigAtomic').mockImplementation((config: any) => {
+            save(config);
+            throw new Error('forced post-commit failure');
+        });
+        await expect(replacement.recoverDevice(recoveryCode, directory, dbPath))
+            .rejects.toThrow('forced post-commit failure');
+        expect(replacement.getDb()).toBeFalsy();
+        expect(fs.readFileSync(configPath, 'utf8')).toBe(before);
+    });
+
+    it('closes the database and restores an existing config when portable install commit fails', async () => {
+        const source = new SecurityService(store);
+        const recoveryCode = await source.setup('admin-secret', dbPath, directory);
+        source.completeProvisioning();
+        const metadata = source.getPortableVaultMetadata();
+        source.closeDb();
+
+        const restoreDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'nalamdesk-security-install-failure-'));
+        const restoreDbPath = path.join(restoreDirectory, 'nalamdesk.db');
+        const restoreConfigPath = path.join(restoreDirectory, 'security.json');
+        const previous = '{"sentinel":true}';
+        fs.copyFileSync(dbPath, restoreDbPath);
+        fs.writeFileSync(restoreConfigPath, previous);
+        databases.set(restoreDbPath, { vault: { ...databases.get(dbPath)!.vault! } });
+        try {
+            const restored = new SecurityService(store);
+            const save = (restored as any).saveConfigAtomic.bind(restored);
+            vi.spyOn(restored as any, 'saveConfigAtomic').mockImplementation((config: any) => {
+                save(config);
+                throw new Error('forced portable commit failure');
+            });
+            await expect(restored.installPortableVaultMetadata(
+                metadata, recoveryCode, restoreDbPath, restoreDirectory
+            )).rejects.toThrow('forced portable commit failure');
+            expect(restored.getDb()).toBeFalsy();
+            expect(fs.readFileSync(restoreConfigPath, 'utf8')).toBe(previous);
+        } finally {
+            fs.rmSync(restoreDirectory, { recursive: true, force: true });
+        }
+    });
+
+    it('rejects hostile portable KDF parameters before deriving a key', async () => {
+        const source = new SecurityService(store);
+        const recoveryCode = await source.setup('admin-secret', dbPath, directory);
+        source.completeProvisioning();
+        const metadata = source.getPortableVaultMetadata();
+        source.closeDb();
+        metadata.recovery.kdfParams.memoryCost = Number.MAX_SAFE_INTEGER;
+
+        await expect(new SecurityService(store).installPortableVaultMetadata(
+            metadata,
+            recoveryCode,
+            dbPath,
+            directory
+        )).rejects.toThrow('INVALID_RECOVERY_ENVELOPE');
+    });
+
+    it('authenticates the recovery envelope against vault context using AAD', async () => {
+        const service = new SecurityService(store);
+        const code = await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        const metadata = service.getPortableVaultMetadata();
+        service.closeDb();
+        metadata.vaultId = crypto.randomUUID();
+        await expect(new SecurityService(store).installPortableVaultMetadata(
+            metadata, code, dbPath, directory
+        )).rejects.toThrow();
+    });
+
+    it.each(['EPERM', 'EINVAL'])(
+        'propagates Windows regular-file fsync %s failures',
+        code => {
+            const failure = Object.assign(new Error(`regular file ${code}`), { code });
+            const service = new SecurityService(store, {
+                platform: 'win32',
+                fsync: () => { throw failure; }
+            });
+            expect(() => (service as any).fsyncFile(dbPath)).toThrow(`regular file ${code}`);
+        }
+    );
+
+    it.each(['EPERM', 'EINVAL', 'ENOSYS', 'ENOTSUP'])(
+        'tolerates Windows directory fsync incompatibility %s',
+        code => {
+            const unsupported = Object.assign(new Error(`directory ${code}`), { code });
+            const service = new SecurityService(store, {
+                platform: 'win32',
+                fsync: () => { throw unsupported; }
+            });
+            (service as any).configurePaths(dbPath, directory);
+            expect(() => (service as any).fsyncDirectory()).not.toThrow();
+        }
+    );
+
+    it('propagates genuine Windows directory fsync I/O failures', () => {
+        const failure = Object.assign(new Error('directory device I/O failure'), { code: 'EIO' });
+        const service = new SecurityService(store, {
+            platform: 'win32',
+            fsync: () => { throw failure; }
+        });
+        (service as any).configurePaths(dbPath, directory);
+        expect(() => (service as any).fsyncDirectory()).toThrow('directory device I/O failure');
     });
 });

--- a/desktop/src/main/services/SecurityService.ts
+++ b/desktop/src/main/services/SecurityService.ts
@@ -1,403 +1,1006 @@
 import * as argon2 from 'argon2';
-// @ts-ignore - types might be missing or need specific import
+// @ts-ignore native module has no compatible default declaration
 import Database from 'better-sqlite3-multiple-ciphers';
-import * as path from 'path';
 import * as crypto from 'crypto';
 import * as fs from 'fs';
+import * as path from 'path';
+import type { DeviceKeyStore } from './DeviceKeyStore';
 
-/**
- * Security Config Interface stored in security.json
- */
-interface SecurityConfig {
-    version: number;
-    salt: string; // Hex string
-    wrappedKey: string; // Encrypted DEK (Hex string) - Encrypted with Password
-    iv: string; // IV used for wrapping key (Hex string)
-    recovery?: {
-        salt: string; // Hex string (Salt for recovery code)
-        wrappedKey: string; // Encrypted DEK (Hex string) - Encrypted with Recovery Code
-        iv: string; // IV used for recovery wrapping
+export interface RecoveryEnvelope {
+    algorithm: 'aes-256-gcm';
+    kdf: 'argon2id';
+    kdfParams: {
+        timeCost: number;
+        memoryCost: number;
+        parallelism: number;
+        hashLength: number;
     };
+    salt: string;
+    iv: string;
+    wrappedKey: string;
+    aadVersion: 1;
 }
 
+interface PendingRecoveryAck {
+    protectedPayload: string;
+    createdAt: string;
+    reason: 'fresh-setup' | 'legacy-migration' | 'transition-recovery';
+}
+
+export interface TransitionRecoveryEnvelope extends RecoveryEnvelope {
+    purpose: 'legacy-transition';
+}
+
+export interface SecurityConfigV3 {
+    version: 3;
+    vaultId: string;
+    keyVersion: number;
+    device: { provider: string; protectedPayload: string };
+    recovery: RecoveryEnvelope;
+    migratedFrom?: 1 | 2;
+    pendingRecoveryAck?: PendingRecoveryAck;
+    transitionRecovery?: TransitionRecoveryEnvelope;
+}
+
+interface SecurityConfigV2 {
+    version: 2;
+    salt: string;
+    wrappedKey: string;
+    iv: string;
+    recovery?: { salt: string; wrappedKey: string; iv: string };
+}
+
+export interface SetupStatus {
+    isSetup: boolean;
+    hasRecovery: boolean;
+    vaultState: 'not-setup' | 'ready' | 'legacy-migration-required' | 'recovery-required' | 'corrupt';
+    configVersion?: number;
+}
+
+export interface VaultUnlockResult { migrated: boolean }
+
+interface MigrationJournal {
+    version: 1;
+    sourceVersion: 1 | 2;
+    phase: 'snapshot-created' | 'database-rekeyed' | 'config-committing' | 'config-written' | 'rollback-restored';
+    databaseBackup: string;
+    configBackup?: string;
+    legacySaltPath?: string;
+    startedAt: string;
+}
+
+export interface SetupJournal {
+    version: 1;
+    phase: 'started' | 'vault-created' | 'complete';
+    databaseCreated: boolean;
+    startedAt: string;
+}
+
+export type SecurityStep =
+    | 'setup-after-journal' | 'setup-after-bind' | 'setup-after-config-commit'
+    | 'migration-after-snapshot' | 'migration-after-rekey' | 'migration-after-bind'
+    | 'migration-after-config-commit' | 'cleanup-legacy-salt' | 'cleanup-database-backup'
+    | 'cleanup-config-backup' | 'cleanup-journal' | 'cleanup-rollback-database-backup'
+    | 'cleanup-rollback-config-backup' | 'cleanup-rollback-journal' | 'cleanup-setup-journal';
+
+export interface SecurityServiceHooks {
+    onStep?: (step: SecurityStep) => void;
+    platform?: NodeJS.Platform;
+    fsync?: (fd: number) => void;
+}
+
+const CONFIG_FILE = 'security.json';
+const JOURNAL_FILE = 'security-migration.json';
+const SETUP_JOURNAL_FILE = 'security-setup.json';
+const LEGACY_SALT_FILE = 'salt.bin';
+const VAULT_TABLE = '__nalamdesk_vault';
+const RECOVERY_KDF_PARAMS = Object.freeze({ timeCost: 3, memoryCost: 65536, parallelism: 1, hashLength: 32 });
+
 /**
- * SecurityService handles database encryption using SQLCipher with a Key Wrapping Architecture.
- * 
- * V2 Architecture:
- * - Data Encryption Key (DEK): A random 32-byte key that actually encrypts the DB.
- * - Key Encryption Key (KEK): Derived from User Password (or Recovery Code).
- * - The DEK is encrypted (wrapped) by the KEK and stored in security.json.
- * 
- * This allows:
- * 1. Password Changes (Re-wrap DEK with new Password KEK) without re-encrypting the whole DB.
- * 2. Password Recovery (Unwrap DEK with Recovery Code KEK, then Re-wrap with new Password KEK).
+ * Owns the SQLCipher DEK. User passwords are intentionally absent from the v3
+ * unlock path: device unlock and user authentication are separate operations.
  */
 export class SecurityService {
     private db: any;
-    private dbPath: string = '';
-    private appUserDataPath: string = '';
-
-    // In-memory DEK (cleared on app exit)
+    private dbPath = '';
+    private appUserDataPath = '';
     private dek: Buffer | null = null;
 
-    /**
-     * Checks if the application is already set up.
-     */
-    isSetup(userDataPath: string): { isSetup: boolean, hasRecovery: boolean } {
-        const configPath = path.join(userDataPath, 'security.json');
-        const legacySaltPath = path.join(userDataPath, 'salt.bin');
+    constructor(
+        private readonly deviceKeyStore: DeviceKeyStore,
+        private readonly hooks: SecurityServiceHooks = {}
+    ) { }
 
-        if (fs.existsSync(configPath)) {
-            try {
-                const config = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as SecurityConfig;
-                return { isSetup: true, hasRecovery: !!config.recovery };
-            } catch (e) {
-                return { isSetup: true, hasRecovery: false }; // Corrupt file? Treat as setup but broken? Or just assume true.
+    isSetup(userDataPath: string): SetupStatus {
+        const configPath = path.join(userDataPath, CONFIG_FILE);
+        const legacySaltPath = path.join(userDataPath, LEGACY_SALT_FILE);
+        if (!fs.existsSync(configPath)) {
+            return fs.existsSync(legacySaltPath)
+                ? { isSetup: true, hasRecovery: false, vaultState: 'legacy-migration-required', configVersion: 1 }
+                : { isSetup: false, hasRecovery: false, vaultState: 'not-setup' };
+        }
+        try {
+            const config = JSON.parse(fs.readFileSync(configPath, 'utf8')) as SecurityConfigV3 | SecurityConfigV2;
+            if (config.version === 3) {
+                return {
+                    isSetup: true,
+                    hasRecovery: true,
+                    vaultState: this.deviceKeyStore.status().available ? 'ready' : 'recovery-required',
+                    configVersion: 3
+                };
             }
+            if (config.version === 2) {
+                return { isSetup: true, hasRecovery: !!config.recovery, vaultState: 'legacy-migration-required', configVersion: 2 };
+            }
+            return { isSetup: true, hasRecovery: false, vaultState: 'corrupt', configVersion: (config as any).version };
+        } catch {
+            return { isSetup: true, hasRecovery: false, vaultState: 'corrupt' };
         }
-
-        // If legacy salt exists, we consider it "Setup" (will migrate on login)
-        if (fs.existsSync(legacySaltPath)) {
-            return { isSetup: true, hasRecovery: false };
-        }
-
-        return { isSetup: false, hasRecovery: false };
     }
 
-    /**
-     * Fresh Setup: Generates new DEK, creates security.json, and initializes DB.
-     * Returns the Recovery Code for the user to save.
-     */
-    async setup(password: string, dbPath: string, userDataPath: string): Promise<string> {
-        this.appUserDataPath = userDataPath;
-        this.dbPath = dbPath;
-
-        // 1. Generate Random DEK
-        this.dek = crypto.randomBytes(32);
-
-        // 2. Generate Recovery Code
+    /** adminPassword remains only for caller compatibility; it never wraps the DEK. */
+    async setup(_adminPassword: string, dbPath: string, userDataPath: string): Promise<string> {
+        this.configurePaths(dbPath, userDataPath);
+        this.assertDeviceStoreAvailable();
+        this.reconcileSetupJournal();
+        if (fs.existsSync(path.join(userDataPath, CONFIG_FILE))) throw new Error('ALREADY_SETUP');
+        const databaseCreated = !fs.existsSync(dbPath) || fs.statSync(dbPath).size === 0;
+        if (!databaseCreated) throw new Error('UNCLAIMED_DATABASE_PRESENT');
+        const journal: SetupJournal = {
+            version: 1,
+            phase: 'started',
+            databaseCreated,
+            startedAt: new Date().toISOString()
+        };
+        this.saveSetupJournal(journal);
+        this.step('setup-after-journal');
+        const dek = crypto.randomBytes(32);
         const recoveryCode = this.generateRecoveryCodeString();
-
-        // 3. Create Security Config (Wrap DEK with Password AND Recovery Code)
-        const config = await this.createSecurityConfig(this.dek, password, recoveryCode);
-        this.saveConfig(config);
-
-        // 4. Initialize DB with DEK
-        this.initDb(this.dbPath, this.dek);
-
-        return recoveryCode;
-    }
-
-    /**
-     * Initialize / Unlock the encrypted database.
-     * Handles V1 -> V2 Migration transparently.
-     */
-    async initialize(password: string, dbPath: string, userDataPath: string): Promise<void> {
-        this.appUserDataPath = userDataPath;
-        this.dbPath = dbPath;
-
-        const configPath = path.join(userDataPath, 'security.json');
-        const legacySaltPath = path.join(userDataPath, 'salt.bin');
-
-        // CASE 1: V2 Setup Exists
-        if (fs.existsSync(configPath)) {
-            console.log('[Security] Loading V2 Configuration...');
-            const config = this.loadConfig();
-
-            // Unwrap DEK using Password
-            try {
-                this.dek = await this.unwrapKey(config.wrappedKey, config.iv, config.salt, password);
-                this.initDb(this.dbPath, this.dek);
-                console.log('[Security] Vault Unlocked (V2).');
-            } catch (e) {
-                console.error('[Security] Failed to unlock vault:', e);
-                throw new Error('INVALID_PASSWORD');
-            }
-            return;
-        }
-
-        // CASE 2: V1 Legacy Exists -> Migrate to V2
-        if (fs.existsSync(legacySaltPath)) {
-            console.log('[Security] Detected V1 Setup. Starting Migration to V2...');
-            await this.migrateV1toV2(password, legacySaltPath);
-            return;
-        }
-
-        // CASE 3: No Setup -> Should have called setup() instead.
-        throw new Error('NOT_SETUP');
-    }
-
-
-    /**
-     * Recover Password using Recovery Code.
-     * Sets a new password and re-wraps the DEK.
-     */
-    async recover(recoveryCode: string, newPassword: string, userDataPath: string, dbPath: string): Promise<string> {
-        this.appUserDataPath = userDataPath;
-        this.dbPath = dbPath;
-
-        const config = this.loadConfig();
-        if (!config.recovery) {
-            throw new Error('NO_RECOVERY_CODE_SET');
-        }
-
-        // 1. Unwrap DEK using Recovery Code
+        const config = await this.createV3Config(dek, recoveryCode, undefined, undefined, 'fresh-setup');
         try {
-            this.dek = await this.unwrapKey(config.recovery.wrappedKey, config.recovery.iv, config.recovery.salt, recoveryCode);
-        } catch (e) {
-            throw new Error('INVALID_RECOVERY_CODE');
-        }
-
-        // 2. Rotate Security Config (New Password KEK + New Recovery Code KEK)
-        const newRecoveryCode = this.generateRecoveryCodeString();
-
-        // Wrap DEK with NEW Password
-        const salt = crypto.randomBytes(16);
-        const kek = await this.deriveKey(newPassword, salt);
-        const { encrypted: wrappedKey, iv } = this.aesEncrypt(this.dek, kek);
-
-        // Wrap DEK with NEW Recovery Code
-        const rSalt = crypto.randomBytes(16);
-        const rKek = await this.deriveKey(newRecoveryCode, rSalt);
-        const { encrypted: rWrappedKey, iv: rIv } = this.aesEncrypt(this.dek, rKek);
-
-        const newConfig: SecurityConfig = {
-            version: 2,
-            salt: salt.toString('hex'),
-            wrappedKey: wrappedKey,
-            iv: iv,
-            recovery: {
-                salt: rSalt.toString('hex'),
-                wrappedKey: rWrappedKey,
-                iv: rIv
-            }
-        };
-
-        this.saveConfig(newConfig);
-
-        // 3. Open DB
-        this.initDb(this.dbPath, this.dek);
-        console.log('[Security] Password reset successful. Vault Unlocked. Recovery Code Rotated.');
-
-        return newRecoveryCode;
-    }
-
-    /**
-     * Helper: Generate a secure recovery code string (Format: XXXX-XXXX-XXXX-XXXX)
-     */
-    generateRecoveryCodeString(): string {
-        // Generate 16 bytes of random entropy, generic human-readable format
-        const bytes = crypto.randomBytes(10); // 20 hex chars
-        const hex = bytes.toString('hex').toUpperCase();
-        return `${hex.slice(0, 5)}-${hex.slice(5, 10)}-${hex.slice(10, 15)}-${hex.slice(15, 20)}`;
-    }
-
-    /**
-     * Regenerate Recovery Code (for Admin).
-     * Requires the current password to unlock logic (though DEK is already in memory).
-     * Re-wraps the DEK with valid Password and NEW Recovery Code.
-     */
-    async regenerateRecoveryCode(password: string): Promise<string> {
-        if (!this.dek) {
-            // Try to load/unlock if not in memory (shouldn't happen if logged in, but safety first)
-            // Or assume DEK is available if app is running and unlocked.
-            // If DEK is missing, we must fail or ask to unlock.
-            throw new Error('VAULT_LOCKED');
-        }
-
-        const config = this.loadConfig();
-
-        // Vefiry password by attempting to derive KEK and check against wrappedKey?
-        // Or just rely on the fact we are re-wrapping. 
-        // Better to re-wrap properly.
-
-        // 1. Generate NEW Recovery Code
-        const newRecoveryCode = this.generateRecoveryCodeString();
-
-        // 2. Create NEW Security Config
-        // We re-use the existing DEK (this.dek).
-        const newConfig = await this.createSecurityConfig(this.dek, password, newRecoveryCode);
-
-        this.saveConfig(newConfig);
-
-        return newRecoveryCode;
-    }
-
-    // ==================================================================================
-    //                                  PRIVATE HELPERS
-    // ==================================================================================
-
-    private async createSecurityConfig(dek: Buffer, password: string, recoveryCode: string): Promise<SecurityConfig> {
-        // 1. Wrap with Password
-        const salt = crypto.randomBytes(16);
-        const kek = await this.deriveKey(password, salt);
-        const { encrypted: wrappedKey, iv } = this.aesEncrypt(dek, kek);
-
-        // 2. Wrap with Recovery Code
-        const rSalt = crypto.randomBytes(16);
-        const rKek = await this.deriveKey(recoveryCode, rSalt);
-        const { encrypted: rWrappedKey, iv: rIv } = this.aesEncrypt(dek, rKek);
-
-        return {
-            version: 2,
-            salt: salt.toString('hex'),
-            wrappedKey: wrappedKey,
-            iv: iv,
-            recovery: {
-                salt: rSalt.toString('hex'),
-                wrappedKey: rWrappedKey,
-                iv: rIv
-            }
-        };
-    }
-
-    private async unwrapKey(wrappedKeyHex: string, ivHex: string, saltHex: string, secret: string): Promise<Buffer> {
-        const salt = Buffer.from(saltHex, 'hex');
-        const kek = await this.deriveKey(secret, salt);
-        return this.aesDecrypt(wrappedKeyHex, ivHex, kek);
-    }
-
-    /**
-     * Migrate V1 (Direct Password) to V2 (Wrapped Key)
-     * 1. Derive OLD Key from Password + Old Salt.
-     * 2. Open DB with OLD Key.
-     * 3. Change DB Key to NEW Random DEK (`PRAGMA rekey`).
-     * 4. Wrap NEW DEK with Password and Save Config.
-     */
-    private async migrateV1toV2(password: string, legacySaltPath: string): Promise<void> {
-        const salt = fs.readFileSync(legacySaltPath);
-
-        // 1. Derive V1 Key
-        const oldKey = await this.deriveKeyArgon2(password, salt); // Use raw argon2 like V1
-
-        // 2. Open DB with V1 Key to verify password
-        try {
-            this.initDb(this.dbPath, oldKey);
-        } catch (e) {
-            throw new Error('INVALID_PASSWORD'); // Pass through
-        }
-
-        console.log('[Security] V1 Key Verified. Rekeying database...');
-
-        // 3. Generate NEW Random DEK
-        this.dek = crypto.randomBytes(32);
-        const newKeyHex = this.dek.toString('hex');
-
-        // 4. PRAGMA rekey (Change DB Encryption Key)
-        this.db.pragma(`rekey = "x'${newKeyHex}'"`);
-
-        // 5. Create V2 Config (Wrap DEK)
-        // Note: We don't have a recovery code yet. User will need to generate one later.
-        const configSalt = crypto.randomBytes(16);
-        const kek = await this.deriveKey(password, configSalt);
-        const { encrypted: wrappedKey, iv } = this.aesEncrypt(this.dek, kek);
-
-        const config: SecurityConfig = {
-            version: 2,
-            salt: configSalt.toString('hex'),
-            wrappedKey: wrappedKey,
-            iv: iv,
-            // recovery: undefined // No recovery code yet
-        };
-
-        this.saveConfig(config);
-
-        // 6. Cleanup V1 Salt
-        // fs.unlinkSync(legacySaltPath); // Optional: keep for safety or backup? Let's keep it but maybe rename?
-        console.log('[Security] Migration to V2 Complete.');
-    }
-
-    private saveConfig(config: SecurityConfig) {
-        const configPath = path.join(this.appUserDataPath, 'security.json');
-        fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
-    }
-
-    private loadConfig(): SecurityConfig {
-        const configPath = path.join(this.appUserDataPath, 'security.json');
-        return JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    }
-
-    /**
-     * V2 Key Derivation (Standardized)
-     * Uses Argon2id but we can tune parameters if needed. 
-     * We keep it simple to match V1 but ensure it's consistent.
-     */
-    private async deriveKey(secret: string, salt: Buffer): Promise<Buffer> {
-        return argon2.hash(secret, {
-            type: argon2.argon2id,
-            raw: true,
-            salt: salt
-        });
-    }
-
-    /**
-     * V1 Key Derivation (Strictly for backward compat with exact V1 params if any)
-     * V1 used default params.
-     */
-    private async deriveKeyArgon2(password: string, salt: Buffer): Promise<Buffer> {
-        return argon2.hash(password, {
-            type: argon2.argon2id,
-            raw: true,
-            salt: salt
-        });
-    }
-
-    private aesEncrypt(data: Buffer, key: Buffer): { encrypted: string, iv: string } {
-        const iv = crypto.randomBytes(16); // IV for AES-256-GCM
-        const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
-        const encrypted = Buffer.concat([cipher.update(data), cipher.final()]);
-        const tag = cipher.getAuthTag();
-        // Return IV + AuthTag + EncryptedData as hex string or define a format
-        // Simple format: iv (hex) | tag (hex) | encrypted (hex)
-        // Actually, let's keep IV separate in JSON for clarity. 
-        // Combine Tag + Encrypted
-        return {
-            encrypted: Buffer.concat([tag, encrypted]).toString('hex'), // First 16 bytes is tag
-            iv: iv.toString('hex')
-        };
-    }
-
-    private aesDecrypt(encryptedHex: string, ivHex: string, key: Buffer): Buffer {
-        const encryptedAndTag = Buffer.from(encryptedHex, 'hex');
-        const tag = encryptedAndTag.subarray(0, 16);
-        const encrypted = encryptedAndTag.subarray(16);
-        const iv = Buffer.from(ivHex, 'hex');
-
-        const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
-        decipher.setAuthTag(tag);
-        return Buffer.concat([decipher.update(encrypted), decipher.final()]);
-    }
-
-    private initDb(filePath: string, key: Buffer): void {
-        try {
-            this.dbPath = filePath;
-            const isDevMode = process.env['NODE_ENV'] !== 'production';
-            const db = new Database(filePath, isDevMode ? { verbose: console.log } : {});
-
-            const hexKey = key.toString('hex');
-            db.pragma(`key = "x'${hexKey}'"`);
-
-            // Verify
-            db.prepare('SELECT count(*) FROM sqlite_master').get();
-
-            this.db = db;
-            console.log('[Security] Database opened successfully');
-        } catch (error: any) {
-            console.error('[Security] Database initialization failed:', error);
-            if (error.message && (error.message.includes('file is not a database') || error.message.includes('SqliteError'))) {
-                throw new Error('INVALID_PASSWORD');
-            }
+            this.initDb(dbPath, dek);
+            this.bindVault(config.vaultId, config.keyVersion, true);
+            this.db.pragma('wal_checkpoint(TRUNCATE)');
+            this.step('setup-after-bind');
+            this.saveConfigAtomic(config);
+            this.step('setup-after-config-commit');
+            journal.phase = 'vault-created';
+            this.saveSetupJournal(journal);
+            this.dek = dek;
+            return recoveryCode;
+        } catch (error) {
+            this.closeDb();
+            this.rollbackSetup(journal);
             throw error;
         }
     }
 
-    getDb() { return this.db; }
-    closeDb() {
-        if (this.db) {
-            this.db.close();
-            this.db = null;
-            this.dek = null; // Clear key from memory on close
+    /** Marks the entire setup pipeline (vault, schema, settings, admin) durable. */
+    completeProvisioning(): void {
+        const journal = this.loadSetupJournal();
+        if (!journal || journal.phase !== 'vault-created') throw new Error('PROVISIONING_NOT_STARTED');
+        this.db?.pragma('wal_checkpoint(TRUNCATE)');
+        journal.phase = 'complete';
+        this.saveSetupJournal(journal);
+        this.cleanupSetupJournal();
+    }
+
+    /** Rolls back only files created by the in-progress fresh provisioning. */
+    abortProvisioning(): void {
+        const journal = this.loadSetupJournal();
+        if (!journal || journal.phase === 'complete') return;
+        this.rollbackSetup(journal);
+    }
+
+    /** Reconciles an interrupted setup before setup-state is presented. */
+    reconcileProvisioning(dbPath: string, userDataPath: string): void {
+        this.configurePaths(dbPath, userDataPath);
+        this.reconcileSetupJournal();
+    }
+
+    /** Unlock v3 using only the OS-bound device envelope. */
+    async initializeDevice(dbPath: string, userDataPath: string): Promise<VaultUnlockResult> {
+        this.configurePaths(dbPath, userDataPath);
+        this.reconcileSetupJournal();
+        this.reconcileMigrationJournal();
+        const status = this.isSetup(userDataPath);
+        if (!status.isSetup) throw new Error('NOT_SETUP');
+        if (status.vaultState === 'legacy-migration-required') throw new Error('LEGACY_MIGRATION_REQUIRED');
+        if (status.vaultState === 'corrupt') throw new Error('SECURITY_CONFIG_CORRUPT');
+        this.assertDeviceStoreAvailable();
+        const config = this.loadConfigV3();
+        try {
+            const dek = this.unprotectDeviceDek(config);
+            this.initDb(dbPath, dek);
+            this.bindVault(config.vaultId, config.keyVersion, false);
+            this.dek = dek;
+            return { migrated: false };
+        } catch (error: any) {
+            this.closeDb();
+            if (error?.message === 'VAULT_BINDING_MISMATCH') throw error;
+            throw new Error('DEVICE_UNLOCK_FAILED');
         }
     }
-    getDbPath() { return this.dbPath; }
+
+    /** One-time compatibility path. The legacy secret is never retained in v3. */
+    async migrateLegacy(legacySecret: string, dbPath: string, userDataPath: string): Promise<VaultUnlockResult> {
+        this.configurePaths(dbPath, userDataPath);
+        this.assertDeviceStoreAvailable();
+        this.reconcileMigrationJournal();
+        const configPath = path.join(userDataPath, CONFIG_FILE);
+        if (fs.existsSync(configPath)) {
+            const parsed = JSON.parse(fs.readFileSync(configPath, 'utf8')) as SecurityConfigV3 | SecurityConfigV2;
+            if (parsed.version === 3) return this.initializeDevice(dbPath, userDataPath);
+            if (parsed.version !== 2) throw new Error('UNSUPPORTED_SECURITY_CONFIG');
+            return this.migrateV2(parsed, legacySecret);
+        }
+        const saltPath = path.join(userDataPath, LEGACY_SALT_FILE);
+        if (!fs.existsSync(saltPath)) throw new Error('NOT_SETUP');
+        return this.migrateV1(legacySecret, saltPath);
+    }
+
+    /** Re-enrol this device from the portable recovery envelope. */
+    async recoverDevice(recoveryCode: string, userDataPath: string, dbPath: string): Promise<VaultUnlockResult> {
+        this.configurePaths(dbPath, userDataPath);
+        this.assertDeviceStoreAvailable();
+        const status = this.isSetup(userDataPath);
+        if (status.configVersion === 2) {
+            return this.migrateLegacy(recoveryCode, dbPath, userDataPath);
+        }
+        const config = this.loadConfigV3();
+        const previousConfigText = fs.readFileSync(path.join(userDataPath, CONFIG_FILE), 'utf8');
+        let dek: Buffer;
+        let usedTransition = false;
+        this.validateRecoveryEnvelope(config.recovery);
+        try {
+            dek = await this.unwrapRecovery(config.recovery, recoveryCode, config.vaultId, config.keyVersion);
+        } catch {
+            if (config.transitionRecovery?.purpose !== 'legacy-transition') throw new Error('INVALID_RECOVERY_CODE');
+            this.validateRecoveryEnvelope(config.transitionRecovery);
+            try {
+                dek = await this.unwrapRecovery(
+                    config.transitionRecovery,
+                    recoveryCode,
+                    config.vaultId,
+                    config.keyVersion,
+                    'legacy-transition'
+                );
+                usedTransition = true;
+            } catch { throw new Error('INVALID_RECOVERY_CODE'); }
+        }
+        try {
+            this.initDb(dbPath, dek);
+            this.bindVault(config.vaultId, config.keyVersion, false);
+        } catch (error: any) {
+            this.closeDb();
+            dek.fill(0);
+            if (error?.message === 'VAULT_BINDING_MISMATCH') throw error;
+            throw new Error('INVALID_RECOVERY_CODE');
+        }
+        try {
+            const updated: SecurityConfigV3 = {
+                ...config,
+                device: this.createDeviceEnvelope(dek, config.vaultId, config.keyVersion)
+            };
+            if (usedTransition) {
+                const freshCode = this.generateRecoveryCodeString();
+                updated.recovery = await this.createRecoveryEnvelope(dek, freshCode, config.vaultId, config.keyVersion);
+                updated.transitionRecovery = await this.createTransitionRecoveryEnvelope(
+                    dek, recoveryCode, config.vaultId, config.keyVersion
+                );
+                updated.pendingRecoveryAck = this.createPendingRecoveryAck(
+                    freshCode, config.vaultId, config.keyVersion, 'transition-recovery'
+                );
+            } else {
+                // Possession of the primary code retires every transitional artifact.
+                delete updated.pendingRecoveryAck;
+                delete updated.transitionRecovery;
+            }
+            this.saveConfigAtomic(updated);
+            this.dek = dek;
+            return { migrated: false };
+        } catch (error) {
+            this.failEnrollment(dek, previousConfigText);
+            throw error;
+        }
+    }
+
+    async regenerateRecoveryCode(): Promise<string> {
+        if (!this.dek) throw new Error('VAULT_LOCKED');
+        const config = this.loadConfigV3();
+        const recoveryCode = this.generateRecoveryCodeString();
+        config.recovery = await this.createRecoveryEnvelope(this.dek, recoveryCode, config.vaultId, config.keyVersion);
+        this.saveConfigAtomic(config);
+        return recoveryCode;
+    }
+
+    /** Re-wrap the unchanged DEK for this device; independent of all user credentials. */
+    rotateDeviceEnvelope(): void {
+        if (!this.dek) throw new Error('VAULT_LOCKED');
+        this.assertDeviceStoreAvailable();
+        const config = this.loadConfigV3();
+        config.device = this.createDeviceEnvelope(this.dek, config.vaultId, config.keyVersion);
+        this.saveConfigAtomic(config);
+    }
+
+    getPendingRecoveryCode(): string | null {
+        const config = this.loadConfigV3();
+        if (!config.pendingRecoveryAck) return null;
+        const payload = this.unprotectContextPayload(config.pendingRecoveryAck.protectedPayload);
+        if (payload.version !== 1 || payload.purpose !== 'recovery-ack' ||
+            payload.vaultId !== config.vaultId || payload.keyVersion !== config.keyVersion ||
+            typeof payload.recoveryCode !== 'string') {
+            throw new Error('PENDING_RECOVERY_CONTEXT_MISMATCH');
+        }
+        return payload.recoveryCode;
+    }
+
+    acknowledgePendingRecoveryCode(recoveryCode: string): void {
+        const config = this.loadConfigV3();
+        if (!config.pendingRecoveryAck) throw new Error('NO_PENDING_RECOVERY_CODE');
+        const pending = this.getPendingRecoveryCode();
+        if (!pending || !this.constantTimeEqual(pending, recoveryCode)) throw new Error('INVALID_RECOVERY_ACK');
+        delete config.pendingRecoveryAck;
+        delete config.transitionRecovery;
+        this.saveConfigAtomic(config);
+    }
+
+    /** Frozen portable contract consumed by issue #8. */
+    getPortableVaultMetadata(): Pick<SecurityConfigV3, 'version' | 'vaultId' | 'keyVersion' | 'recovery' | 'transitionRecovery'> {
+        const { version, vaultId, keyVersion, recovery, transitionRecovery } = this.loadConfigV3();
+        return { version, vaultId, keyVersion, recovery, ...(transitionRecovery ? { transitionRecovery } : {}) };
+    }
+
+    /** Frozen restore contract consumed by issue #8. */
+    async installPortableVaultMetadata(
+        metadata: Pick<SecurityConfigV3, 'version' | 'vaultId' | 'keyVersion' | 'recovery' | 'transitionRecovery'>,
+        recoveryCode: string,
+        dbPath: string,
+        userDataPath: string
+    ): Promise<void> {
+        this.configurePaths(dbPath, userDataPath);
+        this.assertDeviceStoreAvailable();
+        const configPath = path.join(userDataPath, CONFIG_FILE);
+        const previousConfigText = fs.existsSync(configPath)
+            ? fs.readFileSync(configPath, 'utf8')
+            : undefined;
+        let dek: Buffer;
+        let usedTransition = false;
+        this.validateRecoveryEnvelope(metadata.recovery);
+        try {
+            dek = await this.unwrapRecovery(metadata.recovery, recoveryCode, metadata.vaultId, metadata.keyVersion);
+        } catch {
+            if (metadata.transitionRecovery?.purpose !== 'legacy-transition') throw new Error('INVALID_RECOVERY_CODE');
+            this.validateRecoveryEnvelope(metadata.transitionRecovery);
+            dek = await this.unwrapRecovery(
+                metadata.transitionRecovery,
+                recoveryCode,
+                metadata.vaultId,
+                metadata.keyVersion,
+                'legacy-transition'
+            );
+            usedTransition = true;
+        }
+        try {
+            this.initDb(dbPath, dek);
+            this.bindVault(metadata.vaultId, metadata.keyVersion, false);
+        } catch (error) {
+            this.closeDb();
+            dek.fill(0);
+            throw error;
+        }
+        try {
+            const config: SecurityConfigV3 = {
+                ...metadata,
+                device: this.createDeviceEnvelope(dek, metadata.vaultId, metadata.keyVersion)
+            };
+            if (usedTransition) {
+                const freshCode = this.generateRecoveryCodeString();
+                config.recovery = await this.createRecoveryEnvelope(
+                    dek, freshCode, metadata.vaultId, metadata.keyVersion
+                );
+                config.transitionRecovery = await this.createTransitionRecoveryEnvelope(
+                    dek, recoveryCode, metadata.vaultId, metadata.keyVersion
+                );
+                config.pendingRecoveryAck = this.createPendingRecoveryAck(
+                    freshCode, metadata.vaultId, metadata.keyVersion, 'transition-recovery'
+                );
+            } else {
+                delete config.pendingRecoveryAck;
+                delete config.transitionRecovery;
+            }
+            this.saveConfigAtomic(config);
+            this.dek = dek;
+        } catch (error) {
+            this.failEnrollment(dek, previousConfigText);
+            throw error;
+        }
+    }
+
+    generateRecoveryCodeString(): string {
+        const hex = crypto.randomBytes(16).toString('hex').toUpperCase();
+        return `${hex.slice(0, 8)}-${hex.slice(8, 16)}-${hex.slice(16, 24)}-${hex.slice(24, 32)}`;
+    }
+
+    async deriveKey(secret: string, salt: Buffer): Promise<Buffer> {
+        return argon2.hash(secret, {
+            type: argon2.argon2id,
+            raw: true,
+            salt,
+            ...RECOVERY_KDF_PARAMS
+        });
+    }
+
+    getDb(): any { return this.db; }
+    getDbPath(): string { return this.dbPath; }
+    getVaultId(): string | null { try { return this.loadConfigV3().vaultId; } catch { return null; } }
+
+    closeDb(): void {
+        if (this.db) this.db.close();
+        this.db = null;
+        if (this.dek) this.dek.fill(0);
+        this.dek = null;
+    }
+
+    private async migrateV2(config: SecurityConfigV2, secret: string): Promise<VaultUnlockResult> {
+        let oldDek: Buffer;
+        try {
+            oldDek = await this.unwrapLegacy(config.wrappedKey, config.iv, config.salt, secret);
+        } catch {
+            if (!config.recovery) throw new Error('INVALID_LEGACY_CREDENTIAL');
+            try {
+                oldDek = await this.unwrapLegacy(
+                    config.recovery.wrappedKey,
+                    config.recovery.iv,
+                    config.recovery.salt,
+                    secret
+                );
+            } catch { throw new Error('INVALID_LEGACY_CREDENTIAL'); }
+        }
+        try {
+            this.initDb(this.dbPath, oldDek);
+            this.db.pragma('wal_checkpoint(TRUNCATE)');
+            this.closeDb();
+        } catch {
+            this.closeDb();
+            throw new Error('INVALID_LEGACY_CREDENTIAL');
+        }
+        return this.commitLegacyMigration(2, oldDek, this.generateRecoveryCodeString(), secret, false);
+    }
+
+    private async migrateV1(secret: string, saltPath: string): Promise<VaultUnlockResult> {
+        const oldKey = await this.deriveLegacyKey(secret, fs.readFileSync(saltPath));
+        try { this.initDb(this.dbPath, oldKey); } catch { throw new Error('INVALID_LEGACY_CREDENTIAL'); }
+        this.db.pragma('wal_checkpoint(TRUNCATE)');
+        this.closeDb();
+        return this.commitLegacyMigration(1, crypto.randomBytes(32), this.generateRecoveryCodeString(), secret, true, oldKey, saltPath);
+    }
+
+    private async commitLegacyMigration(
+        sourceVersion: 1 | 2,
+        dek: Buffer,
+        recoveryCode: string,
+        legacySecret: string,
+        rekey: boolean,
+        oldKey?: Buffer,
+        saltPath?: string
+    ): Promise<VaultUnlockResult> {
+        const backup = `${this.dbPath}.pre-v3-migration`;
+        const configPath = path.join(this.appUserDataPath, CONFIG_FILE);
+        const configBackup = `${configPath}.pre-v3-migration`;
+        const journal: MigrationJournal = {
+            version: 1,
+            sourceVersion,
+            phase: 'snapshot-created',
+            databaseBackup: backup,
+            configBackup: fs.existsSync(configPath) ? configBackup : undefined,
+            legacySaltPath: saltPath,
+            startedAt: new Date().toISOString()
+        };
+        fs.copyFileSync(this.dbPath, backup);
+        this.fsyncFile(backup);
+        if (journal.configBackup) {
+            fs.copyFileSync(configPath, journal.configBackup);
+            this.fsyncFile(journal.configBackup);
+        }
+        this.saveJournal(journal);
+        this.step('migration-after-snapshot');
+        let committed = false;
+        try {
+            if (rekey) {
+                this.initDb(this.dbPath, oldKey!);
+                this.db.pragma(`rekey = "x'${dek.toString('hex')}'"`);
+                this.db.pragma('wal_checkpoint(TRUNCATE)');
+                this.closeDb();
+                journal.phase = 'database-rekeyed';
+                this.saveJournal(journal);
+                this.step('migration-after-rekey');
+            }
+            this.initDb(this.dbPath, dek);
+            const config = await this.createV3Config(dek, recoveryCode, sourceVersion, legacySecret, 'legacy-migration');
+            this.bindVault(config.vaultId, config.keyVersion, true);
+            // Make the binding durable in the main database before the config
+            // commit becomes authoritative.
+            this.db.pragma('wal_checkpoint(TRUNCATE)');
+            this.step('migration-after-bind');
+            journal.phase = 'config-committing';
+            this.saveJournal(journal);
+            this.saveConfigAtomic(config);
+            committed = true;
+            this.step('migration-after-config-commit');
+            journal.phase = 'config-written';
+            this.saveJournal(journal);
+            this.dek = dek;
+            this.cleanupCommittedMigration(journal, saltPath);
+            return { migrated: true };
+        } catch (error) {
+            if (committed || this.hasV3Config()) {
+                this.dek = dek;
+                this.cleanupCommittedMigration(journal, saltPath);
+                return { migrated: true };
+            }
+            this.closeDb();
+            this.restoreMigrationSnapshot(journal);
+            this.cleanupRollbackArtifacts(journal);
+            throw error;
+        }
+    }
+
+    private reconcileMigrationJournal(): void {
+        const journalPath = this.journalPath();
+        if (!fs.existsSync(journalPath)) return;
+        const journal = JSON.parse(fs.readFileSync(journalPath, 'utf8')) as MigrationJournal;
+        const configCommitted = this.hasV3Config();
+        if (!configCommitted) {
+            this.closeDb();
+            if (journal.phase !== 'rollback-restored') this.restoreMigrationSnapshot(journal);
+            this.cleanupRollbackArtifacts(journal);
+            return;
+        }
+        this.cleanupCommittedMigration(journal, journal.legacySaltPath);
+    }
+
+    private async createV3Config(
+        dek: Buffer,
+        recoveryCode: string,
+        migratedFrom?: 1 | 2,
+        legacySecret?: string,
+        pendingReason?: PendingRecoveryAck['reason']
+    ): Promise<SecurityConfigV3> {
+        const vaultId = crypto.randomUUID();
+        const keyVersion = 1;
+        const config: SecurityConfigV3 = {
+            version: 3,
+            vaultId,
+            keyVersion,
+            device: this.createDeviceEnvelope(dek, vaultId, keyVersion),
+            recovery: await this.createRecoveryEnvelope(dek, recoveryCode, vaultId, keyVersion)
+        };
+        if (pendingReason) {
+            config.pendingRecoveryAck = this.createPendingRecoveryAck(
+                recoveryCode, vaultId, keyVersion, pendingReason
+            );
+        }
+        if (migratedFrom && legacySecret) {
+            config.migratedFrom = migratedFrom;
+            config.transitionRecovery = await this.createTransitionRecoveryEnvelope(
+                dek, legacySecret, vaultId, keyVersion
+            );
+        }
+        return config;
+    }
+
+    private async createRecoveryEnvelope(
+        dek: Buffer,
+        code: string,
+        vaultId: string,
+        keyVersion: number,
+        purpose: 'recovery-dek' | 'legacy-transition' = 'recovery-dek'
+    ): Promise<RecoveryEnvelope> {
+        const salt = crypto.randomBytes(16);
+        const wrapped = this.aesEncrypt(
+            dek,
+            await this.deriveKey(code, salt),
+            this.recoveryAad(vaultId, keyVersion, purpose)
+        );
+        return {
+            algorithm: 'aes-256-gcm',
+            kdf: 'argon2id',
+            kdfParams: { ...RECOVERY_KDF_PARAMS },
+            aadVersion: 1,
+            salt: salt.toString('hex'),
+            ...wrapped
+        };
+    }
+
+    private async unwrapRecovery(
+        envelope: RecoveryEnvelope,
+        code: string,
+        vaultId: string,
+        keyVersion: number,
+        purpose: 'recovery-dek' | 'legacy-transition' = 'recovery-dek'
+    ): Promise<Buffer> {
+        this.validateRecoveryEnvelope(envelope);
+        const salt = Buffer.from(envelope.salt, 'hex');
+        const key = await argon2.hash(code, {
+            type: argon2.argon2id,
+            raw: true,
+            salt,
+            ...envelope.kdfParams
+        });
+        return this.aesDecrypt(envelope.wrappedKey, envelope.iv, key, this.recoveryAad(vaultId, keyVersion, purpose));
+    }
+
+    private validateRecoveryEnvelope(envelope: RecoveryEnvelope): void {
+        const params = envelope?.kdfParams;
+        const validHex = (value: unknown, bytes: number) =>
+            typeof value === 'string' && value.length === bytes * 2 && /^[0-9a-f]+$/i.test(value);
+        if (envelope?.algorithm !== 'aes-256-gcm' || envelope?.kdf !== 'argon2id' || envelope?.aadVersion !== 1 ||
+            !validHex(envelope.salt, 16) || !validHex(envelope.iv, 12) ||
+            typeof envelope.wrappedKey !== 'string' || envelope.wrappedKey.length !== 96 ||
+            !/^[0-9a-f]+$/i.test(envelope.wrappedKey) || !params ||
+            !Number.isInteger(params.timeCost) || params.timeCost < 1 || params.timeCost > 10 ||
+            !Number.isInteger(params.memoryCost) || params.memoryCost < 8192 || params.memoryCost > 1048576 ||
+            !Number.isInteger(params.parallelism) || params.parallelism < 1 || params.parallelism > 16 ||
+            params.hashLength !== 32) {
+            throw new Error('INVALID_RECOVERY_ENVELOPE');
+        }
+    }
+
+    private async unwrapLegacy(wrappedKey: string, iv: string, salt: string, secret: string): Promise<Buffer> {
+        return this.aesDecrypt(wrappedKey, iv, await this.deriveLegacyKey(secret, Buffer.from(salt, 'hex')));
+    }
+
+    private async deriveLegacyKey(secret: string, salt: Buffer): Promise<Buffer> {
+        return argon2.hash(secret, { type: argon2.argon2id, raw: true, salt });
+    }
+
+    private aesEncrypt(data: Buffer, key: Buffer, aad?: Buffer): { wrappedKey: string; iv: string } {
+        const iv = crypto.randomBytes(12);
+        const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+        if (aad) cipher.setAAD(aad);
+        const ciphertext = Buffer.concat([cipher.update(data), cipher.final()]);
+        return { wrappedKey: Buffer.concat([cipher.getAuthTag(), ciphertext]).toString('hex'), iv: iv.toString('hex') };
+    }
+
+    private aesDecrypt(value: string, ivHex: string, key: Buffer, aad?: Buffer): Buffer {
+        const valueBuffer = Buffer.from(value, 'hex');
+        const decipher = crypto.createDecipheriv('aes-256-gcm', key, Buffer.from(ivHex, 'hex'));
+        if (aad) decipher.setAAD(aad);
+        decipher.setAuthTag(valueBuffer.subarray(0, 16));
+        return Buffer.concat([decipher.update(valueBuffer.subarray(16)), decipher.final()]);
+    }
+
+    private bindVault(vaultId: string, keyVersion: number, create: boolean): void {
+        if (create) {
+            this.db.exec(`CREATE TABLE IF NOT EXISTS ${VAULT_TABLE} (singleton INTEGER PRIMARY KEY CHECK(singleton = 1), vault_id TEXT NOT NULL, key_version INTEGER NOT NULL)`);
+        }
+        let row;
+        try {
+            row = this.db.prepare(`SELECT vault_id, key_version FROM ${VAULT_TABLE} WHERE singleton = 1`).get();
+        } catch {
+            throw new Error('VAULT_BINDING_MISMATCH');
+        }
+        if (!row && create) {
+            this.db.prepare(`INSERT INTO ${VAULT_TABLE} (singleton, vault_id, key_version) VALUES (1, ?, ?)`).run(vaultId, keyVersion);
+            return;
+        }
+        if (!row || row.vault_id !== vaultId || row.key_version !== keyVersion) throw new Error('VAULT_BINDING_MISMATCH');
+    }
+
+    private initDb(filePath: string, key: Buffer): void {
+        // Never enable verbose SQL logging here: SQLCipher's key PRAGMA would
+        // disclose the live DEK to logs even in a development build.
+        const db = new Database(filePath);
+        try {
+            db.pragma(`key = "x'${key.toString('hex')}'"`);
+            db.prepare('SELECT count(*) FROM sqlite_master').get();
+            this.db = db;
+        } catch (error: any) {
+            db.close();
+            if (String(error?.message).includes('file is not a database')) throw new Error('INVALID_PASSWORD');
+            throw error;
+        }
+    }
+
+    private configurePaths(dbPath: string, userDataPath: string): void {
+        this.dbPath = dbPath;
+        this.appUserDataPath = userDataPath;
+    }
+
+    private assertDeviceStoreAvailable(): void {
+        const status = this.deviceKeyStore.status();
+        if (!status.available) throw new Error(status.reason || 'DEVICE_KEY_UNAVAILABLE');
+    }
+
+    private loadConfigV3(): SecurityConfigV3 {
+        const config = JSON.parse(fs.readFileSync(path.join(this.appUserDataPath, CONFIG_FILE), 'utf8')) as SecurityConfigV3;
+        if (config.version !== 3) throw new Error('LEGACY_MIGRATION_REQUIRED');
+        if (!config.vaultId || !Number.isInteger(config.keyVersion) || config.keyVersion < 1 ||
+            !config.device?.protectedPayload || !config.recovery?.wrappedKey || !config.recovery?.kdfParams) {
+            throw new Error('SECURITY_CONFIG_CORRUPT');
+        }
+        return config;
+    }
+
+    private saveConfigAtomic(config: SecurityConfigV3): void {
+        fs.mkdirSync(this.appUserDataPath, { recursive: true });
+        const target = path.join(this.appUserDataPath, CONFIG_FILE);
+        const temporary = `${target}.tmp`;
+        const fd = fs.openSync(temporary, 'w', 0o600);
+        try {
+            fs.writeFileSync(fd, JSON.stringify(config, null, 2), 'utf8');
+            this.fsyncDescriptor(fd);
+        } finally { fs.closeSync(fd); }
+        fs.renameSync(temporary, target);
+        this.fsyncDirectory();
+    }
+
+    private failEnrollment(dek: Buffer, previousConfigText?: string): void {
+        this.closeDb();
+        dek.fill(0);
+        const target = path.join(this.appUserDataPath, CONFIG_FILE);
+        const temporary = `${target}.tmp`;
+        if (previousConfigText === undefined) {
+            for (const file of [target, temporary]) {
+                if (fs.existsSync(file)) fs.unlinkSync(file);
+            }
+            this.fsyncDirectory();
+            return;
+        }
+        this.saveTextAtomic(target, previousConfigText);
+    }
+
+    private saveTextAtomic(target: string, text: string): void {
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        const temporary = `${target}.tmp`;
+        const fd = fs.openSync(temporary, 'w', 0o600);
+        try {
+            fs.writeFileSync(fd, text, 'utf8');
+            this.fsyncDescriptor(fd);
+        } finally { fs.closeSync(fd); }
+        fs.renameSync(temporary, target);
+        this.fsyncDirectory();
+    }
+
+    private journalPath(): string { return path.join(this.appUserDataPath, JOURNAL_FILE); }
+    private saveJournal(journal: MigrationJournal): void {
+        const target = this.journalPath();
+        const temporary = `${target}.tmp`;
+        const fd = fs.openSync(temporary, 'w', 0o600);
+        try {
+            fs.writeFileSync(fd, JSON.stringify(journal, null, 2), 'utf8');
+            this.fsyncDescriptor(fd);
+        } finally { fs.closeSync(fd); }
+        fs.renameSync(temporary, target);
+        this.fsyncDirectory();
+    }
+
+    private hasV3Config(): boolean {
+        try {
+            const config = JSON.parse(fs.readFileSync(path.join(this.appUserDataPath, CONFIG_FILE), 'utf8'));
+            return config.version === 3 && !!config.vaultId && !!config.device?.protectedPayload;
+        } catch { return false; }
+    }
+
+    private restoreMigrationSnapshot(journal: MigrationJournal): void {
+        if (!fs.existsSync(journal.databaseBackup)) throw new Error('MIGRATION_SNAPSHOT_MISSING');
+        if (journal.configBackup && !fs.existsSync(journal.configBackup)) throw new Error('MIGRATION_SNAPSHOT_MISSING');
+        for (const suffix of ['-wal', '-shm']) {
+            const sidecar = `${this.dbPath}${suffix}`;
+            if (fs.existsSync(sidecar)) fs.unlinkSync(sidecar);
+        }
+        if (fs.existsSync(journal.databaseBackup)) fs.copyFileSync(journal.databaseBackup, this.dbPath);
+        const configPath = path.join(this.appUserDataPath, CONFIG_FILE);
+        if (journal.configBackup && fs.existsSync(journal.configBackup)) {
+            fs.copyFileSync(journal.configBackup, configPath);
+        } else if (fs.existsSync(configPath)) {
+            fs.unlinkSync(configPath);
+        }
+        journal.phase = 'rollback-restored';
+        this.saveJournal(journal);
+    }
+
+    private createDeviceEnvelope(dek: Buffer, vaultId: string, keyVersion: number): SecurityConfigV3['device'] {
+        return {
+            provider: this.deviceKeyStore.status().provider,
+            protectedPayload: this.protectContextPayload({
+                version: 1,
+                purpose: 'device-dek',
+                vaultId,
+                keyVersion,
+                dek: dek.toString('base64')
+            })
+        };
+    }
+
+    private createPendingRecoveryAck(
+        recoveryCode: string,
+        vaultId: string,
+        keyVersion: number,
+        reason: PendingRecoveryAck['reason']
+    ): PendingRecoveryAck {
+        return {
+            protectedPayload: this.protectContextPayload({
+                version: 1,
+                purpose: 'recovery-ack',
+                vaultId,
+                keyVersion,
+                recoveryCode
+            }),
+            createdAt: new Date().toISOString(),
+            reason
+        };
+    }
+
+    private async createTransitionRecoveryEnvelope(
+        dek: Buffer,
+        legacySecret: string,
+        vaultId: string,
+        keyVersion: number
+    ): Promise<TransitionRecoveryEnvelope> {
+        return {
+            ...await this.createRecoveryEnvelope(
+                dek, legacySecret, vaultId, keyVersion, 'legacy-transition'
+            ),
+            purpose: 'legacy-transition'
+        };
+    }
+
+    private unprotectDeviceDek(config: SecurityConfigV3): Buffer {
+        const payload = this.unprotectContextPayload(config.device.protectedPayload);
+        if (payload.version !== 1 || payload.purpose !== 'device-dek' ||
+            payload.vaultId !== config.vaultId || payload.keyVersion !== config.keyVersion ||
+            typeof payload.dek !== 'string') {
+            throw new Error('VAULT_BINDING_MISMATCH');
+        }
+        const dek = Buffer.from(payload.dek, 'base64');
+        if (dek.length !== 32) throw new Error('INVALID_DEVICE_ENVELOPE');
+        return dek;
+    }
+
+    private protectContextPayload(payload: Record<string, unknown>): string {
+        return this.deviceKeyStore.protect(Buffer.from(JSON.stringify(payload), 'utf8')).toString('base64');
+    }
+
+    private unprotectContextPayload(value: string): any {
+        try {
+            return JSON.parse(this.deviceKeyStore.unprotect(Buffer.from(value, 'base64')).toString('utf8'));
+        } catch { throw new Error('INVALID_DEVICE_ENVELOPE'); }
+    }
+
+    private recoveryAad(
+        vaultId: string,
+        keyVersion: number,
+        purpose: 'recovery-dek' | 'legacy-transition' = 'recovery-dek'
+    ): Buffer {
+        return Buffer.from(`nalamdesk|v3|${purpose}|${vaultId}|${keyVersion}`, 'utf8');
+    }
+
+    private constantTimeEqual(left: string, right: string): boolean {
+        const leftBuffer = Buffer.from(left, 'utf8');
+        const rightBuffer = Buffer.from(right, 'utf8');
+        if (leftBuffer.length !== rightBuffer.length) {
+            // Keep a fixed-cost comparison even when lengths differ.
+            crypto.timingSafeEqual(leftBuffer, Buffer.alloc(leftBuffer.length));
+            return false;
+        }
+        return crypto.timingSafeEqual(leftBuffer, rightBuffer);
+    }
+
+    private cleanupCommittedMigration(journal: MigrationJournal, saltPath?: string): void {
+        let clean = true;
+        const attempt = (step: SecurityStep, action: () => void) => {
+            try { this.step(step); action(); } catch { clean = false; }
+        };
+        if (saltPath && fs.existsSync(saltPath)) {
+            attempt('cleanup-legacy-salt', () => fs.renameSync(saltPath, `${saltPath}.migrated`));
+        }
+        if (fs.existsSync(journal.databaseBackup)) {
+            attempt('cleanup-database-backup', () => fs.unlinkSync(journal.databaseBackup));
+        }
+        if (journal.configBackup && fs.existsSync(journal.configBackup)) {
+            attempt('cleanup-config-backup', () => fs.unlinkSync(journal.configBackup!));
+        }
+        if (clean && fs.existsSync(this.journalPath())) {
+            attempt('cleanup-journal', () => fs.unlinkSync(this.journalPath()));
+        }
+    }
+
+    private cleanupRollbackArtifacts(journal: MigrationJournal): void {
+        let clean = true;
+        const attempt = (step: SecurityStep, file?: string) => {
+            if (!file || !fs.existsSync(file)) return;
+            try { this.step(step); fs.unlinkSync(file); } catch { clean = false; }
+        };
+        attempt('cleanup-rollback-database-backup', journal.databaseBackup);
+        attempt('cleanup-rollback-config-backup', journal.configBackup);
+        if (clean) attempt('cleanup-rollback-journal', this.journalPath());
+    }
+
+    private setupJournalPath(): string { return path.join(this.appUserDataPath, SETUP_JOURNAL_FILE); }
+    private saveSetupJournal(journal: SetupJournal): void {
+        this.saveJsonAtomic(this.setupJournalPath(), journal);
+    }
+
+    private loadSetupJournal(): SetupJournal | null {
+        try { return JSON.parse(fs.readFileSync(this.setupJournalPath(), 'utf8')) as SetupJournal; }
+        catch { return null; }
+    }
+
+    private reconcileSetupJournal(): void {
+        const journalPath = this.setupJournalPath();
+        if (!fs.existsSync(journalPath)) return;
+        const journal = JSON.parse(fs.readFileSync(journalPath, 'utf8')) as SetupJournal;
+        if (journal.phase === 'complete') this.cleanupSetupJournal();
+        else this.rollbackSetup(journal);
+    }
+
+    private rollbackSetup(journal: SetupJournal): void {
+        this.closeDb();
+        if (journal.databaseCreated) {
+            for (const file of [this.dbPath, `${this.dbPath}-wal`, `${this.dbPath}-shm`]) {
+                if (fs.existsSync(file)) fs.unlinkSync(file);
+            }
+        }
+        const configPath = path.join(this.appUserDataPath, CONFIG_FILE);
+        for (const file of [configPath, `${configPath}.tmp`]) {
+            if (fs.existsSync(file)) fs.unlinkSync(file);
+        }
+        this.cleanupSetupJournal();
+    }
+
+    private cleanupSetupJournal(): void {
+        try {
+            this.step('cleanup-setup-journal');
+            if (fs.existsSync(this.setupJournalPath())) fs.unlinkSync(this.setupJournalPath());
+        } catch { /* committed setup is authoritative; reconcile cleanup on next start */ }
+    }
+
+    private saveJsonAtomic(target: string, value: unknown): void {
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        const temporary = `${target}.tmp`;
+        const fd = fs.openSync(temporary, 'w', 0o600);
+        try {
+            fs.writeFileSync(fd, JSON.stringify(value, null, 2), 'utf8');
+            this.fsyncDescriptor(fd);
+        } finally { fs.closeSync(fd); }
+        fs.renameSync(temporary, target);
+        this.fsyncDirectory();
+    }
+
+    private step(step: SecurityStep): void { this.hooks.onStep?.(step); }
+
+    private fsyncFile(filePath: string): void {
+        // Windows FlushFileBuffers requires a handle opened with write access.
+        // POSIX accepts a read-only descriptor and avoids broadening access.
+        const platform = this.hooks.platform ?? process.platform;
+        const fd = fs.openSync(filePath, platform === 'win32' ? 'r+' : 'r');
+        try { this.fsyncDescriptor(fd); } finally { fs.closeSync(fd); }
+    }
+
+    private fsyncDirectory(): void {
+        const platform = this.hooks.platform ?? process.platform;
+        try {
+            const directory = fs.openSync(this.appUserDataPath, 'r');
+            try { this.fsyncDescriptor(directory); } finally { fs.closeSync(directory); }
+        } catch (error) {
+            // Windows does not expose directory handles compatible with fsync.
+            // All other failures remain fatal so supported platforms retain
+            // the durability guarantee.
+            if (!this.isUnsupportedWindowsFsync(error, platform)) throw error;
+        }
+    }
+
+    private fsyncDescriptor(fd: number): void {
+        // Regular files are opened writable (including r+ on Windows), so an
+        // fsync failure is a real durability failure and must never be hidden.
+        (this.hooks.fsync ?? fs.fsyncSync)(fd);
+    }
+
+    private isUnsupportedWindowsFsync(error: unknown, platform: NodeJS.Platform): boolean {
+        if (platform !== 'win32' || !error || typeof error !== 'object') return false;
+        const code = (error as NodeJS.ErrnoException).code;
+        return code === 'EPERM' || code === 'EINVAL' || code === 'ENOSYS' || code === 'ENOTSUP';
+    }
 }

--- a/desktop/src/main/services/SessionService.spec.ts
+++ b/desktop/src/main/services/SessionService.spec.ts
@@ -39,4 +39,21 @@ describe('SessionService', () => {
         expect(service.getUser()).toBeNull();
         expect(service.isAuthenticated()).toBe(false);
     });
+
+    it('allowlists session fields and never retains a password hash', () => {
+        service.setUser({
+            id: 1,
+            username: 'admin',
+            role: 'admin',
+            name: 'Administrator',
+            password_reset_required: 0,
+            password: '$argon2id$secret-hash'
+        } as any);
+        const session = service.getUser() as any;
+        expect(session.password).toBeUndefined();
+        expect(session.password_reset_required).toBe(0);
+        expect(Object.keys(session).sort()).toEqual([
+            'id', 'name', 'password_reset_required', 'role', 'sessionId', 'username'
+        ]);
+    });
 });

--- a/desktop/src/main/services/SessionService.ts
+++ b/desktop/src/main/services/SessionService.ts
@@ -7,6 +7,7 @@ export interface UserSession {
     name: string;
     specialty?: string;
     license_number?: string;
+    password_reset_required?: number;
     sessionId?: string;
 }
 
@@ -18,7 +19,13 @@ export class SessionService {
             throw new Error('Invalid user session data');
         }
         this.currentUser = {
-            ...user,
+            id: user.id,
+            username: user.username,
+            role: user.role,
+            name: user.name,
+            ...(user.specialty ? { specialty: user.specialty } : {}),
+            ...(user.license_number ? { license_number: user.license_number } : {}),
+            ...(user.password_reset_required !== undefined ? { password_reset_required: user.password_reset_required } : {}),
             sessionId: crypto.randomUUID()
         };
     }

--- a/desktop/src/main/verify-security.ts
+++ b/desktop/src/main/verify-security.ts
@@ -1,5 +1,6 @@
 
 import { SecurityService } from './services/SecurityService';
+import type { DeviceKeyStore } from './services/DeviceKeyStore';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -10,11 +11,17 @@ async function testSecurity() {
     if (!fs.existsSync(userDataPath)) fs.mkdirSync(userDataPath);
     if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
 
-    const security = new SecurityService();
-    const password = 'mySecretPassword';
+    let protectedKey: Buffer | null = null;
+    const deviceStore: DeviceKeyStore = {
+        status: () => ({ available: true, provider: 'verification-memory-store' }),
+        protect: (value) => { protectedKey = Buffer.from(value); return Buffer.from(value); },
+        unprotect: () => { if (!protectedKey) throw new Error('missing key'); return Buffer.from(protectedKey); }
+    };
+    const security = new SecurityService(deviceStore);
+    const password = 'adminLoginPassword';
 
-    console.log('1. Initializing DB (Fresh)...');
-    await security.initialize(password, dbPath, userDataPath);
+    console.log('1. Creating a fresh device-bound vault...');
+    await security.setup(password, dbPath, userDataPath);
 
     const db = security.getDb();
     db.exec(`CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY, secret TEXT)`);
@@ -23,23 +30,10 @@ async function testSecurity() {
     console.log('2. Data inserted. Closing DB.');
     security.closeDb();
 
-    console.log('3. Attempting to open with WRONG password...');
-    const security2 = new SecurityService();
+    console.log('3. Cold-starting without a user password...');
     try {
-        await security2.initialize('wrongPassword', dbPath, userDataPath);
-        console.error('FAIL: Database should NOT open with wrong key!');
-    } catch (e: any) {
-        if (e.message === 'INVALID_PASSWORD') {
-            console.log('PASS: Correctly rejected wrong password.');
-        } else {
-            console.error('FAIL: Unexpected error:', e);
-        }
-    }
-
-    console.log('4. Attempting to open with CORRECT password...');
-    try {
-        const security3 = new SecurityService();
-        await security3.initialize(password, dbPath, userDataPath);
+        const security3 = new SecurityService(deviceStore);
+        await security3.initializeDevice(dbPath, userDataPath);
         const row = security3.getDb().prepare('SELECT * FROM test').get() as any;
         if (row && row.secret === 'This is a secret message') {
             console.log('PASS: Data recovered successfully:', row.secret);
@@ -48,7 +42,7 @@ async function testSecurity() {
         }
         security3.closeDb();
     } catch (e) {
-        console.error('FAIL: Could not reopen with correct key:', e);
+        console.error('FAIL: Could not reopen with the device key:', e);
     }
 
     // Cleanup

--- a/desktop/src/renderer/app/login/login.component.spec.ts
+++ b/desktop/src/renderer/app/login/login.component.spec.ts
@@ -27,6 +27,7 @@ describe('LoginComponent', () => {
         mockAuthService = {
             login: vi.fn(),
             getUser: vi.fn(),
+            acknowledgeRecoveryCode: vi.fn().mockResolvedValue(undefined),
             checkSetup: vi.fn().mockResolvedValue({ isSetup: true }) // Default to setup complete
         };
         mockRuntimeService = {
@@ -47,6 +48,18 @@ describe('LoginComponent', () => {
         mockAuthService.checkSetup.mockResolvedValue({ isSetup: true });
         await component.ngOnInit();
         expect(mockRouter.navigate).not.toHaveBeenCalled();
+    });
+
+    it('explains when a legacy administrator migration is required', async () => {
+        mockAuthService.checkSetup.mockResolvedValue({ isSetup: true, vaultState: 'legacy-migration-required' });
+        await component.ngOnInit();
+        expect(component.vaultNotice).toContain('administrator must sign in once');
+    });
+
+    it('directs the user to device recovery when the OS key is unavailable', async () => {
+        mockAuthService.checkSetup.mockResolvedValue({ isSetup: true, vaultState: 'recovery-required' });
+        await component.ngOnInit();
+        expect(component.vaultNotice).toContain('Recover Device');
     });
 
     it('should initialize with default values', () => {
@@ -81,6 +94,20 @@ describe('LoginComponent', () => {
 
         expect(component.isLoading).toBe(false);
         expect(component.error).toBe('');
+        expect(mockRouter.navigate).toHaveBeenCalledWith(['/dashboard']);
+    });
+
+    it('requires acknowledgement of the new recovery code after legacy migration', async () => {
+        component.username = 'admin';
+        component.password = 'legacy-password';
+        mockAuthService.login.mockResolvedValue({ success: true, pendingRecoveryCode: 'AAAA-BBBB-CCCC-DDDD' });
+
+        await component.onLogin();
+
+        expect(component.pendingRecoveryCode).toBe('AAAA-BBBB-CCCC-DDDD');
+        expect(mockRouter.navigate).not.toHaveBeenCalled();
+        await component.acknowledgeMigration();
+        expect(mockAuthService.acknowledgeRecoveryCode).toHaveBeenCalledWith('AAAA-BBBB-CCCC-DDDD');
         expect(mockRouter.navigate).toHaveBeenCalledWith(['/dashboard']);
     });
 

--- a/desktop/src/renderer/app/login/login.component.ts
+++ b/desktop/src/renderer/app/login/login.component.ts
@@ -17,8 +17,20 @@ import { RuntimeService } from '../services/runtime.service';
         <div *ngIf="error" class="bg-red-900/50 border border-red-500 text-red-200 px-4 py-2 rounded mb-4 text-sm">
           {{ error }}
         </div>
+        <div *ngIf="vaultNotice" class="bg-blue-950/60 border border-blue-600 text-blue-100 px-4 py-2 rounded mb-4 text-sm">
+          {{ vaultNotice }}
+        </div>
 
-        <form (ngSubmit)="onLogin()">
+        <div *ngIf="pendingRecoveryCode" class="bg-amber-950 border border-amber-500 p-4 rounded mb-4 text-sm">
+          <p class="font-bold text-amber-300 mb-2">Security upgrade complete</p>
+          <p class="text-amber-100 mb-2">Save this new recovery code before continuing. The old vault password wrapper has been removed.</p>
+          <code class="block bg-gray-950 p-2 rounded select-all break-all">{{ pendingRecoveryCode }}</code>
+          <button type="button" (click)="acknowledgeMigration()" class="mt-3 w-full bg-amber-600 hover:bg-amber-700 py-2 rounded font-bold">
+            I have saved this code
+          </button>
+        </div>
+
+        <form (ngSubmit)="onLogin()" *ngIf="!pendingRecoveryCode">
           <div class="mb-4">
             <label class="block text-gray-400 text-sm font-bold mb-2" for="username">
               Username
@@ -60,7 +72,7 @@ import { RuntimeService } from '../services/runtime.service';
         </form>
         
         <div class="mt-4 text-center flex justify-between text-xs text-gray-400">
-            <a routerLink="/recover" class="hover:text-blue-400">Forgot Password?</a>
+            <a routerLink="/recover" class="hover:text-blue-400">Recover Device</a>
             <div class="flex flex-col items-end">
                 <span>Secure Local-First Access</span>
                 <div *ngIf="runtime.lanAccessUrl" class="mt-1 flex items-center gap-1.5 bg-gray-700/50 px-2 py-0.5 rounded-md border border-gray-600/30">
@@ -82,6 +94,9 @@ export class LoginComponent implements OnInit {
   password = '';
   error = '';
   isLoading = false;
+  pendingRecoveryCode = '';
+  vaultNotice = '';
+  private pendingRoute = '/dashboard';
   isElectron = !!(globalThis as any).electron;
 
   constructor(
@@ -96,6 +111,10 @@ export class LoginComponent implements OnInit {
     const status = await this.authService.checkSetup();
     if (!status.isSetup) {
       this.router.navigate(['/setup']);
+    } else if (status.vaultState === 'legacy-migration-required') {
+      this.vaultNotice = 'Security upgrade required: the administrator must sign in once. A new recovery code will be shown.';
+    } else if (status.vaultState === 'recovery-required') {
+      this.vaultNotice = 'This device cannot access its protected vault key. Use Recover Device below.';
     }
 
     if (this.isElectron) {
@@ -119,10 +138,11 @@ export class LoginComponent implements OnInit {
           const user = this.authService.getUser();
           this.password = ''; // Clear sensitive data
 
-          if (user && user.password_reset_required) {
-            this.router.navigate(['/change-password']);
+          this.pendingRoute = user && user.password_reset_required ? '/change-password' : '/dashboard';
+          if (result.pendingRecoveryCode) {
+            this.pendingRecoveryCode = result.pendingRecoveryCode;
           } else {
-            this.router.navigate(['/dashboard']);
+            this.router.navigate([this.pendingRoute]);
           }
         } else {
           this.password = ''; // Clear sensitive data on failure too
@@ -130,6 +150,10 @@ export class LoginComponent implements OnInit {
 
           if (this.error === 'SYSTEM_LOCKED') {
             this.error = 'System Locked. Please login as Administrator to unlock.';
+          } else if (this.error === 'RECOVERY_REQUIRED') {
+            this.error = 'Device recovery is required before anyone can sign in.';
+          } else if (this.error === 'VAULT_BINDING_MISMATCH') {
+            this.error = 'The database and security metadata do not belong to the same vault.';
           }
         }
       });
@@ -140,5 +164,11 @@ export class LoginComponent implements OnInit {
         console.error(e);
       });
     }
+  }
+
+  async acknowledgeMigration() {
+    await this.authService.acknowledgeRecoveryCode(this.pendingRecoveryCode);
+    this.pendingRecoveryCode = '';
+    this.router.navigate([this.pendingRoute]);
   }
 }

--- a/desktop/src/renderer/app/login/recovery/recovery.component.ts
+++ b/desktop/src/renderer/app/login/recovery/recovery.component.ts
@@ -11,29 +11,25 @@ import { AuthService } from '../../services/auth.service';
   template: `
     <div class="min-h-screen flex items-center justify-center bg-gray-900 text-white p-6">
       <div class="bg-gray-800 p-8 rounded-lg shadow-xl w-full max-w-md border border-gray-700">
-        <h2 class="text-2xl font-bold mb-6 text-center text-red-400">Recover Password</h2>
+        <h2 class="text-2xl font-bold mb-6 text-center text-red-400">Recover This Device</h2>
         
         <div *ngIf="error" class="bg-red-900/50 border border-red-500 text-red-200 px-4 py-2 rounded mb-6 text-sm">
           {{ error }}
         </div>
         
         <div *ngIf="success" class="bg-green-100 border border-green-500 rounded p-6 mb-6">
-          <h3 class="text-green-800 font-bold text-lg mb-2">Password Reset Successful!</h3>
+          <h3 class="text-green-800 font-bold text-lg mb-2">Device Recovery Successful</h3>
           <p class="text-green-700 text-sm mb-4">
-              Your recovery code has been rotated for security. 
-              <strong>You must save this new code</strong> to recover your account in the future.
+              This device can access the clinic vault again. User passwords were not changed.
           </p>
-          
-          <div class="bg-white p-3 rounded border border-gray-300 mb-4 flex justify-between items-center">
-              <code class="text-lg font-mono font-bold text-gray-800">{{ newRecoveryCode }}</code>
-              <button (click)="copyCode()" class="text-sm text-blue-600 hover:text-blue-800 font-bold">
-                  {{ isCopied ? 'Copied!' : 'Copy' }}
-              </button>
+          <div *ngIf="newRecoveryCode" class="bg-white p-3 rounded border border-gray-300 mb-4">
+            <p class="text-red-700 text-xs mb-2">The legacy recovery wrapper was replaced. Save this new code:</p>
+            <code class="block text-lg font-mono font-bold text-gray-800 select-all break-all">{{ newRecoveryCode }}</code>
+            <button (click)="copyCode()" class="mt-2 text-sm text-blue-600 font-bold">{{ isCopied ? 'Copied!' : 'Copy' }}</button>
           </div>
-
           <div class="flex justify-center">
               <button (click)="finish()" class="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-6 rounded">
-                  I have saved this code
+                  {{ newRecoveryCode ? 'I have saved this code' : 'Return to Login' }}
               </button>
           </div>
         </div>
@@ -53,45 +49,15 @@ import { AuthService } from '../../services/auth.service';
               [disabled]="isLoading"
               autofocus
             >
-            <p class="text-xs text-gray-500 mt-1">Enter the code provided during setup.</p>
-          </div>
-
-          <!-- New Password -->
-          <div class="mb-4">
-            <label class="block text-gray-400 text-sm font-bold mb-2">
-              New Master Password
-            </label>
-            <input
-              type="password"
-              [(ngModel)]="newPassword"
-              name="newPassword"
-              class="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded text-white focus:outline-none focus:border-red-500 transition-colors"
-              placeholder="Enter new password"
-              [disabled]="isLoading"
-            >
-          </div>
-
-           <!-- Confirm Password -->
-          <div class="mb-6">
-            <label class="block text-gray-400 text-sm font-bold mb-2">
-              Confirm New Password
-            </label>
-            <input
-              type="password"
-              [(ngModel)]="confirmPassword"
-              name="confirmPassword"
-              class="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded text-white focus:outline-none focus:border-red-500 transition-colors"
-              placeholder="Confirm new password"
-              [disabled]="isLoading"
-            >
+            <p class="text-xs text-gray-500 mt-1">Enter the portable vault recovery code provided during setup.</p>
           </div>
           
           <button
             type="submit"
-            [disabled]="isLoading || !recoveryCode || !newPassword || newPassword !== confirmPassword"
+            [disabled]="isLoading || !recoveryCode"
             class="w-full bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {{ isLoading ? 'Recovering...' : 'Reset Password' }}
+            {{ isLoading ? 'Recovering...' : 'Recover Device' }}
           </button>
         </form>
         
@@ -104,13 +70,10 @@ import { AuthService } from '../../services/auth.service';
 })
 export class RecoveryComponent {
   recoveryCode = '';
-  newPassword = '';
-  confirmPassword = '';
   error = '';
   success = false;
   isLoading = false;
-
-  newRecoveryCode: string | null = null;
+  newRecoveryCode = '';
   isCopied = false;
 
   constructor(
@@ -119,24 +82,19 @@ export class RecoveryComponent {
   ) { }
 
   async onRecover() {
-    if (!this.recoveryCode || !this.newPassword) return;
-    if (this.newPassword !== this.confirmPassword) {
-      this.error = 'Passwords do not match';
-      return;
-    }
+    if (!this.recoveryCode) return;
 
     this.isLoading = true;
     this.error = '';
 
     try {
       const result = await this.authService.recover({
-        recoveryCode: this.recoveryCode.trim(),
-        newPassword: this.newPassword
+        recoveryCode: this.recoveryCode.trim()
       });
 
-      if (result.success && result.recoveryCode) {
+      if (result.success) {
         this.success = true;
-        this.newRecoveryCode = result.recoveryCode;
+        this.newRecoveryCode = result.pendingRecoveryCode || '';
         this.isLoading = false;
       } else {
         this.error = result.error || 'Recovery Failed. Check your code.';
@@ -150,15 +108,10 @@ export class RecoveryComponent {
   }
 
   async copyCode() {
-    if (this.newRecoveryCode) {
-      if (window.electron) {
-        await window.electron.clipboard.writeText(this.newRecoveryCode);
-      } else {
-        navigator.clipboard.writeText(this.newRecoveryCode);
-      }
-      this.isCopied = true;
-      setTimeout(() => this.isCopied = false, 2000);
-    }
+    if (!this.newRecoveryCode) return;
+    if (window.electron) await window.electron.clipboard.writeText(this.newRecoveryCode);
+    else await navigator.clipboard.writeText(this.newRecoveryCode);
+    this.isCopied = true;
   }
 
   finish() {

--- a/desktop/src/renderer/app/services/auth.service.spec.ts
+++ b/desktop/src/renderer/app/services/auth.service.spec.ts
@@ -30,6 +30,29 @@ describe('AuthService', () => {
             expect(window.electron.login).toHaveBeenCalledWith({ username: 'admin', password: 'pass' });
         });
 
+        it('preserves a one-time migration recovery code for acknowledgement', async () => {
+            (window as any).electron = {
+                login: vi.fn().mockResolvedValue({
+                    success: true,
+                    user: { id: 1, role: 'admin' },
+                    pendingRecoveryCode: 'AAAA-BBBB-CCCC-DDDD'
+                })
+            };
+            await expect(service.login('admin', 'legacy')).resolves.toMatchObject({
+                success: true,
+                pendingRecoveryCode: 'AAAA-BBBB-CCCC-DDDD'
+            });
+        });
+
+        it('sends the exact displayed recovery code when acknowledging', async () => {
+            (window as any).electron = {
+                acknowledgeRecoveryCode: vi.fn().mockResolvedValue({ success: true })
+            };
+            await service.acknowledgeRecoveryCode('AAAA-BBBB-CCCC-DDDD');
+            expect(window.electron.acknowledgeRecoveryCode)
+                .toHaveBeenCalledWith('AAAA-BBBB-CCCC-DDDD');
+        });
+
         it('should handle login failure', async () => {
             (window as any).electron = {
                 login: vi.fn().mockResolvedValue({ success: false, error: 'Invalid' })
@@ -48,6 +71,18 @@ describe('AuthService', () => {
             const result = await service.login('a', 'b');
             expect(result.success).toBe(false);
             expect(result.error).toBe('IPC Error');
+        });
+
+        it('never persists a password hash returned by a compromised IPC payload', async () => {
+            (window as any).electron = {
+                login: vi.fn().mockResolvedValue({
+                    success: true,
+                    user: { id: 1, username: 'admin', role: 'admin', name: 'Admin', password: '$argon2id$hash' }
+                })
+            };
+            await service.login('admin', 'pass');
+            expect((service.getUser() as any).password).toBeUndefined();
+            expect(localStorage.getItem('nalamdesk_user')).not.toContain('$argon2id$hash');
         });
     });
 

--- a/desktop/src/renderer/app/services/auth.service.ts
+++ b/desktop/src/renderer/app/services/auth.service.ts
@@ -9,13 +9,13 @@ export class AuthService {
 
     constructor() { }
 
-    async login(username: string, password: string): Promise<{ success: boolean; error?: string }> {
+    async login(username: string, password: string): Promise<{ success: boolean; error?: string; pendingRecoveryCode?: string }> {
         if (window.electron) {
             try {
                 const result = await window.electron.login({ username, password });
                 if (result.success) {
                     this.setUser(result.user);
-                    return { success: true };
+                    return { success: true, pendingRecoveryCode: result.pendingRecoveryCode };
                 } else {
                     return { success: false, error: result.error };
                 }
@@ -43,7 +43,7 @@ export class AuthService {
         }
     }
 
-    async checkSetup(): Promise<{ isSetup: boolean, hasRecovery: boolean }> {
+    async checkSetup(): Promise<{ isSetup: boolean, hasRecovery: boolean, vaultState?: string, configVersion?: number }> {
         if (window.electron) {
             return await window.electron.checkSetup();
         } else {
@@ -60,11 +60,16 @@ export class AuthService {
         return { success: false, error: 'Web setup not supported yet' };
     }
 
-    async recover(data: any): Promise<{ success: boolean, recoveryCode?: string, error?: string }> {
+    async recover(data: { recoveryCode: string }): Promise<{ success: boolean, pendingRecoveryCode?: string, error?: string }> {
         if (window.electron) {
             return await window.electron.recover(data);
         }
         return { success: false, error: 'Web recovery not supported yet' };
+    }
+
+    async acknowledgeRecoveryCode(recoveryCode: string): Promise<void> {
+        if (!window.electron) return;
+        await window.electron.acknowledgeRecoveryCode(recoveryCode);
     }
 
     async regenerateRecoveryCode(password: string): Promise<{ success: boolean, recoveryCode?: string, error?: string }> {
@@ -99,7 +104,18 @@ export class AuthService {
     }
 
     private setUser(user: any) {
-        localStorage.setItem(this.userKey, JSON.stringify(user));
+        const safeUser = {
+            id: user?.id,
+            username: user?.username,
+            role: user?.role,
+            name: user?.name,
+            ...(user?.specialty ? { specialty: user.specialty } : {}),
+            ...(user?.license_number ? { license_number: user.license_number } : {}),
+            ...(user?.password_reset_required !== undefined
+                ? { password_reset_required: user.password_reset_required }
+                : {})
+        };
+        localStorage.setItem(this.userKey, JSON.stringify(safeUser));
     }
 
     private setToken(token: string) {

--- a/desktop/src/renderer/app/settings/settings.component.html
+++ b/desktop/src/renderer/app/settings/settings.component.html
@@ -586,9 +586,9 @@
     <div class="bg-white rounded-lg p-6 w-full max-w-md">
         <h3 class="text-xl font-bold mb-4">Generate Recovery Code</h3>
         <div *ngIf="!newRecoveryCode">
-            <p class="text-sm text-gray-600 mb-4">Enter Master Password to confirm.</p>
+            <p class="text-sm text-gray-600 mb-4">Enter the administrator login password to confirm.</p>
             <input type="password" [(ngModel)]="confirmPassword" class="input input-bordered w-full mb-4"
-                placeholder="Master Password">
+                placeholder="Administrator Password">
             <div class="flex justify-end gap-2">
                 <button (click)="showRecoveryModal = false" class="btn btn-ghost">Cancel</button>
                 <button (click)="generateRecoveryCode()" class="btn btn-error"

--- a/desktop/src/renderer/app/setup/setup.component.spec.ts
+++ b/desktop/src/renderer/app/setup/setup.component.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SetupComponent } from './setup.component';
+
+function component() {
+    return new SetupComponent({} as any, {} as any, { run: (fn: () => void) => fn() } as any);
+}
+
+describe('SetupComponent external backup selection', () => {
+    it('leaves setup unchanged when the sandboxed picker is cancelled', async () => {
+        (window as any).electron = { backup: { selectRestoreBundle: vi.fn(async () => null) } };
+        const value = component();
+        await value.selectExternalBackup();
+        expect(value.hasBackups).toBe(false);
+        expect(value.localBackups).toEqual([]);
+    });
+
+    it('adds an external recoverable bundle without exposing raw filesystem APIs', async () => {
+        (window as any).electron = { backup: { selectRestoreBundle: vi.fn(async () => ({
+            path: '/external/clinic.ndbackup', name: 'clinic.ndbackup'
+        })) } };
+        const value = component();
+        await value.selectExternalBackup();
+        expect(value.hasBackups).toBe(true);
+        expect(value.localBackups[0]).toMatchObject({ name: 'clinic.ndbackup', recoverable: true });
+        expect((window as any).electron.fs).toBeUndefined();
+        expect((window as any).electron.backup.readFile).toBeUndefined();
+    });
+
+    it('labels a selected legacy DB as non-recoverable', async () => {
+        (window as any).electron = { backup: { selectRestoreBundle: vi.fn(async () => ({
+            path: '/external/old.db', name: 'old.db'
+        })) } };
+        const value = component();
+        await value.selectExternalBackup();
+        expect(value.localBackups[0]).toMatchObject({ format: 'legacy-database-only', recoverable: false });
+        expect(value.restoreError).toContain('legacy backup');
+    });
+});

--- a/desktop/src/renderer/app/setup/setup.component.ts
+++ b/desktop/src/renderer/app/setup/setup.component.ts
@@ -45,14 +45,27 @@ import { jsPDF } from 'jspdf';
                     </p>
                 </div>
 
+                <div class="mb-4">
+                    <button (click)="selectExternalBackup()"
+                        class="mb-4 px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded text-white text-sm">
+                        Choose Backup File…
+                    </button>
+                    <label class="block text-gray-300 text-sm mb-1">Recovery Code</label>
+                    <input type="password" [(ngModel)]="restoreRecoveryCode" autocomplete="off"
+                        placeholder="Required to validate and restore the encrypted vault"
+                        class="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white">
+                    <p *ngIf="restoreError" class="text-red-400 text-sm mt-2">{{restoreError}}</p>
+                </div>
+
                 <div class="space-y-3 mb-8 max-h-60 overflow-y-auto pr-2">
                     <div *ngFor="let b of localBackups" class="flex items-center justify-between p-3 bg-gray-700 rounded border border-gray-600 hover:bg-gray-650 transition-colors">
                         <div>
                             <div class="font-medium text-white text-sm">{{b.name}}</div>
                             <div class="text-xs text-gray-400">{{b.createdTime | date:'medium'}} &bull; {{ (b.size / 1024 / 1024) | number:'1.1-2' }} MB</div>
+                            <div *ngIf="b.warning" class="text-xs text-amber-400 mt-1">{{b.warning}}</div>
                         </div>
                         <button (click)="restoreLocal(b.path)" 
-                            [disabled]="isRestoring"
+                            [disabled]="isRestoring || !restoreRecoveryCode || !b.recoverable"
                             class="px-3 py-1 bg-green-600 hover:bg-green-700 text-white text-xs rounded font-medium disabled:opacity-50">
                             {{ isRestoring ? 'Restoring...' : 'Restore' }}
                         </button>
@@ -82,9 +95,14 @@ import { jsPDF } from 'jspdf';
                 <li>Configure your Clinic details.</li>
                 <li>Generate a Recovery Code for restoring the encrypted vault on a new device.</li>
                 </ul>
-                <button (click)="step = 2" class="px-6 py-2 bg-blue-600 hover:bg-blue-700 rounded text-white font-medium">
-                Get Started
-                </button>
+                <div class="flex gap-3">
+                  <button (click)="step = 2" class="px-6 py-2 bg-blue-600 hover:bg-blue-700 rounded text-white font-medium">
+                    Get Started
+                  </button>
+                  <button (click)="selectExternalBackup()" class="px-6 py-2 bg-gray-700 hover:bg-gray-600 border border-gray-600 rounded text-white font-medium">
+                    Restore Backup File…
+                  </button>
+                </div>
             </ng-template>
           </div>
 
@@ -197,6 +215,8 @@ export class SetupComponent implements OnInit {
   showCloudRestore = false;
   localBackups: any[] = [];
   isRestoring = false;
+  restoreRecoveryCode = '';
+  restoreError = '';
 
   constructor(private authService: AuthService, private router: Router, private ngZone: NgZone) { }
 
@@ -222,17 +242,50 @@ export class SetupComponent implements OnInit {
   }
 
   async restoreLocal(path: string) {
-    if (!confirm('This will restore the selected database and restart the application. Continue?')) return;
+    if (!this.restoreRecoveryCode) {
+      this.restoreError = 'Enter the Recovery Code for this backup.';
+      return;
+    }
+    if (!confirm('The backup will be validated first. Your current vault will be snapshotted before replacement. Continue?')) return;
 
     this.isRestoring = true;
+    this.restoreError = '';
     try {
-      await (window as any).electron.restoreSystemBackup(path);
-      // App should restart, but if not:
-      this.isRestoring = false;
-    } catch (e) {
+      const result = await window.electron.restoreSystemBackup({ path, recoveryCode: this.restoreRecoveryCode });
+      this.restoreRecoveryCode = '';
+      if (!result.success) throw new Error(result.error || 'Restore failed');
+    } catch (e: any) {
       console.error(e);
       this.isRestoring = false;
-      alert('Restore Failed');
+      const code = e?.message || 'Restore failed';
+      this.restoreError = code === 'LEGACY_DATABASE_ONLY_BACKUP'
+        ? 'This legacy database-only backup is missing recovery metadata and cannot be restored on a clean device.'
+        : code === 'INVALID_RECOVERY_CODE'
+          ? 'The Recovery Code is incorrect for this backup.'
+          : `Restore failed: ${code}`;
+    }
+  }
+
+  async selectExternalBackup() {
+    try {
+      const selected = await window.electron.backup.selectRestoreBundle();
+      if (!selected) return;
+      const legacy = selected.name.toLowerCase().endsWith('.db');
+      this.localBackups = [{
+        name: selected.name,
+        path: selected.path,
+        createdTime: new Date(),
+        size: 0,
+        format: legacy ? 'legacy-database-only' : 'bundle-v1',
+        recoverable: !legacy,
+        warning: legacy
+          ? 'Legacy database-only backup: wrapped-key metadata is missing; clean-machine recovery is unavailable.'
+          : undefined
+      }, ...this.localBackups.filter(item => item.path !== selected.path)];
+      this.hasBackups = true;
+      if (legacy) this.restoreError = 'This legacy backup can be identified, but cannot recover a clean device.';
+    } catch (e: any) {
+      this.restoreError = e?.message || 'Unable to select the backup file.';
     }
   }
 

--- a/desktop/src/renderer/app/setup/setup.component.ts
+++ b/desktop/src/renderer/app/setup/setup.component.ts
@@ -78,9 +78,9 @@ import { jsPDF } from 'jspdf';
                 This setup wizard will help you:
                 </p>
                 <ul class="list-disc list-inside text-gray-400 mb-8 space-y-2">
-                <li>Secure your patient data with a Master Password.</li>
+                <li>Create the administrator login and a device-protected local vault.</li>
                 <li>Configure your Clinic details.</li>
-                <li>Generate a Recovery Code (Essential for password reset).</li>
+                <li>Generate a Recovery Code for restoring the encrypted vault on a new device.</li>
                 </ul>
                 <button (click)="step = 2" class="px-6 py-2 bg-blue-600 hover:bg-blue-700 rounded text-white font-medium">
                 Get Started
@@ -88,17 +88,17 @@ import { jsPDF } from 'jspdf';
             </ng-template>
           </div>
 
-          <!-- Step 2: Master Password -->
+          <!-- Step 2: Administrator password -->
           <div *ngIf="step === 2">
-            <h3 class="text-xl font-semibold mb-4 text-white">Create Master Password</h3>
+            <h3 class="text-xl font-semibold mb-4 text-white">Create Administrator Password</h3>
             <div class="bg-yellow-900/30 border border-yellow-700 text-yellow-200 p-4 rounded mb-6 text-sm">
-              <span class="font-bold">IMPORTANT:</span> This password encrypts your database. 
-              If you lose it, you can ONLY restore access using the Recovery Code generated in Step 4.
+              <span class="font-bold">IMPORTANT:</span> This password signs in the administrator.
+              The local vault is protected by this device, and recovery uses the separate Recovery Code generated in Step 4.
             </div>
 
             <div class="space-y-4">
               <div>
-                <label class="block text-gray-400 text-sm mb-1">Master Password</label>
+                <label class="block text-gray-400 text-sm mb-1">Administrator Password</label>
                 <input type="password" [(ngModel)]="password" class="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white">
               </div>
               <div>
@@ -159,7 +159,7 @@ import { jsPDF } from 'jspdf';
                  {{ recoveryCode }}
                </div>
                <p class="text-red-400 text-xs mt-3">
-                 SAVE THIS CODE! It is the ONLY way to reset your password if lost.
+                 SAVE THIS CODE! It is required to recover the encrypted vault on a new or reset device.
                </p>
             </div>
 
@@ -273,7 +273,7 @@ export class SetupComponent implements OnInit {
 
     doc.setFontSize(12);
     doc.setTextColor(50, 50, 50);
-    doc.text("Keep this document safe. This code allows you to reset your Master Password.", 20, 40);
+    doc.text("Keep this document safe. This code restores access to your encrypted clinic vault.", 20, 40);
 
     doc.setDrawColor(200, 200, 200);
     doc.setFillColor(245, 245, 245);
@@ -292,7 +292,7 @@ export class SetupComponent implements OnInit {
     doc.save("nalamdesk-recovery-code.pdf");
   }
 
-  goToDashboard() {
+  async goToDashboard() {
     // Setup automatically calls ensureAdminUser which sets up DB.
     // But we are not technically "logged in" via session service yet in the Renderer (AuthService).
     // We should probably auto-login or redirect to login page (but nicely).
@@ -300,12 +300,12 @@ export class SetupComponent implements OnInit {
     // OR, since we just made the password, we can auto-login behind the scenes.
 
     // Auto-login attempt
-    this.authService.login('admin', this.password).then(res => {
-      if (res.success) {
-        this.router.navigate(['/dashboard']);
-      } else {
-        this.router.navigate(['/login']);
-      }
-    });
+    const res = await this.authService.login('admin', this.password);
+    if (res.success) {
+      await this.authService.acknowledgeRecoveryCode(this.recoveryCode);
+      this.router.navigate(['/dashboard']);
+    } else {
+      this.router.navigate(['/login']);
+    }
   }
 }

--- a/desktop/src/renderer/types.d.ts
+++ b/desktop/src/renderer/types.d.ts
@@ -6,7 +6,9 @@ declare global {
             login: (credentials: { username: string, password: string }) => Promise<{ success: boolean; user?: any; error?: string; pendingRecoveryCode?: string }>;
             checkSetup: () => Promise<{ isSetup: boolean; hasRecovery: boolean; vaultState?: string; configVersion?: number }>;
             getRecoveryStatus: () => Promise<{ isSetup: boolean; hasRecovery: boolean; hasBackups: boolean; backups?: any[] }>;
-            restoreSystemBackup: (path: string) => Promise<void>;
+            restoreSystemBackup: (request: { path: string; recoveryCode: string; currentAdminPassword?: string }) => Promise<{
+                success: boolean; restartRequired?: boolean; preRestoreSnapshot?: string; error?: string
+            }>;
             setup: (data: any) => Promise<{ success: boolean; recoveryCode?: string; error?: string }>;
             recover: (data: { recoveryCode: string }) => Promise<{ success: boolean; pendingRecoveryCode?: string; error?: string }>;
             acknowledgeRecoveryCode: (recoveryCode: string) => Promise<{ success: boolean }>;
@@ -65,6 +67,7 @@ declare global {
             },
             backup: {
                 selectPath: () => Promise<string | null>;
+                selectRestoreBundle: () => Promise<{ path: string; name: string } | null>;
                 useDefaultPath: () => Promise<string | null>;
                 runNow: () => Promise<{ success: boolean; error?: string }>;
                 listSystemBackups: () => Promise<any[]>;

--- a/desktop/src/renderer/types.d.ts
+++ b/desktop/src/renderer/types.d.ts
@@ -3,12 +3,13 @@ export { };
 declare global {
     interface Window {
         electron: {
-            login: (credentials: { username: string, password: string }) => Promise<{ success: boolean; user?: any; error?: string }>;
-            checkSetup: () => Promise<{ isSetup: boolean; hasRecovery: boolean }>;
+            login: (credentials: { username: string, password: string }) => Promise<{ success: boolean; user?: any; error?: string; pendingRecoveryCode?: string }>;
+            checkSetup: () => Promise<{ isSetup: boolean; hasRecovery: boolean; vaultState?: string; configVersion?: number }>;
             getRecoveryStatus: () => Promise<{ isSetup: boolean; hasRecovery: boolean; hasBackups: boolean; backups?: any[] }>;
             restoreSystemBackup: (path: string) => Promise<void>;
             setup: (data: any) => Promise<{ success: boolean; recoveryCode?: string; error?: string }>;
-            recover: (data: any) => Promise<{ success: boolean; recoveryCode?: string; error?: string }>;
+            recover: (data: { recoveryCode: string }) => Promise<{ success: boolean; pendingRecoveryCode?: string; error?: string }>;
+            acknowledgeRecoveryCode: (recoveryCode: string) => Promise<{ success: boolean }>;
             regenerateRecoveryCode: (password: string) => Promise<{ success: boolean; recoveryCode?: string; error?: string }>;
             db: {
                 getPatients: (query: string) => Promise<any[]>;

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -12700,6 +12700,10 @@ html:has(.drawer-toggle:checked) {
   white-space: pre-line;
 }
 
+.break-all {
+  word-break: break-all;
+}
+
 .rounded {
   border-radius: 0.25rem;
 }
@@ -12773,6 +12777,11 @@ html:has(.drawer-toggle:checked) {
 
 .border-dashed {
   border-style: dashed;
+}
+
+.border-amber-500 {
+  --tw-border-opacity: 1;
+  border-color: rgb(245 158 11 / var(--tw-border-opacity, 1));
 }
 
 .border-base-200 {
@@ -12912,6 +12921,16 @@ html:has(.drawer-toggle:checked) {
   background-color: var(--fallback-p,oklch(var(--p)/var(--tw-bg-opacity, 1))) !important;
 }
 
+.bg-amber-600 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(217 119 6 / var(--tw-bg-opacity, 1));
+}
+
+.bg-amber-950 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(69 26 3 / var(--tw-bg-opacity, 1));
+}
+
 .bg-base-100 {
   --tw-bg-opacity: 1;
   background-color: var(--fallback-b1,oklch(var(--b1)/var(--tw-bg-opacity, 1)));
@@ -12980,6 +12999,10 @@ html:has(.drawer-toggle:checked) {
   background-color: rgb(30 58 138 / 0.3);
 }
 
+.bg-blue-950\/60 {
+  background-color: rgb(23 37 84 / 0.6);
+}
+
 .bg-current {
   background-color: currentColor;
 }
@@ -13038,6 +13061,11 @@ html:has(.drawer-toggle:checked) {
 .bg-gray-900 {
   --tw-bg-opacity: 1;
   background-color: rgb(17 24 39 / var(--tw-bg-opacity, 1));
+}
+
+.bg-gray-950 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(3 7 18 / var(--tw-bg-opacity, 1));
 }
 
 .bg-green-100 {
@@ -13497,6 +13525,21 @@ html:has(.drawer-toggle:checked) {
   color: rgb(255 255 255 / var(--tw-text-opacity, 1)) !important;
 }
 
+.text-amber-100 {
+  --tw-text-opacity: 1;
+  color: rgb(254 243 199 / var(--tw-text-opacity, 1));
+}
+
+.text-amber-300 {
+  --tw-text-opacity: 1;
+  color: rgb(252 211 77 / var(--tw-text-opacity, 1));
+}
+
+.text-amber-400 {
+  --tw-text-opacity: 1;
+  color: rgb(251 191 36 / var(--tw-text-opacity, 1));
+}
+
 .text-base-content {
   --tw-text-opacity: 1;
   color: var(--fallback-bc,oklch(var(--bc)/var(--tw-text-opacity, 1)));
@@ -13678,6 +13721,11 @@ html:has(.drawer-toggle:checked) {
 .text-red-600 {
   --tw-text-opacity: 1;
   color: rgb(220 38 38 / var(--tw-text-opacity, 1));
+}
+
+.text-red-700 {
+  --tw-text-opacity: 1;
+  color: rgb(185 28 28 / var(--tw-text-opacity, 1));
 }
 
 .text-secondary {
@@ -14179,6 +14227,11 @@ h6 {
   border-color: rgb(14 165 233 / 0.2);
 }
 
+.hover\:bg-amber-700:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(180 83 9 / var(--tw-bg-opacity, 1));
+}
+
 .hover\:bg-base-200:hover {
   --tw-bg-opacity: 1;
   background-color: var(--fallback-b2,oklch(var(--b2)/var(--tw-bg-opacity, 1)));
@@ -14239,6 +14292,11 @@ h6 {
 .hover\:bg-gray-500:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(107 114 128 / var(--tw-bg-opacity, 1));
+}
+
+.hover\:bg-gray-600:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(75 85 99 / var(--tw-bg-opacity, 1));
 }
 
 .hover\:bg-green-50:hover {


### PR DESCRIPTION
## Summary

- replace offline database-only backups with a versioned single-file `.ndbackup` bundle
- include the encrypted SQLCipher database, strictly sanitized portable wrapped-key metadata, checksums, schema/app metadata, and no plaintext/device secrets
- validate checksums, recovery AEAD, full keyed SQLCipher/SQLite integrity, vault binding, and schema compatibility in isolated staging before live mutation
- restore the database/config pair through journaled atomic replacement with a durable pre-restore recoverable snapshot and deterministic rollback
- support clean-machine selection of an external bundle through a sandboxed file picker
- identify legacy database-only backups and explain why they cannot recover a clean device
- invalidate the pre-restore session at the commit boundary and require fresh active-admin authorization when replacing an existing live vault

Closes #8.

## Dependency and format

- Stacked on #25 / issue #7 (`d3e1e80`) and consumes only its frozen portable metadata/install APIs.
- Bundle v1 layout: fixed magic, bounded length-delimited JSON manifest, then raw encrypted SQLCipher snapshot bytes.
- Manifest records format/version, creation/app version, encrypted DB byte size/SHA-256/schema version, vault ID/key version, primary recovery envelope, and optional transition envelope.
- Device envelope, pending recovery acknowledgement, login hashes/passwords, raw DEK, recovery code, tokens, and arbitrary nested metadata are rejected and never exported.

## Security and recovery considerations

- SHA-256 detects transport/storage corruption; authenticity and recoverability come from Argon2id + AES-GCM recovery unwrap, real SQLCipher open, full `cipher_integrity_check`, SQLite `integrity_check`, and database vault-ID/key-version binding.
- Hostile KDF parameters, unexpected fields, malformed optional transition envelopes, database/manifest schema mismatch, and future unsupported schema versions fail before live files are touched.
- Restore validation uses isolated database/security service paths and cannot reconfigure or close the live vault.
- A clean target requires only the selected bundle recovery code. Replacing an existing complete/open vault also requires the matching persisted active administrator and freshly verified current admin password; locked/incomplete live pairs fail closed.
- The restore journal uses exact validated paths and fsynced rollback copies. Every pre-commit interruption restores the prior DB/config pair; clean-machine interruption removes the partial pair.
- At activation, the old session is cleared immediately. Post-activation cleanup failures are committed success, force restart, and reconcile cleanup on next launch.
- Cloud scheduling/upload remains unchanged and is regression-tested; this PR changes offline local backup/restore only.

## Validation

- Focused backup/authorization/file-picker main tests: 36/36 passed
- Real Electron/SQLCipher combined integration: 19/19 passed
- Full main suite passed
- Full renderer suite: 168/168 passed
- Main and renderer TypeScript passed
- Angular production build passed
- Diff checks passed

## Smoke evidence

- clean-machine restore cold-starts using a newly device-bound envelope and preserves clinical data
- wrong recovery code, recomputed-checksum encrypted-page corruption, vault mismatch, schema mismatch, and future schema all fail before live mutation
- interrupted DB/config replacement restores the exact prior real vault
- the persistent pre-restore snapshot itself restores on another clean target with the prior recovery code and clinical data
- local backup failure still allows the independent cloud attempt
- cancellation/external picker/legacy `.db` detection paths are covered
- cleanup failure after activation returns committed success with the old session invalidated

## Rollback

- Before merge: close this PR; no production data has changed.
- Before every authorized live replacement, NalamDesk writes a persistent recoverable pre-restore `.ndbackup` snapshot.
- Pre-commit interruption automatically restores the durable rollback DB/config pair from the journal.
- Post-commit cleanup is reconciled at next startup; the restored pair remains authoritative.
- Preserve each encrypted database together with its matching portable metadata/bundle. Never restore a raw database alone.

## Residual limitations

- Legacy database-only backups lack wrapped-key metadata and cannot recover a clean machine.
- A closed legacy v1/v2 vault is not overwritten because a recoverable pre-restore snapshot cannot be produced safely; migrate/recover it first.
- Cloud backup format remains unchanged because cloud functionality is out of scope.

## Approval

- Do not merge without explicit owner approval.
