### PR TITLE
fix(desktop): journal credential rotation

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -24,6 +24,7 @@
     "watch": "ng build --watch --configuration development",
     "test": "npm run test:main && npm run test:renderer",
     "test:main": "vitest run -c vitest.config.main.js",
+    "test:security:electron": "node scripts/run-security-integration.js",
     "test:renderer": "vitest run -c vitest.config.renderer.mjs",
     "test:coverage": "vitest run -c vitest.config.main.js --coverage && vitest run -c vitest.config.renderer.mjs --coverage",
     "e2e": "playwright test",

--- a/desktop/scripts/run-security-integration.js
+++ b/desktop/scripts/run-security-integration.js
@@ -9,6 +9,7 @@ const result = spawnSync(electron, [
     '-c',
     'vitest.config.main.js',
     'src/main/services/SecurityService.integration.spec.ts',
+    'src/main/services/CredentialRotationService.integration.spec.ts',
     '--reporter=default'
 ], {
     cwd: process.cwd(),

--- a/desktop/scripts/run-security-integration.js
+++ b/desktop/scripts/run-security-integration.js
@@ -1,0 +1,20 @@
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+const electron = require('electron');
+const vitest = path.join(path.dirname(require.resolve('vitest/package.json')), 'vitest.mjs');
+
+const result = spawnSync(electron, [
+    vitest,
+    'run',
+    '-c',
+    'vitest.config.main.js',
+    'src/main/services/SecurityService.integration.spec.ts',
+    '--reporter=default'
+], {
+    cwd: process.cwd(),
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+    stdio: 'inherit'
+});
+
+if (result.error) throw result.error;
+process.exit(result.status ?? 1);

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -13,6 +13,9 @@ import { GoogleDriveService } from './services/GoogleDriveService';
 import { CloudSyncService } from './services/CloudSyncService';
 import { buildAuthenticatedLoginResult } from './services/AuthResult';
 import { ProvisioningService } from './services/ProvisioningService';
+import { CredentialRotationService } from './services/CredentialRotationService';
+import { verifyPersistedActiveAdmin } from './services/AdminCredentialVerifier';
+import { acknowledgeRecoveryCodeForActiveAdmin } from './services/RecoveryCodeAcknowledgement';
 import { ApiServer } from '../server/app';
 import {
     DEV_APP_NAME,
@@ -102,6 +105,7 @@ ipcMain.handle('utils:getRuntimeInfo', () => ({
 // Services
 const securityService = new SecurityService(new ElectronSafeStorageDeviceKeyStore());
 const databaseService = new DatabaseService();
+const credentialRotationService = new CredentialRotationService();
 const provisioningService = new ProvisioningService(securityService, databaseService);
 const googleDriveService = new GoogleDriveService();
 const cloudSyncService = new CloudSyncService(databaseService);
@@ -303,6 +307,8 @@ ipcMain.handle('auth:setup', async (event, { password, clinicDetails, adminDetai
         const recoveryCode = await provisioningService.provision(
             password, clinicDetails, dbPath, userDataPath
         );
+        credentialRotationService.setDb(securityService.getDb());
+        credentialRotationService.reconcileInterruptedRotation();
 
         console.log('[Auth] Setup Complete.');
         return { success: true, recoveryCode };
@@ -324,9 +330,12 @@ ipcMain.handle('auth:recover', async (event, { recoveryCode }) => {
         await securityService.recoverDevice(recoveryCode, userDataPath, dbPath);
 
         // 2. Set DB
-        databaseService.setDb(securityService.getDb());
+        const db = securityService.getDb();
+        databaseService.setDb(db);
 
         await databaseService.migrate();
+        credentialRotationService.setDb(db);
+        credentialRotationService.reconcileInterruptedRotation();
         return {
             success: true,
             pendingRecoveryCode: securityService.getPendingRecoveryCode() || undefined
@@ -340,10 +349,7 @@ ipcMain.handle('auth:recover', async (event, { recoveryCode }) => {
 ipcMain.handle('auth:regenerateRecoveryCode', async (event, { password }) => {
     try {
         const user = sessionService.getUser();
-        if (!user || user.role !== 'admin') throw new Error('Forbidden');
-        const argon2 = await import('argon2');
-        const admin = await databaseService.getUserByUsername('admin');
-        if (!admin || !password || !await argon2.verify(admin.password, password)) throw new Error('INVALID_CREDENTIALS');
+        if (!await verifyPersistedActiveAdmin(user, databaseService, password)) throw new Error('INVALID_CREDENTIALS');
 
         console.log('[Auth] Regenerating Recovery Code...');
         const recoveryCode = await securityService.regenerateRecoveryCode();
@@ -354,10 +360,47 @@ ipcMain.handle('auth:regenerateRecoveryCode', async (event, { password }) => {
     }
 });
 
-ipcMain.handle('auth:acknowledgeRecoveryCode', (_event, { recoveryCode }) => {
+ipcMain.handle('auth:rotateDeviceEnvelope', async (_event, { currentPassword }) => {
+    try {
+        const user = sessionService.getUser();
+        if (!await verifyPersistedActiveAdmin(user, databaseService, currentPassword)) {
+            throw new Error('INVALID_CREDENTIALS');
+        }
+        securityService.rotateDeviceEnvelope();
+        return { success: true };
+    } catch (e: any) {
+        return { success: false, error: e.message };
+    }
+});
+
+ipcMain.handle('auth:changeLoginPassword', async (_event, { currentPassword, newPassword }) => {
+    try {
+        const user = sessionService.getUser();
+        if (!user) throw new Error('Unauthorized');
+        await credentialRotationService.changeOwnPassword(user.id, currentPassword, newPassword);
+        sessionService.setUser({ ...user, password_reset_required: 0 });
+        return { success: true };
+    } catch (e: any) {
+        return { success: false, error: e.message };
+    }
+});
+
+ipcMain.handle('auth:resetUserPassword', async (_event, { targetUserId, currentAdminPassword, temporaryPassword }) => {
+    try {
+        const user = sessionService.getUser();
+        if (!user || user.role !== 'admin') throw new Error('Forbidden');
+        await credentialRotationService.resetUserPassword(
+            user.id, currentAdminPassword, targetUserId, temporaryPassword
+        );
+        return { success: true };
+    } catch (e: any) {
+        return { success: false, error: e.message };
+    }
+});
+
+ipcMain.handle('auth:acknowledgeRecoveryCode', async (_event, { recoveryCode }) => {
     const user = sessionService.getUser();
-    if (!user || user.role !== 'admin') throw new Error('Forbidden');
-    securityService.acknowledgePendingRecoveryCode(recoveryCode);
+    acknowledgeRecoveryCodeForActiveAdmin(user, databaseService, securityService, recoveryCode);
     return { success: true };
 });
 
@@ -367,7 +410,13 @@ ipcMain.handle('clipboard:writeText', (event, text) => {
 });
 
 async function tryUnlockDatabase(legacySecret: string): Promise<{ error?: string; migrated?: boolean }> {
-    if (securityService.getDb()) return {};
+    if (securityService.getDb()) {
+        const openDb = securityService.getDb();
+        databaseService.setDb(openDb);
+        credentialRotationService.setDb(openDb);
+        credentialRotationService.reconcileInterruptedRotation();
+        return {};
+    }
 
     try {
         const userDataPath = app.getPath('userData');
@@ -383,10 +432,13 @@ async function tryUnlockDatabase(legacySecret: string): Promise<{ error?: string
             // migration. It is not part of the v3 device unlock contract.
             result = await securityService.migrateLegacy(legacySecret, dbPath, userDataPath);
         }
-        databaseService.setDb(securityService.getDb());
+        const db = securityService.getDb();
+        databaseService.setDb(db);
 
         // Ensure schema is up to date (safe idempotent)
         await databaseService.migrate();
+        credentialRotationService.setDb(db);
+        credentialRotationService.reconcileInterruptedRotation();
         return { migrated: result.migrated };
     } catch (e: any) {
         if (e.message === 'NOT_SETUP') return { error: 'SETUP_REQUIRED' };
@@ -553,7 +605,7 @@ ipcMain.handle('db:saveUser', (_, userData) => {
     const user = sessionService.getUser();
     if (!user) throw new Error('Unauthorized');
     if (user.role !== 'admin') throw new Error('Forbidden');
-    return databaseService.saveUser(userData);
+    return databaseService.saveUser(userData, user.id);
 });
 ipcMain.handle('db:deleteUser', (_, id) => {
     const user = sessionService.getUser();

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -7,9 +7,12 @@ import { SessionService } from './services/SessionService';
 import { BackupService } from './services/BackupService';
 import { CrashService } from './services/CrashService';
 import { SecurityService } from './services/SecurityService';
+import { ElectronSafeStorageDeviceKeyStore } from './services/DeviceKeyStore';
 import { DatabaseService } from './services/DatabaseService';
 import { GoogleDriveService } from './services/GoogleDriveService';
 import { CloudSyncService } from './services/CloudSyncService';
+import { buildAuthenticatedLoginResult } from './services/AuthResult';
+import { ProvisioningService } from './services/ProvisioningService';
 import { ApiServer } from '../server/app';
 import {
     DEV_APP_NAME,
@@ -97,8 +100,9 @@ ipcMain.handle('utils:getRuntimeInfo', () => ({
 }));
 
 // Services
-const securityService = new SecurityService();
+const securityService = new SecurityService(new ElectronSafeStorageDeviceKeyStore());
 const databaseService = new DatabaseService();
+const provisioningService = new ProvisioningService(securityService, databaseService);
 const googleDriveService = new GoogleDriveService();
 const cloudSyncService = new CloudSyncService(databaseService);
 
@@ -282,6 +286,8 @@ app.on('before-quit', async (e) => {
 // IPC Handlers
 ipcMain.handle('auth:checkSetup', () => {
     const userDataPath = app.getPath('userData');
+    const dbName = process.env['NODE_ENV'] === 'test' ? 'nalamdesk-test.db' : 'nalamdesk.db';
+    securityService.reconcileProvisioning(getDatabasePath(userDataPath, dbName), userDataPath);
     return securityService.isSetup(userDataPath);
 });
 
@@ -292,22 +298,11 @@ ipcMain.handle('auth:setup', async (event, { password, clinicDetails, adminDetai
         const dbName = process.env['NODE_ENV'] === 'test' ? 'nalamdesk-test.db' : 'nalamdesk.db';
         const dbPath = getDatabasePath(userDataPath, dbName);
 
-        // 1. Setup Security (Generates DEK + Recovery Code)
-        const recoveryCode = await securityService.setup(password, dbPath, userDataPath);
-
-        // 2. Set DB Service
-        databaseService.setDb(securityService.getDb());
-
-        // 3. Migrate DB Schema
-        await databaseService.migrate();
-
-        // 4. Save Settings
-        databaseService.saveSettings(clinicDetails);
-
-        // 5. Create Admin User
-        // We pass password here, but remember, Auth is now decoupled from DB Key.
-        // The Admin Password is the same as the Master Password for simplicity in V1/V2 transition.
-        await databaseService.ensureAdminUser(password);
+        // One durable transaction covers vault creation, schema, clinic settings,
+        // and the administrator credential. The password never wraps the DEK.
+        const recoveryCode = await provisioningService.provision(
+            password, clinicDetails, dbPath, userDataPath
+        );
 
         console.log('[Auth] Setup Complete.');
         return { success: true, recoveryCode };
@@ -317,26 +312,25 @@ ipcMain.handle('auth:setup', async (event, { password, clinicDetails, adminDetai
     }
 });
 
-ipcMain.handle('auth:recover', async (event, { recoveryCode, newPassword }) => {
+ipcMain.handle('auth:recover', async (event, { recoveryCode }) => {
     try {
         console.log('[Auth] Starting Recovery...');
         const userDataPath = app.getPath('userData');
         const dbName = process.env['NODE_ENV'] === 'test' ? 'nalamdesk-test.db' : 'nalamdesk.db';
         const dbPath = getDatabasePath(userDataPath, dbName);
 
-        // 1. Recover Vault
-        const newRecoveryCode = await securityService.recover(recoveryCode, newPassword, userDataPath, dbPath);
+        // Recovery re-enrols this device. Account password recovery is a
+        // separate workflow owned by issue #6.
+        await securityService.recoverDevice(recoveryCode, userDataPath, dbPath);
 
         // 2. Set DB
         databaseService.setDb(securityService.getDb());
 
-        // 3. Update Admin Password in DB (since we reset it)
-        // Note: We need a way to find the admin user and update their password hash.
-        // DatabaseService needs a method for this.
-        // For now, let's assume 'admin' user exists.
-        await databaseService.updateUserPassword('admin', newPassword);
-
-        return { success: true, recoveryCode: newRecoveryCode };
+        await databaseService.migrate();
+        return {
+            success: true,
+            pendingRecoveryCode: securityService.getPendingRecoveryCode() || undefined
+        };
     } catch (e: any) {
         console.error('[Auth] Recovery failed:', e);
         return { success: false, error: e.message };
@@ -347,9 +341,12 @@ ipcMain.handle('auth:regenerateRecoveryCode', async (event, { password }) => {
     try {
         const user = sessionService.getUser();
         if (!user || user.role !== 'admin') throw new Error('Forbidden');
+        const argon2 = await import('argon2');
+        const admin = await databaseService.getUserByUsername('admin');
+        if (!admin || !password || !await argon2.verify(admin.password, password)) throw new Error('INVALID_CREDENTIALS');
 
         console.log('[Auth] Regenerating Recovery Code...');
-        const recoveryCode = await securityService.regenerateRecoveryCode(password);
+        const recoveryCode = await securityService.regenerateRecoveryCode();
         return { success: true, recoveryCode };
     } catch (e: any) {
         console.error('[Auth] Regenerate Recovery Code failed:', e);
@@ -357,32 +354,50 @@ ipcMain.handle('auth:regenerateRecoveryCode', async (event, { password }) => {
     }
 });
 
+ipcMain.handle('auth:acknowledgeRecoveryCode', (_event, { recoveryCode }) => {
+    const user = sessionService.getUser();
+    if (!user || user.role !== 'admin') throw new Error('Forbidden');
+    securityService.acknowledgePendingRecoveryCode(recoveryCode);
+    return { success: true };
+});
+
 ipcMain.handle('clipboard:writeText', (event, text) => {
     clipboard.writeText(text);
     return true;
 });
 
-async function tryUnlockDatabase(password: string): Promise<string | null> {
-    if (securityService.getDb()) return null; // Already open
+async function tryUnlockDatabase(legacySecret: string): Promise<{ error?: string; migrated?: boolean }> {
+    if (securityService.getDb()) return {};
 
     try {
         const userDataPath = app.getPath('userData');
         const dbName = process.env['NODE_ENV'] === 'test' ? 'nalamdesk-test.db' : 'nalamdesk.db';
         const dbPath = getDatabasePath(userDataPath, dbName);
 
-        // This handles Unlock OR V1->V2 Migration
-        await securityService.initialize(password, dbPath, userDataPath);
+        let result;
+        try {
+            result = await securityService.initializeDevice(dbPath, userDataPath);
+        } catch (error: any) {
+            if (error.message !== 'LEGACY_MIGRATION_REQUIRED') throw error;
+            // The submitted password is used only for this one-time legacy
+            // migration. It is not part of the v3 device unlock contract.
+            result = await securityService.migrateLegacy(legacySecret, dbPath, userDataPath);
+        }
         databaseService.setDb(securityService.getDb());
 
         // Ensure schema is up to date (safe idempotent)
         await databaseService.migrate();
-        return null;
+        return { migrated: result.migrated };
     } catch (e: any) {
-        if (e.message === 'NOT_SETUP') return 'SETUP_REQUIRED';
-        if (e.message === 'INVALID_PASSWORD') return 'INVALID_PASSWORD';
+        if (e.message === 'NOT_SETUP') return { error: 'SETUP_REQUIRED' };
+        if (e.message === 'INVALID_LEGACY_CREDENTIAL') return { error: 'INVALID_CREDENTIALS' };
+        if (['ENCRYPTION_UNAVAILABLE', 'INSECURE_LINUX_BACKEND', 'DEVICE_UNLOCK_FAILED'].includes(e.message)) {
+            return { error: 'RECOVERY_REQUIRED' };
+        }
+        if (e.message === 'VAULT_BINDING_MISMATCH') return { error: 'VAULT_BINDING_MISMATCH' };
 
         console.error('DB Init failed:', e);
-        return 'SYSTEM_ERROR';
+        return { error: 'SYSTEM_ERROR' };
     }
 }
 
@@ -411,7 +426,7 @@ async function handleAdminLogin(password: string): Promise<{ success: boolean; u
 
     sessionService.setUser(user);
     initializeServices(databaseService.getSettings());
-    return { success: true, user };
+    return buildAuthenticatedLoginResult(sessionService.getUser()!, securityService);
 }
 
 ipcMain.handle('auth:login', async (event, credentials) => {
@@ -420,8 +435,7 @@ ipcMain.handle('auth:login', async (event, credentials) => {
 
         // 1. Initialize / Unlock DB
         const unlockResult = await tryUnlockDatabase(password);
-        if (unlockResult === 'SETUP_REQUIRED') return { success: false, error: 'SETUP_REQUIRED' };
-        if (unlockResult === 'SYSTEM_ERROR') return { success: false, error: 'SYSTEM_ERROR' };
+        if (unlockResult.error) return { success: false, error: unlockResult.error };
 
         // 2. Check if DB is open
         const db = securityService.getDb();
@@ -436,7 +450,9 @@ ipcMain.handle('auth:login', async (event, credentials) => {
         // 3. Admin fast path
         if (username === 'admin') {
             const adminResult = await handleAdminLogin(password);
-            if (adminResult) return adminResult;
+            if (adminResult) {
+                return adminResult;
+            }
             // Fallthrough to standard validation if admin user missing from DB
         }
 
@@ -447,7 +463,7 @@ ipcMain.handle('auth:login', async (event, credentials) => {
         if (result.success && result.user) {
             sessionService.setUser(result.user);
             initializeServices(databaseService.getSettings());
-            return { success: true, user: result.user };
+            return buildAuthenticatedLoginResult(sessionService.getUser()!, securityService);
         }
 
         return { success: false, error: 'INVALID_CREDENTIALS' };
@@ -835,6 +851,3 @@ ipcMain.handle('auth:restoreSystemBackup', async (_, backupPath) => {
         return { success: false, error: e.message };
     }
 });
-
-
-

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -2,7 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron';
 
 console.log('Preload script loaded!');
 contextBridge.exposeInMainWorld('electron', {
-    login: (password: string) => ipcRenderer.invoke('auth:login', password),
+    login: (credentials: { username: string; password: string }) => ipcRenderer.invoke('auth:login', credentials),
     checkSetup: () => ipcRenderer.invoke('auth:checkSetup'),
     getRecoveryStatus: () => ipcRenderer.invoke('auth:getRecoveryStatus'),
     restoreSystemBackup: (path: string) => ipcRenderer.invoke('auth:restoreSystemBackup', path),
@@ -10,6 +10,9 @@ contextBridge.exposeInMainWorld('electron', {
     recover: (data: any) => ipcRenderer.invoke('auth:recover', data),
     acknowledgeRecoveryCode: (recoveryCode: string) => ipcRenderer.invoke('auth:acknowledgeRecoveryCode', { recoveryCode }),
     regenerateRecoveryCode: (password: string) => ipcRenderer.invoke('auth:regenerateRecoveryCode', { password }),
+    rotateDeviceEnvelope: (currentPassword: string) => ipcRenderer.invoke('auth:rotateDeviceEnvelope', { currentPassword }),
+    changeLoginPassword: (data: { currentPassword: string; newPassword: string }) => ipcRenderer.invoke('auth:changeLoginPassword', data),
+    resetUserPassword: (data: { targetUserId: number; currentAdminPassword: string; temporaryPassword: string }) => ipcRenderer.invoke('auth:resetUserPassword', data),
     // ...
     backup: {
         selectPath: () => ipcRenderer.invoke('backup:selectPath'),
@@ -37,7 +40,6 @@ contextBridge.exposeInMainWorld('electron', {
         getUsers: () => ipcRenderer.invoke('db:getUsers'),
         saveUser: (user: any) => ipcRenderer.invoke('db:saveUser', user),
         deleteUser: (id: number) => ipcRenderer.invoke('db:deleteUser', id),
-        updateUserPassword: (data: any) => ipcRenderer.invoke('db:updateUserPassword', data),
         // Queue
         getQueue: () => ipcRenderer.invoke('db:getQueue'),
         addToQueue: (data: { patientId: number, priority: number }) => ipcRenderer.invoke('db:addToQueue', data),

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -8,6 +8,7 @@ contextBridge.exposeInMainWorld('electron', {
     restoreSystemBackup: (path: string) => ipcRenderer.invoke('auth:restoreSystemBackup', path),
     setup: (data: any) => ipcRenderer.invoke('auth:setup', data),
     recover: (data: any) => ipcRenderer.invoke('auth:recover', data),
+    acknowledgeRecoveryCode: (recoveryCode: string) => ipcRenderer.invoke('auth:acknowledgeRecoveryCode', { recoveryCode }),
     regenerateRecoveryCode: (password: string) => ipcRenderer.invoke('auth:regenerateRecoveryCode', { password }),
     // ...
     backup: {

--- a/desktop/src/main/schema/migrations.spec.ts
+++ b/desktop/src/main/schema/migrations.spec.ts
@@ -33,8 +33,21 @@ describe('Database Migrations', () => {
             });
         });
 
-        it('should have 6 migrations total', () => {
-            expect(MIGRATIONS).toHaveLength(6);
+        it('should have 7 migrations total', () => {
+            expect(MIGRATIONS).toHaveLength(7);
+        });
+    });
+
+    describe('Migration v7 (Credential Rotation Journal)', () => {
+        it('stores only hashes and constrains the recoverable phases', () => {
+            MIGRATIONS[6].up(mockDb);
+            const sql = executedSql.join('\n');
+            expect(sql).toContain('credential_rotation_journal');
+            expect(sql).toContain("phase IN ('prepared', 'applied')");
+            expect(sql).toContain('previous_hash');
+            expect(sql).toContain('replacement_hash');
+            expect(sql).not.toContain('current_password');
+            expect(sql).not.toContain('new_password');
         });
     });
 

--- a/desktop/src/main/schema/migrations.ts
+++ b/desktop/src/main/schema/migrations.ts
@@ -271,5 +271,22 @@ export const MIGRATIONS = [
             console.log('Running Migration v6 (Cloud Backup Schedule)...');
             try { db.exec(`ALTER TABLE settings ADD COLUMN cloud_backup_schedule TEXT DEFAULT '13:00'`); } catch (e) { console.debug('[Migration] cloud_backup_schedule column might already exist.'); }
         }
+    },
+    {
+        version: 7,
+        up: (db: any) => {
+            console.log('Running Migration v7 (Credential Rotation Journal)...');
+            db.exec(`
+                CREATE TABLE IF NOT EXISTS credential_rotation_journal (
+                    id INTEGER PRIMARY KEY CHECK (id = 1),
+                    username TEXT NOT NULL,
+                    previous_hash TEXT NOT NULL,
+                    replacement_hash TEXT NOT NULL,
+                    previous_reset_required INTEGER NOT NULL DEFAULT 0,
+                    phase TEXT NOT NULL CHECK (phase IN ('prepared', 'applied')),
+                    started_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+                );
+            `);
+        }
     }
 ];

--- a/desktop/src/main/services/AdminCredentialVerifier.spec.ts
+++ b/desktop/src/main/services/AdminCredentialVerifier.spec.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as argon2 from 'argon2';
+import { isPersistedActiveAdminSession, verifyPersistedActiveAdmin } from './AdminCredentialVerifier';
+
+vi.mock('argon2', () => ({
+    verify: vi.fn(async (hash: string, password: string) => hash === 'admin-hash' && password === 'current')
+}));
+
+describe('verifyPersistedActiveAdmin', () => {
+    const session = { id: 1, username: 'admin', role: 'admin', name: 'Administrator' } as any;
+    let persisted: any;
+    let database: any;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        persisted = { id: 1, username: 'admin', role: 'admin', active: 1, password: 'admin-hash' };
+        database = { getUserByUsername: vi.fn(() => persisted) };
+    });
+
+    it('accepts only a matching persisted active administrator with the current password', async () => {
+        await expect(verifyPersistedActiveAdmin(session, database, 'current')).resolves.toBe(true);
+        expect(argon2.verify).toHaveBeenCalledWith('admin-hash', 'current');
+    });
+
+    it.each([
+        ['demoted', { role: 'doctor' }],
+        ['deactivated', { active: 0 }],
+        ['id mismatch', { id: 99 }],
+        ['username mismatch', { username: 'other-admin' }]
+    ])('rejects a stale session when the persisted administrator is %s', async (_label, change) => {
+        persisted = { ...persisted, ...change };
+        expect(isPersistedActiveAdminSession(session, database)).toBe(false);
+        await expect(verifyPersistedActiveAdmin(session, database, 'current')).resolves.toBe(false);
+        expect(argon2.verify).not.toHaveBeenCalled();
+    });
+
+    it('rejects an invalid current password and malformed password hashes', async () => {
+        await expect(verifyPersistedActiveAdmin(session, database, 'wrong')).resolves.toBe(false);
+        vi.mocked(argon2.verify).mockRejectedValueOnce(new Error('malformed hash'));
+        await expect(verifyPersistedActiveAdmin(session, database, 'current')).resolves.toBe(false);
+    });
+});

--- a/desktop/src/main/services/AdminCredentialVerifier.ts
+++ b/desktop/src/main/services/AdminCredentialVerifier.ts
@@ -1,0 +1,39 @@
+import * as argon2 from 'argon2';
+import type { UserSession } from './SessionService';
+import type { DatabaseService } from './DatabaseService';
+
+function getPersistedActiveAdmin(sessionUser: UserSession | null, databaseService: DatabaseService): any | null {
+    if (!sessionUser) return null;
+    const persisted = databaseService.getUserByUsername(sessionUser.username);
+    if (!persisted || persisted.id !== sessionUser.id || persisted.username !== sessionUser.username ||
+        persisted.active !== 1 || persisted.role !== 'admin') {
+        return null;
+    }
+    return persisted;
+}
+
+/** Reject stale privileged sessions after role, activation, or identity changes. */
+export function isPersistedActiveAdminSession(
+    sessionUser: UserSession | null,
+    databaseService: DatabaseService
+): boolean {
+    return getPersistedActiveAdmin(sessionUser, databaseService) !== null;
+}
+
+/** Re-authorize sensitive vault metadata changes against current DB state. */
+export async function verifyPersistedActiveAdmin(
+    sessionUser: UserSession | null,
+    databaseService: DatabaseService,
+    password: string
+): Promise<boolean> {
+    if (!sessionUser || typeof password !== 'string' || password.length === 0) return false;
+    const persisted = getPersistedActiveAdmin(sessionUser, databaseService);
+    if (!persisted || typeof persisted.password !== 'string') {
+        return false;
+    }
+    try {
+        return await argon2.verify(persisted.password, password);
+    } catch {
+        return false;
+    }
+}

--- a/desktop/src/main/services/AuthResult.spec.ts
+++ b/desktop/src/main/services/AuthResult.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildAuthenticatedLoginResult } from './AuthResult';
+
+const user = (role: string) => ({ id: 1, username: role, role, name: role, sessionId: 'private-session-id' });
+
+describe('buildAuthenticatedLoginResult', () => {
+    it('discloses a pending recovery code only to an authenticated admin', () => {
+        const recovery = { getPendingRecoveryCode: vi.fn(() => 'NEW-RECOVERY-CODE') };
+        expect(buildAuthenticatedLoginResult(user('admin'), recovery)).toMatchObject({
+            success: true,
+            pendingRecoveryCode: 'NEW-RECOVERY-CODE'
+        });
+        expect(recovery.getPendingRecoveryCode).toHaveBeenCalledOnce();
+    });
+
+    it.each(['doctor', 'nurse', 'receptionist'])('never reads or returns pending recovery for %s', role => {
+        const recovery = { getPendingRecoveryCode: vi.fn(() => 'NEW-RECOVERY-CODE') };
+        const result = buildAuthenticatedLoginResult(user(role), recovery) as any;
+        expect(result.pendingRecoveryCode).toBeUndefined();
+        expect(recovery.getPendingRecoveryCode).not.toHaveBeenCalled();
+    });
+
+    it('allowlists IPC user fields and excludes session or credential internals', () => {
+        const result = buildAuthenticatedLoginResult({
+            ...user('admin'),
+            password: '$argon2id$hash'
+        } as any, { getPendingRecoveryCode: () => null }) as any;
+        expect(result.user.password).toBeUndefined();
+        expect(result.user.sessionId).toBeUndefined();
+    });
+});

--- a/desktop/src/main/services/AuthResult.ts
+++ b/desktop/src/main/services/AuthResult.ts
@@ -1,0 +1,25 @@
+import type { UserSession } from './SessionService';
+
+export interface PendingRecoveryReader { getPendingRecoveryCode(): string | null }
+
+/** Builds the only user object allowed across the authentication IPC boundary. */
+export function buildAuthenticatedLoginResult(user: UserSession, recovery: PendingRecoveryReader) {
+    const publicUser = {
+        id: user.id,
+        username: user.username,
+        role: user.role,
+        name: user.name,
+        ...(user.specialty ? { specialty: user.specialty } : {}),
+        ...(user.license_number ? { license_number: user.license_number } : {}),
+        ...(user.password_reset_required !== undefined
+            ? { password_reset_required: user.password_reset_required }
+            : {})
+    };
+    return {
+        success: true as const,
+        user: publicUser,
+        ...(user.role === 'admin'
+            ? { pendingRecoveryCode: recovery.getPendingRecoveryCode() || undefined }
+            : {})
+    };
+}

--- a/desktop/src/main/services/CredentialRotationService.integration.spec.ts
+++ b/desktop/src/main/services/CredentialRotationService.integration.spec.ts
@@ -1,0 +1,239 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as argon2 from 'argon2';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { DeviceKeyStore } from './DeviceKeyStore';
+import { SecurityService } from './SecurityService';
+import { DatabaseService } from './DatabaseService';
+import { CredentialRotationService, CredentialRotationStep } from './CredentialRotationService';
+
+class IntegrationDeviceStore implements DeviceKeyStore {
+    constructor(private readonly mask: number) { }
+    status() { return { available: true, provider: 'credential-integration-store' }; }
+    protect(value: Buffer) { return Buffer.from(value.map(byte => byte ^ this.mask)); }
+    unprotect(value: Buffer) { return this.protect(value); }
+}
+
+describe.skipIf(!process.versions.electron)('CredentialRotationService SQLCipher integration', () => {
+    let directory: string;
+    let dbPath: string;
+    let store: IntegrationDeviceStore;
+    let security: SecurityService;
+    let database: DatabaseService;
+    let recoveryCode: string;
+
+    beforeEach(async () => {
+        directory = fs.mkdtempSync(path.join(os.tmpdir(), 'nalamdesk-credential-integration-'));
+        dbPath = path.join(directory, 'nalamdesk.db');
+        store = new IntegrationDeviceStore(0x45);
+        security = new SecurityService(store);
+        recoveryCode = await security.setup('not-used-for-vault', dbPath, directory);
+        database = new DatabaseService();
+        database.setDb(security.getDb());
+        await database.migrate({ skipBackup: true });
+        await database.ensureAdminUser('admin-current');
+        await database.saveUser({
+            username: 'doctor', password: 'doctor-current', role: 'doctor', name: 'Doctor'
+        });
+        security.completeProvisioning();
+    });
+
+    afterEach(() => {
+        security?.closeDb();
+        fs.rmSync(directory, { recursive: true, force: true });
+    });
+
+    const restart = async () => {
+        security.closeDb();
+        security = new SecurityService(store);
+        await security.initializeDevice(dbPath, directory);
+        database = new DatabaseService();
+        database.setDb(security.getDb());
+        await database.migrate({ skipBackup: true });
+        const rotations = new CredentialRotationService();
+        rotations.setDb(security.getDb());
+        rotations.reconcileInterruptedRotation();
+        return rotations;
+    };
+
+    it('binds a freshly provisioned same-process vault and changes login across restart without changing vault metadata', async () => {
+        const configBefore = fs.readFileSync(path.join(directory, 'security.json'));
+        const rotations = new CredentialRotationService();
+        rotations.setDb(security.getDb());
+        await rotations.changeOwnPassword(1, 'admin-current', 'admin-replacement');
+
+        await restart();
+        expect(await database.validateUser('admin', 'admin-current')).toMatchObject({ success: false });
+        expect(await database.validateUser('admin', 'admin-replacement')).toMatchObject({ success: true });
+        expect(fs.readFileSync(path.join(directory, 'security.json'))).toEqual(configBefore);
+    });
+
+    it('rejects an invalid current credential without creating a journal', async () => {
+        const rotations = new CredentialRotationService();
+        rotations.setDb(security.getDb());
+        await expect(rotations.changeOwnPassword(1, 'wrong-current', 'admin-replacement'))
+            .rejects.toThrow('INVALID_CREDENTIALS');
+        expect(security.getDb().prepare('SELECT COUNT(*) AS count FROM credential_rotation_journal').get())
+            .toEqual({ count: 0 });
+        expect(await database.validateUser('admin', 'admin-current')).toMatchObject({ success: true });
+    });
+
+    it('migrates an existing encrypted v6 database without changing clinic data or credentials', async () => {
+        security.getDb().exec(`
+            CREATE TABLE preserved_clinic_data(value TEXT);
+            INSERT INTO preserved_clinic_data VALUES ('preserved');
+            DROP TABLE credential_rotation_journal;
+        `);
+        security.getDb().pragma('user_version = 6');
+        await database.migrate({ skipBackup: true });
+        expect(security.getDb().prepare('SELECT value FROM preserved_clinic_data').get())
+            .toEqual({ value: 'preserved' });
+        expect(await database.validateUser('admin', 'admin-current')).toMatchObject({ success: true });
+        expect(security.getDb().pragma('user_version', { simple: true })).toBe(7);
+    });
+
+    it.each(['after-prepare', 'after-apply'] as CredentialRotationStep[])(
+        'rolls back an interruption at %s on the next encrypted-database unlock',
+        async interruptedStep => {
+            const rotations = new CredentialRotationService({
+                onStep: step => { if (step === interruptedStep) throw new Error('simulated process death'); }
+            });
+            rotations.setDb(security.getDb());
+            await expect(rotations.changeOwnPassword(1, 'admin-current', 'admin-replacement'))
+                .rejects.toThrow('simulated process death');
+
+            await restart();
+            expect(await database.validateUser('admin', 'admin-current')).toMatchObject({ success: true });
+            expect(await database.validateUser('admin', 'admin-replacement')).toMatchObject({ success: false });
+            expect(security.getDb().prepare('SELECT COUNT(*) AS count FROM credential_rotation_journal').get())
+                .toEqual({ count: 0 });
+        }
+    );
+
+    it('keeps the completed credential authoritative if notification fails after the commit boundary', async () => {
+        const rotations = new CredentialRotationService({
+            onStep: step => { if (step === 'after-complete') throw new Error('post-commit notification failure'); }
+        });
+        rotations.setDb(security.getDb());
+        await expect(rotations.changeOwnPassword(1, 'admin-current', 'admin-replacement'))
+            .rejects.toThrow('post-commit notification failure');
+        await restart();
+        expect(await database.validateUser('admin', 'admin-current')).toMatchObject({ success: false });
+        expect(await database.validateUser('admin', 'admin-replacement')).toMatchObject({ success: true });
+    });
+
+    it('requires the current admin credential for a separate staff reset workflow', async () => {
+        const doctor = database.getUserByUsername('doctor');
+        const rotations = new CredentialRotationService();
+        rotations.setDb(security.getDb());
+        await expect(rotations.resetUserPassword(1, 'wrong', doctor.id, 'doctor-temporary'))
+            .rejects.toThrow('INVALID_CREDENTIALS');
+        await rotations.resetUserPassword(1, 'admin-current', doctor.id, 'doctor-temporary');
+        await restart();
+        expect(await database.validateUser('doctor', 'doctor-current')).toMatchObject({ success: false });
+        expect(await database.validateUser('doctor', 'doctor-temporary')).toMatchObject({
+            success: true, user: { password_reset_required: 1 }
+        });
+    });
+
+    it('lets a forced-reset user change their own temporary credential and clears the reset flag', async () => {
+        const doctor = database.getUserByUsername('doctor');
+        const rotations = new CredentialRotationService();
+        rotations.setDb(security.getDb());
+        await rotations.changeOwnPassword(doctor.id, 'doctor-current', 'doctor-permanent');
+        await restart();
+        expect(await database.validateUser('doctor', 'doctor-permanent')).toMatchObject({
+            success: true, user: { password_reset_required: 0 }
+        });
+    });
+
+    it('rejects existing-user password fields through the real encrypted generic edit path', async () => {
+        const admin = database.getUserByUsername('admin');
+        await expect(database.saveUser({
+            ...admin,
+            password: 'generic-bypass-attempt'
+        }, admin.id)).rejects.toThrow('GENERIC_PASSWORD_CHANGE_FORBIDDEN');
+        expect(await database.validateUser('admin', 'admin-current')).toMatchObject({ success: true });
+        expect(await database.validateUser('admin', 'generic-bypass-attempt')).toMatchObject({ success: false });
+    });
+
+    it('keeps login, device-envelope, and recovery rotations independent and recoverable', async () => {
+        const rotations = new CredentialRotationService();
+        rotations.setDb(security.getDb());
+        await rotations.changeOwnPassword(1, 'admin-current', 'admin-replacement');
+
+        security.rotateDeviceEnvelope();
+        const afterDevice = fs.readFileSync(path.join(directory, 'security.json'));
+        expect(JSON.parse(afterDevice.toString())).toMatchObject({ version: 3 });
+        expect(await database.validateUser('admin', 'admin-replacement')).toMatchObject({ success: true });
+
+        const newRecoveryCode = await security.regenerateRecoveryCode();
+        expect(security.getPendingRecoveryCode()).toBe(newRecoveryCode);
+        const afterRecovery = fs.readFileSync(path.join(directory, 'security.json'));
+        expect(afterRecovery).not.toEqual(afterDevice);
+        expect(await database.validateUser('admin', 'admin-replacement')).toMatchObject({ success: true });
+        security.acknowledgePendingRecoveryCode(newRecoveryCode);
+
+        security.closeDb();
+        const replacementStore = new IntegrationDeviceStore(0x72);
+        security = new SecurityService(replacementStore);
+        await expect(security.recoverDevice(recoveryCode, directory, dbPath)).rejects.toThrow('INVALID_RECOVERY_CODE');
+        await security.recoverDevice(newRecoveryCode, directory, dbPath);
+        database = new DatabaseService();
+        database.setDb(security.getDb());
+        expect(await database.validateUser('admin', 'admin-replacement')).toMatchObject({ success: true });
+    });
+
+    it('keeps the old recovery authoritative until the proposed code is acknowledged', async () => {
+        const before = JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8'));
+        const proposedCode = await security.regenerateRecoveryCode();
+        const pending = JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8'));
+        expect(pending.recovery).toEqual(before.recovery);
+        expect(pending.pendingRecoveryAck.nextRecovery).toBeTruthy();
+        expect(JSON.stringify(pending)).not.toContain(proposedCode);
+        expect(security.getPortableVaultMetadata().recovery).toEqual(before.recovery);
+
+        security.closeDb();
+        const replacementStore = new IntegrationDeviceStore(0x73);
+        security = new SecurityService(replacementStore);
+        await expect(security.recoverDevice(proposedCode, directory, dbPath))
+            .rejects.toThrow('INVALID_RECOVERY_CODE');
+        await expect(security.recoverDevice(recoveryCode, directory, dbPath))
+            .resolves.toEqual({ migrated: false });
+    });
+
+    it('keeps a rotated recovery code pending across restart until exact acknowledgement', async () => {
+        const before = JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8'));
+        const rotatedCode = await security.regenerateRecoveryCode();
+        const configText = fs.readFileSync(path.join(directory, 'security.json'), 'utf8');
+        expect(configText).not.toContain(rotatedCode);
+        await restart();
+        expect(security.getPendingRecoveryCode()).toBe(rotatedCode);
+        expect(() => security.acknowledgePendingRecoveryCode(`${rotatedCode}X`))
+            .toThrow('INVALID_RECOVERY_ACK');
+        expect(security.getPendingRecoveryCode()).toBe(rotatedCode);
+        const afterWrongAck = JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8'));
+        expect(afterWrongAck.recovery).toEqual(before.recovery);
+        expect(afterWrongAck.pendingRecoveryAck).toBeTruthy();
+        security.acknowledgePendingRecoveryCode(rotatedCode);
+        expect(security.getPendingRecoveryCode()).toBeNull();
+        const activated = JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8'));
+        expect(activated.recovery).not.toEqual(before.recovery);
+        expect(activated.pendingRecoveryAck).toBeUndefined();
+    });
+
+    it('never stores submitted plaintext credentials in the journal', async () => {
+        const rotations = new CredentialRotationService({
+            onStep: step => { if (step === 'after-prepare') throw new Error('inspect journal'); }
+        });
+        rotations.setDb(security.getDb());
+        await expect(rotations.changeOwnPassword(1, 'admin-current', 'plaintext-sentinel'))
+            .rejects.toThrow('inspect journal');
+        const journal = security.getDb().prepare('SELECT * FROM credential_rotation_journal').get();
+        expect(JSON.stringify(journal)).not.toContain('admin-current');
+        expect(JSON.stringify(journal)).not.toContain('plaintext-sentinel');
+        expect(await argon2.verify(journal.previous_hash, 'admin-current')).toBe(true);
+        expect(await argon2.verify(journal.replacement_hash, 'plaintext-sentinel')).toBe(true);
+    });
+});

--- a/desktop/src/main/services/CredentialRotationService.ts
+++ b/desktop/src/main/services/CredentialRotationService.ts
@@ -1,0 +1,177 @@
+import * as argon2 from 'argon2';
+
+export type CredentialRotationStep = 'after-prepare' | 'after-apply' | 'after-complete';
+
+export interface CredentialRotationHooks {
+    onStep?: (step: CredentialRotationStep) => void;
+}
+
+interface RotationJournal {
+    username: string;
+    previous_hash: string;
+    replacement_hash: string;
+    previous_reset_required: number;
+    phase: 'prepared' | 'applied';
+}
+
+const MIN_PASSWORD_LENGTH = 6;
+
+/**
+ * Changes login credentials inside the encrypted database. Login credentials
+ * intentionally never participate in the device or recovery envelope paths.
+ * The journal contains Argon2 hashes only and rolls an interrupted apply back
+ * to the previously accepted credential on the next unlock.
+ */
+export class CredentialRotationService {
+    private db: any;
+
+    constructor(private readonly hooks: CredentialRotationHooks = {}) { }
+
+    setDb(db: any): void {
+        this.db = db;
+    }
+
+    async changeOwnPassword(
+        actorId: number,
+        currentPassword: string,
+        newPassword: string
+    ): Promise<void> {
+        const actor = this.getActiveUser(actorId);
+        await this.rotate(actor, currentPassword, newPassword, false, actorId);
+    }
+
+    async resetUserPassword(
+        adminId: number,
+        currentAdminPassword: string,
+        targetUserId: number,
+        temporaryPassword: string
+    ): Promise<void> {
+        const admin = this.getActiveUser(adminId);
+        if (admin.role !== 'admin') throw new Error('FORBIDDEN');
+        if (admin.id === targetUserId) throw new Error('USE_SELF_PASSWORD_CHANGE');
+        if (!await argon2.verify(admin.password, currentAdminPassword)) {
+            throw new Error('INVALID_CREDENTIALS');
+        }
+        const target = this.getActiveUser(targetUserId);
+        await this.rotate(target, undefined, temporaryPassword, true, adminId, {
+            id: admin.id,
+            password: admin.password
+        });
+    }
+
+    /** Restore the old login hash after any interrupted pre-completion phase. */
+    reconcileInterruptedRotation(): void {
+        this.assertReady();
+        const journal = this.db.prepare(`
+            SELECT username, previous_hash, replacement_hash, previous_reset_required, phase
+            FROM credential_rotation_journal WHERE id = 1
+        `).get() as RotationJournal | undefined;
+        if (!journal) return;
+
+        this.db.transaction(() => {
+            const user = this.db.prepare('SELECT password FROM users WHERE username = ?').get(journal.username);
+            if (!user) throw new Error('CREDENTIAL_JOURNAL_USER_MISSING');
+            if (journal.phase === 'applied') {
+                if (user.password === journal.replacement_hash) {
+                    this.db.prepare(`
+                        UPDATE users SET password = ?, password_reset_required = ? WHERE username = ?
+                    `).run(journal.previous_hash, journal.previous_reset_required, journal.username);
+                } else if (user.password !== journal.previous_hash) {
+                    throw new Error('CREDENTIAL_JOURNAL_STATE_MISMATCH');
+                }
+            } else if (journal.phase !== 'prepared') {
+                throw new Error('CREDENTIAL_JOURNAL_CORRUPT');
+            }
+            this.db.prepare('DELETE FROM credential_rotation_journal WHERE id = 1').run();
+        })();
+    }
+
+    private async rotate(
+        target: any,
+        currentPassword: string | undefined,
+        newPassword: string,
+        forceReset: boolean,
+        actingUserId: number,
+        expectedAuthorizer?: { id: number; password: string }
+    ): Promise<void> {
+        this.assertPassword(newPassword);
+        this.reconcileInterruptedRotation();
+        if (currentPassword !== undefined && !await argon2.verify(target.password, currentPassword)) {
+            throw new Error('INVALID_CREDENTIALS');
+        }
+        if (await argon2.verify(target.password, newPassword)) {
+            throw new Error('PASSWORD_UNCHANGED');
+        }
+
+        const replacementHash = await argon2.hash(newPassword);
+        if (expectedAuthorizer) {
+            const currentAuthorizer = this.db.prepare('SELECT password FROM users WHERE id = ?')
+                .get(expectedAuthorizer.id);
+            if (!currentAuthorizer || currentAuthorizer.password !== expectedAuthorizer.password) {
+                throw new Error('CREDENTIAL_CHANGED_CONCURRENTLY');
+            }
+        }
+        this.db.prepare(`
+            INSERT INTO credential_rotation_journal(
+                id, username, previous_hash, replacement_hash, previous_reset_required, phase, started_at
+            ) VALUES (1, ?, ?, ?, ?, 'prepared', CURRENT_TIMESTAMP)
+        `).run(target.username, target.password, replacementHash, target.password_reset_required ?? 0);
+        this.step('after-prepare');
+
+        this.db.transaction(() => {
+            const result = this.db.prepare(`
+                UPDATE users SET password = ?, password_reset_required = ?
+                WHERE id = ? AND password = ?
+            `).run(replacementHash, forceReset ? 1 : 0, target.id, target.password);
+            if (result.changes !== 1) throw new Error('CREDENTIAL_CHANGED_CONCURRENTLY');
+            this.db.prepare(`
+                UPDATE credential_rotation_journal SET phase = 'applied' WHERE id = 1
+            `).run();
+        })();
+        this.step('after-apply');
+
+        try {
+            this.db.transaction(() => {
+                this.db.prepare('DELETE FROM credential_rotation_journal WHERE id = 1').run();
+                this.db.prepare(`
+                    INSERT INTO audit_logs(action, table_name, record_id, user_id, details)
+                    VALUES (?, 'users', ?, ?, ?)
+                `).run(
+                    forceReset ? 'USER_PASSWORD_RESET' : 'LOGIN_PASSWORD_CHANGE',
+                    target.id,
+                    actingUserId,
+                    forceReset ? `Reset login password for ${target.username}` : `Changed login password for ${target.username}`
+                );
+            })();
+        } catch (error) {
+            // A normal completion error is recoverable without waiting for a
+            // restart. A true process interruption is reconciled on unlock.
+            this.reconcileInterruptedRotation();
+            throw error;
+        }
+        this.step('after-complete');
+    }
+
+    private getActiveUser(id: number): any {
+        this.assertReady();
+        const user = this.db.prepare(`
+            SELECT id, username, password, role, active, password_reset_required FROM users WHERE id = ?
+        `).get(id);
+        if (!user || user.active !== 1) throw new Error('ACCESS_DENIED');
+        return user;
+    }
+
+    private assertPassword(password: string): void {
+        if (typeof password !== 'string' || password.length < MIN_PASSWORD_LENGTH) {
+            throw new Error('PASSWORD_TOO_SHORT');
+        }
+    }
+
+    private assertReady(): void {
+        if (!this.db) throw new Error('VAULT_LOCKED');
+    }
+
+    private step(step: CredentialRotationStep): void {
+        this.hooks.onStep?.(step);
+    }
+}

--- a/desktop/src/main/services/DatabaseService.spec.ts
+++ b/desktop/src/main/services/DatabaseService.spec.ts
@@ -96,6 +96,21 @@ describe('DatabaseService', () => {
             expect(mockStatement.run).toHaveBeenCalled();
         });
 
+        it.each(['admin', 'doctor'])('rejects generic password mutation for an existing %s', async username => {
+            mockStatement.get.mockReturnValue({ id: 1, username, role: username === 'admin' ? 'admin' : 'doctor' });
+            await expect(service.saveUser({
+                id: 1, username, role: username === 'admin' ? 'admin' : 'doctor', name: username,
+                password: 'malicious-change'
+            })).rejects.toThrow('GENERIC_PASSWORD_CHANGE_FORBIDDEN');
+            expect(mockDb.prepare).not.toHaveBeenCalledWith(expect.stringContaining('password = @password'));
+        });
+
+        it('does not overwrite an existing admin credential during provisioning retries', async () => {
+            mockStatement.get.mockReturnValue({ id: 1 });
+            await service.ensureAdminUser('different-password');
+            expect(mockStatement.run).not.toHaveBeenCalled();
+        });
+
         it('should validate user credentials correctly', async () => {
             mockStatement.get.mockReturnValue({
                 id: 1,

--- a/desktop/src/main/services/DatabaseService.ts
+++ b/desktop/src/main/services/DatabaseService.ts
@@ -34,15 +34,17 @@ export class DatabaseService {
         }
     }
 
-    async migrate() {
+    async migrate(options: { skipBackup?: boolean } = {}) {
         if (!this.db) throw new Error('DB not initialized');
 
         // Safety: Backup before migrating
-        try {
-            await this.createBackup(this.db.name);
-        } catch (e) {
-            console.error('[DB] Backup failed! Proceeding with caution...', e);
-            // Optional: Throw if backup is critical? For now, log and proceed (or user can't login).
+        if (!options.skipBackup) {
+            try {
+                await this.createBackup(this.db.name);
+            } catch (e) {
+                console.error('[DB] Backup failed! Proceeding with caution...', e);
+                // Optional: Throw if backup is critical? For now, log and proceed (or user can't login).
+            }
         }
 
         // Check Version
@@ -698,4 +700,3 @@ export class DatabaseService {
         }
     }
 }
-

--- a/desktop/src/main/services/DatabaseService.ts
+++ b/desktop/src/main/services/DatabaseService.ts
@@ -93,15 +93,15 @@ export class DatabaseService {
     }
 
     async ensureAdminUser(password: string) {
-        const hash = await import('argon2').then(a => a.hash(password));
         const admin = this.db.prepare('SELECT id FROM users WHERE username = ?').get('admin');
         if (!admin) {
+            const hash = await import('argon2').then(a => a.hash(password));
             this.db.prepare('INSERT INTO users (username, password, role, name) VALUES (?, ?, ?, ?)').run('admin', hash, 'admin', 'Administrator');
             console.log('Default admin user created.');
         } else {
-            // Update admin password to match current DB key - ensures they are always in sync
-            this.db.prepare('UPDATE users SET password = ? WHERE username = ?').run(hash, 'admin');
-            console.log('Admin password synced with DB key.');
+            // Existing login credentials are never changed by provisioning or
+            // database-key operations. CredentialRotationService owns changes.
+            console.log('Administrator already provisioned; login password preserved.');
         }
 
         // Migration: Add doctor fields to users if missing
@@ -159,29 +159,20 @@ export class DatabaseService {
         };
 
         const result = user.id
-            ? await this.updateExistingUser(safeUser, user, argon2, actingUserId)
+            ? await this.updateExistingUser(safeUser, user, actingUserId)
             : await this.insertNewUser(safeUser, argon2, actingUserId);
 
         return result;
     }
 
-    private async updateExistingUser(safeUser: any, user: any, argon2: any, actingUserId?: number) {
+    private async updateExistingUser(safeUser: any, user: any, actingUserId?: number) {
         const existing = this.db.prepare('SELECT * FROM users WHERE id = ?').get(user.id);
         if (!existing) throw new Error('User not found');
-
-        const includePassword = !!user.password;
-        const forceReset = includePassword && (
-            (actingUserId && actingUserId !== user.id) || user.force_reset
-        );
-
-        if (includePassword) {
-            safeUser.password = await argon2.hash(user.password);
-        }
-        if (forceReset) {
-            safeUser.password_reset_required = 1;
+        if (Object.prototype.hasOwnProperty.call(user, 'password')) {
+            throw new Error('GENERIC_PASSWORD_CHANGE_FORBIDDEN');
         }
 
-        const query = this.buildUpdateQuery(includePassword, forceReset);
+        const query = this.buildUpdateQuery();
         const result = this.db.prepare(query).run(safeUser);
 
         if (actingUserId) {
@@ -190,18 +181,12 @@ export class DatabaseService {
         return result;
     }
 
-    private buildUpdateQuery(includePassword: boolean, forceReset: boolean): string {
+    private buildUpdateQuery(): string {
         const baseCols = `role = @role, name = @name, active = @active, specialty = @specialty, license_number = @license_number,
             mobile = @mobile, email = @email, designation = @designation, joining_date = @joining_date,
             address = @address, emergency_contact_name = @emergency_contact_name, emergency_contact_phone = @emergency_contact_phone`;
 
-        if (!includePassword) {
-            return `UPDATE users SET ${baseCols} WHERE id = @id`;
-        }
-        if (forceReset) {
-            return `UPDATE users SET ${baseCols}, password = @password, password_reset_required = 1 WHERE id = @id`;
-        }
-        return `UPDATE users SET ${baseCols}, password = @password WHERE id = @id`;
+        return `UPDATE users SET ${baseCols} WHERE id = @id`;
     }
 
     private async insertNewUser(safeUser: any, argon2: any, actingUserId?: number) {
@@ -253,13 +238,6 @@ export class DatabaseService {
             this.logAudit('USER_DELETE', 'users', id, actingUserId, `Deleted user ${id}`);
         }
         return result;
-    }
-
-    async updateUserPassword(username: string, newPassword: string) {
-        const argon2 = await import('argon2');
-        const hash = await argon2.hash(newPassword);
-        // This is self-service password change, so we clear the reset_required flag
-        return this.db.prepare('UPDATE users SET password = ?, password_reset_required = 0 WHERE username = ?').run(hash, username);
     }
 
     // ... existing methods ...

--- a/desktop/src/main/services/DeviceKeyStore.spec.ts
+++ b/desktop/src/main/services/DeviceKeyStore.spec.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const safeStorage = {
+    isEncryptionAvailable: vi.fn(),
+    getSelectedStorageBackend: vi.fn(),
+    encryptString: vi.fn(),
+    decryptString: vi.fn()
+};
+
+vi.mock('electron', () => ({ safeStorage }));
+
+describe('ElectronSafeStorageDeviceKeyStore', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.clearAllMocks();
+        safeStorage.isEncryptionAvailable.mockReturnValue(true);
+        safeStorage.getSelectedStorageBackend.mockReturnValue('keychain');
+    });
+
+    it('round-trips a 32-byte key without exposing plaintext to the config', async () => {
+        const key = Buffer.alloc(32, 7);
+        safeStorage.encryptString.mockReturnValue(Buffer.from('ciphertext'));
+        safeStorage.decryptString.mockReturnValue(key.toString('base64'));
+        const { ElectronSafeStorageDeviceKeyStore } = await import('./DeviceKeyStore');
+        const store = new ElectronSafeStorageDeviceKeyStore();
+        expect(store.protect(key)).toEqual(Buffer.from('ciphertext'));
+        expect(safeStorage.encryptString).toHaveBeenCalledWith(key.toString('base64'));
+        expect(store.unprotect(Buffer.from('ciphertext'))).toEqual(key);
+    });
+
+    it('fails when Electron reports encryption unavailable', async () => {
+        safeStorage.isEncryptionAvailable.mockReturnValue(false);
+        const { ElectronSafeStorageDeviceKeyStore } = await import('./DeviceKeyStore');
+        const store = new ElectronSafeStorageDeviceKeyStore();
+        expect(store.status()).toMatchObject({ available: false, reason: 'ENCRYPTION_UNAVAILABLE' });
+        expect(() => store.protect(Buffer.alloc(32))).toThrow('ENCRYPTION_UNAVAILABLE');
+    });
+
+    it('rejects Linux basic_text instead of silently weakening protection', async () => {
+        const originalPlatform = process.platform;
+        Object.defineProperty(process, 'platform', { value: 'linux' });
+        safeStorage.getSelectedStorageBackend.mockReturnValue('basic_text');
+        try {
+            const { ElectronSafeStorageDeviceKeyStore } = await import('./DeviceKeyStore');
+            expect(new ElectronSafeStorageDeviceKeyStore().status()).toMatchObject({
+                available: false,
+                reason: 'INSECURE_LINUX_BACKEND'
+            });
+        } finally {
+            Object.defineProperty(process, 'platform', { value: originalPlatform });
+        }
+    });
+});

--- a/desktop/src/main/services/DeviceKeyStore.ts
+++ b/desktop/src/main/services/DeviceKeyStore.ts
@@ -1,0 +1,41 @@
+import { safeStorage } from 'electron';
+
+export interface DeviceKeyStoreStatus {
+    available: boolean;
+    provider: string;
+    reason?: 'ENCRYPTION_UNAVAILABLE' | 'INSECURE_LINUX_BACKEND';
+}
+
+/** Device-bound wrapping boundary; injectable for tests and future platforms. */
+export interface DeviceKeyStore {
+    status(): DeviceKeyStoreStatus;
+    protect(value: Buffer): Buffer;
+    unprotect(value: Buffer): Buffer;
+}
+
+export class ElectronSafeStorageDeviceKeyStore implements DeviceKeyStore {
+    status(): DeviceKeyStoreStatus {
+        if (!safeStorage.isEncryptionAvailable()) {
+            return { available: false, provider: 'electron-safe-storage', reason: 'ENCRYPTION_UNAVAILABLE' };
+        }
+        if (process.platform === 'linux' && safeStorage.getSelectedStorageBackend() === 'basic_text') {
+            return { available: false, provider: 'electron-safe-storage', reason: 'INSECURE_LINUX_BACKEND' };
+        }
+        return { available: true, provider: 'electron-safe-storage' };
+    }
+
+    protect(value: Buffer): Buffer {
+        this.assertAvailable();
+        return safeStorage.encryptString(value.toString('base64'));
+    }
+
+    unprotect(value: Buffer): Buffer {
+        this.assertAvailable();
+        return Buffer.from(safeStorage.decryptString(value), 'base64');
+    }
+
+    private assertAvailable(): void {
+        const current = this.status();
+        if (!current.available) throw new Error(current.reason || 'DEVICE_KEY_UNAVAILABLE');
+    }
+}

--- a/desktop/src/main/services/ProvisioningService.spec.ts
+++ b/desktop/src/main/services/ProvisioningService.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ProvisioningService } from './ProvisioningService';
+
+describe('ProvisioningService', () => {
+    it.each(['migration', 'settings', 'admin'] as const)(
+        'aborts the durable fresh provisioning transaction when %s fails',
+        async failure => {
+            const security = {
+                setup: vi.fn().mockResolvedValue('RECOVERY'),
+                getDb: vi.fn().mockReturnValue({}),
+                completeProvisioning: vi.fn(),
+                abortProvisioning: vi.fn()
+            };
+            const database = {
+                setDb: vi.fn(),
+                migrate: failure === 'migration'
+                    ? vi.fn().mockRejectedValue(new Error('migration failed'))
+                    : vi.fn().mockResolvedValue(undefined),
+                saveSettings: failure === 'settings'
+                    ? vi.fn(() => { throw new Error('settings failed'); })
+                    : vi.fn(),
+                ensureAdminUser: failure === 'admin'
+                    ? vi.fn().mockRejectedValue(new Error('admin failed'))
+                    : vi.fn().mockResolvedValue(undefined)
+            };
+
+            await expect(new ProvisioningService(security, database).provision(
+                'admin-password', {}, '/db', '/data'
+            )).rejects.toThrow(`${failure} failed`);
+            expect(security.abortProvisioning).toHaveBeenCalledOnce();
+            expect(security.completeProvisioning).not.toHaveBeenCalled();
+        }
+    );
+
+    it('commits only after schema, settings, and administrator creation succeed', async () => {
+        const calls: string[] = [];
+        const security = {
+            setup: vi.fn(async () => { calls.push('setup'); return 'RECOVERY'; }),
+            getDb: vi.fn(() => ({})),
+            completeProvisioning: vi.fn(() => calls.push('complete')),
+            abortProvisioning: vi.fn()
+        };
+        const database = {
+            setDb: vi.fn(() => calls.push('set-db')),
+            migrate: vi.fn(async () => { calls.push('migrate'); }),
+            saveSettings: vi.fn(() => calls.push('settings')),
+            ensureAdminUser: vi.fn(async () => { calls.push('admin'); })
+        };
+        await expect(new ProvisioningService(security, database).provision(
+            'admin-password', {}, '/db', '/data'
+        )).resolves.toBe('RECOVERY');
+        expect(calls).toEqual(['setup', 'set-db', 'migrate', 'settings', 'admin', 'complete']);
+        expect(database.migrate).toHaveBeenCalledWith({ skipBackup: true });
+        expect(security.abortProvisioning).not.toHaveBeenCalled();
+    });
+});

--- a/desktop/src/main/services/ProvisioningService.ts
+++ b/desktop/src/main/services/ProvisioningService.ts
@@ -1,0 +1,42 @@
+export interface VaultProvisioner {
+    setup(adminPassword: string, dbPath: string, userDataPath: string): Promise<string>;
+    getDb(): any;
+    completeProvisioning(): void;
+    abortProvisioning(): void;
+}
+
+export interface ProvisioningDatabase {
+    setDb(db: any): void;
+    migrate(options?: { skipBackup?: boolean }): Promise<void>;
+    saveSettings(settings: any): unknown;
+    ensureAdminUser(password: string): Promise<void>;
+}
+
+/** Coordinates the full fresh-install transaction across vault and application data. */
+export class ProvisioningService {
+    constructor(
+        private readonly security: VaultProvisioner,
+        private readonly database: ProvisioningDatabase
+    ) { }
+
+    async provision(
+        adminPassword: string,
+        clinicDetails: any,
+        dbPath: string,
+        userDataPath: string
+    ): Promise<string> {
+        try {
+            const recoveryCode = await this.security.setup(adminPassword, dbPath, userDataPath);
+            this.database.setDb(this.security.getDb());
+            await this.database.migrate({ skipBackup: true });
+            this.database.saveSettings(clinicDetails);
+            await this.database.ensureAdminUser(adminPassword);
+            this.security.completeProvisioning();
+            return recoveryCode;
+        } catch (error) {
+            this.security.abortProvisioning();
+            this.database.setDb(null);
+            throw error;
+        }
+    }
+}

--- a/desktop/src/main/services/RecoveryCodeAcknowledgement.spec.ts
+++ b/desktop/src/main/services/RecoveryCodeAcknowledgement.spec.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { acknowledgeRecoveryCodeForActiveAdmin } from './RecoveryCodeAcknowledgement';
+
+describe('acknowledgeRecoveryCodeForActiveAdmin', () => {
+    const session = { id: 1, username: 'admin', role: 'admin', name: 'Administrator' } as any;
+    const exactCode = 'AAAA-BBBB-CCCC-DDDD';
+    let persisted: any;
+    let database: any;
+    let state: { recovery: string; pending: string | null };
+    let security: any;
+
+    beforeEach(() => {
+        persisted = { id: 1, username: 'admin', role: 'admin', active: 1, password: 'hash' };
+        database = { getUserByUsername: vi.fn(() => persisted) };
+        state = { recovery: 'old-envelope', pending: exactCode };
+        security = {
+            acknowledgePendingRecoveryCode: vi.fn((code: string) => {
+                if (code !== state.pending) throw new Error('INVALID_RECOVERY_ACK');
+                state = { recovery: 'next-envelope', pending: null };
+            })
+        };
+    });
+
+    it.each([
+        ['demoted', { role: 'doctor' }],
+        ['deactivated', { active: 0 }],
+        ['id mismatch', { id: 99 }],
+        ['username mismatch', { username: 'other-admin' }]
+    ])('does not promote recovery for a %s stale session', (_label, change) => {
+        persisted = { ...persisted, ...change };
+        expect(() => acknowledgeRecoveryCodeForActiveAdmin(
+            session, database, security, exactCode
+        )).toThrow('Forbidden');
+        expect(state).toEqual({ recovery: 'old-envelope', pending: exactCode });
+        expect(security.acknowledgePendingRecoveryCode).not.toHaveBeenCalled();
+    });
+
+    it('promotes the pending recovery for a matching active administrator with the exact code', () => {
+        acknowledgeRecoveryCodeForActiveAdmin(session, database, security, exactCode);
+        expect(state).toEqual({ recovery: 'next-envelope', pending: null });
+        expect(security.acknowledgePendingRecoveryCode).toHaveBeenCalledWith(exactCode);
+    });
+});

--- a/desktop/src/main/services/RecoveryCodeAcknowledgement.ts
+++ b/desktop/src/main/services/RecoveryCodeAcknowledgement.ts
@@ -1,0 +1,15 @@
+import type { UserSession } from './SessionService';
+import type { DatabaseService } from './DatabaseService';
+import type { SecurityService } from './SecurityService';
+import { isPersistedActiveAdminSession } from './AdminCredentialVerifier';
+
+/** Commit a pending recovery rotation only for an administrator still active in the database. */
+export function acknowledgeRecoveryCodeForActiveAdmin(
+    sessionUser: UserSession | null,
+    databaseService: DatabaseService,
+    securityService: SecurityService,
+    recoveryCode: string
+): void {
+    if (!isPersistedActiveAdminSession(sessionUser, databaseService)) throw new Error('Forbidden');
+    securityService.acknowledgePendingRecoveryCode(recoveryCode);
+}

--- a/desktop/src/main/services/SecurityService.integration.spec.ts
+++ b/desktop/src/main/services/SecurityService.integration.spec.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import * as argon2 from 'argon2';
+// @ts-ignore native SQLCipher module
+import Database from 'better-sqlite3-multiple-ciphers';
+import type { DeviceKeyStore } from './DeviceKeyStore';
+import { SecurityService } from './SecurityService';
+import { DatabaseService } from './DatabaseService';
+import { ProvisioningService } from './ProvisioningService';
+
+class IntegrationDeviceStore implements DeviceKeyStore {
+    constructor(private readonly mask: number) { }
+    status() { return { available: true, provider: 'integration-device-store' }; }
+    protect(value: Buffer) { return Buffer.from(value.map(byte => byte ^ this.mask)); }
+    unprotect(value: Buffer) { return this.protect(value); }
+}
+
+// The native SQLCipher module is rebuilt for Electron by postinstall, so these
+// run under Electron's Node mode rather than the host Node ABI.
+describe.skipIf(!process.versions.electron)('SecurityService SQLCipher integration', () => {
+    let directory: string;
+    let dbPath: string;
+
+    beforeEach(() => {
+        directory = fs.mkdtempSync(path.join(os.tmpdir(), 'nalamdesk-vault-integration-'));
+        dbPath = path.join(directory, 'nalamdesk.db');
+    });
+    afterEach(() => fs.rmSync(directory, { recursive: true, force: true }));
+
+    const createEncryptedDb = (key: Buffer, value = 'legacy-preserved') => {
+        const db = new Database(dbPath);
+        db.pragma(`key = "x'${key.toString('hex')}'"`);
+        db.exec(`CREATE TABLE clinical_data (value TEXT); INSERT INTO clinical_data VALUES ('${value}')`);
+        db.close();
+    };
+    const wrapLegacyV2 = (dek: Buffer, kek: Buffer) => {
+        const iv = crypto.randomBytes(16);
+        const cipher = crypto.createCipheriv('aes-256-gcm', kek, iv);
+        const ciphertext = Buffer.concat([cipher.update(dek), cipher.final()]);
+        return {
+            iv: iv.toString('hex'),
+            wrappedKey: Buffer.concat([cipher.getAuthTag(), ciphertext]).toString('hex')
+        };
+    };
+
+    it('cold-starts the same encrypted database using only the device envelope', async () => {
+        const store = new IntegrationDeviceStore(0x42);
+        const first = new SecurityService(store);
+        await first.setup('admin-login-only', dbPath, directory);
+        first.getDb().exec('CREATE TABLE clinical_data (value TEXT); INSERT INTO clinical_data VALUES (\'preserved\')');
+        first.completeProvisioning();
+        first.closeDb();
+
+        const coldStart = new SecurityService(store);
+        await coldStart.initializeDevice(dbPath, directory);
+        expect(coldStart.getDb().prepare('SELECT value FROM clinical_data').get()).toEqual({ value: 'preserved' });
+        coldStart.closeDb();
+    });
+
+    it.each(['migration', 'settings', 'admin'] as const)(
+        'rolls back real fresh provisioning after a %s failure and succeeds on retry',
+        async failure => {
+            const store = new IntegrationDeviceStore(0x44);
+            const security = new SecurityService(store);
+            const database = new DatabaseService();
+            if (failure === 'migration') {
+                vi.spyOn(database, 'migrate').mockRejectedValueOnce(new Error('forced migration failure'));
+            } else if (failure === 'settings') {
+                vi.spyOn(database, 'saveSettings').mockImplementationOnce(() => {
+                    throw new Error('forced settings failure');
+                });
+            } else {
+                vi.spyOn(database, 'ensureAdminUser').mockRejectedValueOnce(new Error('forced admin failure'));
+            }
+            await expect(new ProvisioningService(security, database).provision(
+                'admin-password', { clinic_name: 'Test Clinic' }, dbPath, directory
+            )).rejects.toThrow(`forced ${failure} failure`);
+            expect(fs.existsSync(dbPath)).toBe(false);
+            expect(fs.existsSync(path.join(directory, 'security.json'))).toBe(false);
+            expect(fs.existsSync(path.join(directory, 'security-setup.json'))).toBe(false);
+
+            const retrySecurity = new SecurityService(store);
+            const retryDatabase = new DatabaseService();
+            const code = await new ProvisioningService(retrySecurity, retryDatabase).provision(
+                'admin-password', { clinic_name: 'Test Clinic' }, dbPath, directory
+            );
+            expect(retrySecurity.getPendingRecoveryCode()).toBe(code);
+            expect(await retryDatabase.validateUser('admin', 'admin-password')).toMatchObject({ success: true });
+            retrySecurity.closeDb();
+            await expect(new SecurityService(store).initializeDevice(dbPath, directory))
+                .resolves.toEqual({ migrated: false });
+        }
+    );
+
+    it('re-enrols a new device through the recovery envelope', async () => {
+        const original = new SecurityService(new IntegrationDeviceStore(0x11));
+        const code = await original.setup('admin-login-only', dbPath, directory);
+        original.completeProvisioning();
+        original.closeDb();
+
+        const replacementStore = new IntegrationDeviceStore(0x77);
+        const replacement = new SecurityService(replacementStore);
+        await expect(replacement.recoverDevice(code, directory, dbPath)).resolves.toEqual({ migrated: false });
+        replacement.closeDb();
+        await expect(new SecurityService(replacementStore).initializeDevice(dbPath, directory)).resolves.toEqual({ migrated: false });
+    });
+
+    it('rejects valid key material paired with a different vault identity', async () => {
+        const store = new IntegrationDeviceStore(0x42);
+        const service = new SecurityService(store);
+        await service.setup('admin-login-only', dbPath, directory);
+        service.completeProvisioning();
+        service.closeDb();
+        const configPath = path.join(directory, 'security.json');
+        const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+        config.vaultId = '00000000-0000-4000-8000-000000000000';
+        fs.writeFileSync(configPath, JSON.stringify(config));
+
+        await expect(new SecurityService(store).initializeDevice(dbPath, directory)).rejects.toThrow('VAULT_BINDING_MISMATCH');
+    });
+
+    it('allows admin, doctor, nurse, and receptionist to be first login after separate cold starts', async () => {
+        const store = new IntegrationDeviceStore(0x24);
+        const setup = new SecurityService(store);
+        await setup.setup('admin-password', dbPath, directory);
+        setup.getDb().exec(`CREATE TABLE users (
+            id INTEGER PRIMARY KEY, username TEXT, password TEXT, role TEXT, name TEXT,
+            active INTEGER DEFAULT 1, password_reset_required INTEGER DEFAULT 0
+        )`);
+        const insert = setup.getDb().prepare('INSERT INTO users (id, username, password, role, name) VALUES (?, ?, ?, ?, ?)');
+        const roles = ['admin', 'doctor', 'nurse', 'receptionist'];
+        for (const [index, role] of roles.entries()) {
+            insert.run(index + 1, role, await argon2.hash(`${role}-password`), role, role);
+        }
+        setup.completeProvisioning();
+        setup.closeDb();
+
+        for (const role of roles) {
+            const coldStart = new SecurityService(store);
+            await coldStart.initializeDevice(dbPath, directory);
+            const database = new DatabaseService();
+            database.setDb(coldStart.getDb());
+            await expect(database.validateUser(role, `${role}-password`)).resolves.toMatchObject({
+                success: true,
+                user: { role }
+            });
+            coldStart.closeDb();
+        }
+    });
+
+    it('migrates a real v2 SQLCipher database and preserves data across restart', async () => {
+        const store = new IntegrationDeviceStore(0x31);
+        const builder = new SecurityService(store) as any;
+        const dek = crypto.randomBytes(32);
+        createEncryptedDb(dek);
+        const salt = crypto.randomBytes(16);
+        const wrapped = wrapLegacyV2(dek, await builder.deriveLegacyKey('legacy-master', salt));
+        fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+            version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
+        }));
+
+        const migrated = new SecurityService(store);
+        await expect(migrated.migrateLegacy('legacy-master', dbPath, directory)).resolves.toEqual({ migrated: true });
+        expect(migrated.getDb().prepare('SELECT value FROM clinical_data').get()).toEqual({ value: 'legacy-preserved' });
+        expect(migrated.getPendingRecoveryCode()).toBeTruthy();
+        migrated.closeDb();
+        await expect(new SecurityService(store).initializeDevice(dbPath, directory)).resolves.toEqual({ migrated: false });
+    });
+
+    it('migrates and rekeys a real v1 SQLCipher database', async () => {
+        const store = new IntegrationDeviceStore(0x17);
+        const builder = new SecurityService(store) as any;
+        const salt = crypto.randomBytes(16);
+        fs.writeFileSync(path.join(directory, 'salt.bin'), salt);
+        const legacyKey = await builder.deriveLegacyKey('legacy-master', salt);
+        createEncryptedDb(legacyKey);
+
+        const migrated = new SecurityService(store);
+        await migrated.migrateLegacy('legacy-master', dbPath, directory);
+        expect(migrated.getDb().prepare('SELECT value FROM clinical_data').get()).toEqual({ value: 'legacy-preserved' });
+        expect(fs.existsSync(path.join(directory, 'salt.bin.migrated'))).toBe(true);
+    });
+
+    it('restores the real v1 database and old key when migration fails after rekey', async () => {
+        const store = new IntegrationDeviceStore(0x61);
+        const builder = new SecurityService(store) as any;
+        const salt = crypto.randomBytes(16);
+        fs.writeFileSync(path.join(directory, 'salt.bin'), salt);
+        const legacyKey = await builder.deriveLegacyKey('legacy-master', salt);
+        createEncryptedDb(legacyKey, 'rollback-preserved');
+        const failing = new SecurityService(store, {
+            onStep: step => { if (step === 'migration-after-rekey') throw new Error('forced crash'); }
+        });
+
+        await expect(failing.migrateLegacy('legacy-master', dbPath, directory)).rejects.toThrow('forced crash');
+        const restored = new Database(dbPath);
+        restored.pragma(`key = "x'${legacyKey.toString('hex')}'"`);
+        expect(restored.prepare('SELECT value FROM clinical_data').get()).toEqual({ value: 'rollback-preserved' });
+        restored.close();
+    });
+
+    it.each([
+        { version: 1 as const, path: 'final' as const },
+        { version: 1 as const, path: 'transition' as const },
+        { version: 2 as const, path: 'final' as const },
+        { version: 2 as const, path: 'transition' as const }
+    ])('survives v$version device loss before acknowledgement through the $path recovery path', async ({ version, path: recoveryPath }) => {
+        const legacySecret = `legacy-v${version}`;
+        const oldStore = new IntegrationDeviceStore(0x21);
+        const builder = new SecurityService(oldStore) as any;
+        if (version === 1) {
+            const salt = crypto.randomBytes(16);
+            fs.writeFileSync(path.join(directory, 'salt.bin'), salt);
+            createEncryptedDb(await builder.deriveLegacyKey(legacySecret, salt), 'device-loss-preserved');
+        } else {
+            const dek = crypto.randomBytes(32);
+            createEncryptedDb(dek, 'device-loss-preserved');
+            const salt = crypto.randomBytes(16);
+            const wrapped = wrapLegacyV2(dek, await builder.deriveLegacyKey(legacySecret, salt));
+            fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+                version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
+            }));
+        }
+
+        const migrated = new SecurityService(oldStore);
+        await migrated.migrateLegacy(legacySecret, dbPath, directory);
+        const pendingFinalCode = migrated.getPendingRecoveryCode()!;
+        migrated.closeDb();
+
+        const newStore = new IntegrationDeviceStore(0x72);
+        const recovered = new SecurityService(newStore);
+        await recovered.recoverDevice(
+            recoveryPath === 'final' ? pendingFinalCode : legacySecret,
+            directory,
+            dbPath
+        );
+        expect(recovered.getDb().prepare('SELECT value FROM clinical_data').get())
+            .toEqual({ value: 'device-loss-preserved' });
+        if (recoveryPath === 'final') {
+            expect(recovered.getPendingRecoveryCode()).toBeNull();
+        } else {
+            const rotatedCode = recovered.getPendingRecoveryCode();
+            expect(rotatedCode).toBeTruthy();
+            recovered.acknowledgePendingRecoveryCode(rotatedCode!);
+        }
+        recovered.closeDb();
+        await expect(new SecurityService(newStore).initializeDevice(dbPath, directory))
+            .resolves.toEqual({ migrated: false });
+        await expect(new SecurityService(oldStore).initializeDevice(dbPath, directory))
+            .rejects.toThrow('DEVICE_UNLOCK_FAILED');
+    });
+});

--- a/desktop/src/main/services/SecurityService.spec.ts
+++ b/desktop/src/main/services/SecurityService.spec.ts
@@ -1,107 +1,697 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { DeviceKeyStore } from './DeviceKeyStore';
 import { SecurityService } from './SecurityService';
 
-// Mock dependencies
 vi.mock('argon2', () => ({
-    hash: vi.fn(),
-    argon2id: 2
+    argon2id: 2,
+    hash: vi.fn(async (secret: string, options: { salt: Buffer }) =>
+        crypto.createHash('sha256').update(options.salt).update(secret).digest())
 }));
 
-// Mock better-sqlite3-multiple-ciphers (used in app)
-const mockPragma = vi.fn();
-const mockPrepare = vi.fn();
-const mockGet = vi.fn();
-const mockClose = vi.fn();
+interface DbState { vault?: { vault_id: string; key_version: number } }
+const databases = new Map<string, DbState>();
+let rejectOpen = false;
+let failInsert = false;
 
-mockPrepare.mockReturnValue({ get: mockGet });
-
-vi.mock('better-sqlite3-multiple-ciphers', () => {
-    return {
-        default: class {
-            pragma: any;
-            prepare: any;
-            close: any;
-            constructor() {
-                this.pragma = mockPragma;
-                this.prepare = mockPrepare;
-                this.close = mockClose;
-            }
+vi.mock('better-sqlite3-multiple-ciphers', () => ({
+    default: class MockDatabase {
+        private state: DbState;
+        constructor(private file: string) {
+            this.state = databases.get(file) || {};
+            databases.set(file, this.state);
         }
-    };
-});
+        pragma(statement: string) {
+            if (rejectOpen && statement.startsWith('key =')) throw new Error('file is not a database');
+        }
+        exec() { }
+        prepare(sql: string) {
+            if (sql.includes('count(*)')) return { get: () => ({ count: 1 }) };
+            if (sql.startsWith('SELECT vault_id')) return { get: () => this.state.vault };
+            if (sql.startsWith('INSERT INTO')) return {
+                run: (vaultId: string, keyVersion: number) => {
+                    if (failInsert) throw new Error('forced binding failure');
+                    this.state.vault = { vault_id: vaultId, key_version: keyVersion };
+                }
+            };
+            throw new Error(`Unexpected SQL: ${sql}`);
+        }
+        close() { }
+    }
+}));
 
+class MemoryDeviceKeyStore implements DeviceKeyStore {
+    available = true;
+    private maskByte = 0x5a;
+    status() {
+        return this.available
+            ? { available: true, provider: 'test-device-store' }
+            : { available: false, provider: 'test-device-store', reason: 'ENCRYPTION_UNAVAILABLE' as const };
+    }
+    protect(value: Buffer): Buffer { return Buffer.from(value.map(byte => byte ^ this.maskByte)); }
+    unprotect(value: Buffer): Buffer { return this.protect(value); }
+}
 
-describe('SecurityService', () => {
-    let service: SecurityService;
-    let argon2: any;
+describe('SecurityService v3', () => {
+    let directory: string;
+    let dbPath: string;
+    let store: MemoryDeviceKeyStore;
 
-    beforeEach(async () => {
-        vi.clearAllMocks();
-        argon2 = await import('argon2');
-        service = new SecurityService();
-
-        // Default mock behaviors
-        argon2.hash.mockResolvedValue(Buffer.from('mocked-hash-key'));
-        mockGet.mockReturnValue({ 'count(*)': 1 }); // Success by default
+    beforeEach(() => {
+        directory = fs.mkdtempSync(path.join(os.tmpdir(), 'nalamdesk-security-'));
+        dbPath = path.join(directory, 'nalamdesk.db');
+        fs.writeFileSync(dbPath, '');
+        databases.clear();
+        rejectOpen = false;
+        failInsert = false;
+        store = new MemoryDeviceKeyStore();
     });
 
-    describe('deriveKey', () => {
-        it('should derive a 32-byte key using argon2id', async () => {
-            const password = 'my-secret-password';
-            const salt = Buffer.alloc(16, 'a');
-            const result = await service.deriveKey(password, salt);
+    afterEach(() => fs.rmSync(directory, { recursive: true, force: true }));
 
-            expect(argon2.hash).toHaveBeenCalledWith(password, expect.objectContaining({
-                type: 2, // argon2id
-                raw: true,
-                salt: salt // Ensuring salt is passed
+    it('creates a v3 config without the admin password or plaintext DEK', async () => {
+        const service = new SecurityService(store);
+        const code = await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        const text = fs.readFileSync(path.join(directory, 'security.json'), 'utf8');
+        const config = JSON.parse(text);
+
+        expect(config.version).toBe(3);
+        expect(config.vaultId).toMatch(/^[0-9a-f-]{36}$/);
+        expect(config.keyVersion).toBe(1);
+        expect(config.device.provider).toBe('test-device-store');
+        expect(config.recovery.kdf).toBe('argon2id');
+        expect(text).not.toContain('admin-secret');
+        expect(code).toMatch(/^[A-F0-9]{8}(?:-[A-F0-9]{8}){3}$/);
+    });
+
+    it('unlocks after a cold start without receiving any user password', async () => {
+        const first = new SecurityService(store);
+        await first.setup('admin-secret', dbPath, directory);
+        first.completeProvisioning();
+        first.closeDb();
+
+        const coldStart = new SecurityService(store);
+        await expect(coldStart.initializeDevice(dbPath, directory)).resolves.toEqual({ migrated: false });
+        expect(coldStart.getDb()).toBeTruthy();
+    });
+
+    it('fails closed when device encryption is unavailable', async () => {
+        store.available = false;
+        const service = new SecurityService(store);
+        await expect(service.setup('irrelevant', dbPath, directory)).rejects.toThrow('ENCRYPTION_UNAVAILABLE');
+    });
+
+    it('rolls back a newly-created database when setup fails after binding and permits retry', async () => {
+        const failing = new SecurityService(store);
+        vi.spyOn(failing as any, 'saveConfigAtomic').mockImplementation(() => { throw new Error('forced config failure'); });
+        await expect(failing.setup('admin-secret', dbPath, directory)).rejects.toThrow('forced config failure');
+        expect(fs.existsSync(dbPath)).toBe(false);
+        expect(fs.existsSync(path.join(directory, 'security.json'))).toBe(false);
+        expect(fs.existsSync(path.join(directory, 'security-setup.json'))).toBe(false);
+
+        databases.delete(dbPath);
+        const retry = new SecurityService(store);
+        await expect(retry.setup('admin-secret', dbPath, directory)).resolves.toBeTruthy();
+        retry.completeProvisioning();
+    });
+
+    it('rolls back an interrupted full provisioning on restart and permits retry', async () => {
+        const interrupted = new SecurityService(store);
+        await interrupted.setup('admin-secret', dbPath, directory);
+        expect(fs.existsSync(path.join(directory, 'security-setup.json'))).toBe(true);
+        interrupted.closeDb();
+
+        const restarted = new SecurityService(store);
+        restarted.reconcileProvisioning(dbPath, directory);
+        expect(fs.existsSync(dbPath)).toBe(false);
+        expect(fs.existsSync(path.join(directory, 'security.json'))).toBe(false);
+        expect(fs.existsSync(path.join(directory, 'security-setup.json'))).toBe(false);
+
+        databases.delete(dbPath);
+        const code = await restarted.setup('admin-secret', dbPath, directory);
+        restarted.completeProvisioning();
+        expect(code).toBe(restarted.getPendingRecoveryCode());
+    });
+
+    it('keeps a fresh recovery code device-encrypted until exact acknowledgement', async () => {
+        const service = new SecurityService(store);
+        const code = await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        const configText = fs.readFileSync(path.join(directory, 'security.json'), 'utf8');
+        expect(configText).not.toContain(code);
+        service.closeDb();
+
+        const restarted = new SecurityService(store);
+        await restarted.initializeDevice(dbPath, directory);
+        expect(restarted.getPendingRecoveryCode()).toBe(code);
+        expect(() => restarted.acknowledgePendingRecoveryCode(`${code}X`)).toThrow('INVALID_RECOVERY_ACK');
+        restarted.acknowledgePendingRecoveryCode(code);
+        expect(restarted.getPendingRecoveryCode()).toBeNull();
+    });
+
+    it('reconciles an already-complete provisioning journal after cleanup interruption', async () => {
+        let failed = false;
+        const service = new SecurityService(store, {
+            onStep: step => {
+                if (step === 'cleanup-setup-journal' && !failed) {
+                    failed = true;
+                    throw new Error('cleanup interrupted');
+                }
+            }
+        });
+        await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        expect(fs.existsSync(path.join(directory, 'security-setup.json'))).toBe(true);
+        service.closeDb();
+
+        const restarted = new SecurityService(store);
+        restarted.reconcileProvisioning(dbPath, directory);
+        expect(fs.existsSync(path.join(directory, 'security-setup.json'))).toBe(false);
+        await expect(restarted.initializeDevice(dbPath, directory)).resolves.toEqual({ migrated: false });
+    });
+
+    it('refuses and preserves an existing unclaimed database during fresh setup', async () => {
+        fs.writeFileSync(dbPath, 'existing clinic data');
+        await expect(new SecurityService(store).setup('admin-secret', dbPath, directory))
+            .rejects.toThrow('UNCLAIMED_DATABASE_PRESENT');
+        expect(fs.readFileSync(dbPath, 'utf8')).toBe('existing clinic data');
+    });
+
+    it('requires recovery when the device envelope cannot be decrypted', async () => {
+        const service = new SecurityService(store);
+        await service.setup('irrelevant', dbPath, directory);
+        service.completeProvisioning();
+        service.closeDb();
+        vi.spyOn(store, 'unprotect').mockImplementation(() => { throw new Error('keychain denied'); });
+
+        await expect(new SecurityService(store).initializeDevice(dbPath, directory)).rejects.toThrow('DEVICE_UNLOCK_FAILED');
+    });
+
+    it('re-enrols a replacement device with the recovery code', async () => {
+        const originalStore = new MemoryDeviceKeyStore();
+        const original = new SecurityService(originalStore);
+        const recoveryCode = await original.setup('admin-secret', dbPath, directory);
+        original.completeProvisioning();
+        original.closeDb();
+
+        const replacementStore = new MemoryDeviceKeyStore();
+        (replacementStore as any).maskByte = 0x33;
+        const replacement = new SecurityService(replacementStore);
+        await expect(replacement.recoverDevice(recoveryCode, directory, dbPath)).resolves.toEqual({ migrated: false });
+        replacement.closeDb();
+        await expect(new SecurityService(replacementStore).initializeDevice(dbPath, directory)).resolves.toEqual({ migrated: false });
+    });
+
+    it('rejects an incorrect recovery code without rewriting config', async () => {
+        const service = new SecurityService(store);
+        await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        service.closeDb();
+        const before = fs.readFileSync(path.join(directory, 'security.json'));
+
+        await expect(service.recoverDevice('WRONG-CODE', directory, dbPath)).rejects.toThrow('INVALID_RECOVERY_CODE');
+        expect(fs.readFileSync(path.join(directory, 'security.json'))).toEqual(before);
+    });
+
+    it('detects a swapped security config using the database vault binding', async () => {
+        const service = new SecurityService(store);
+        await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        service.closeDb();
+        const configPath = path.join(directory, 'security.json');
+        const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+        config.vaultId = crypto.randomUUID();
+        fs.writeFileSync(configPath, JSON.stringify(config));
+
+        await expect(new SecurityService(store).initializeDevice(dbPath, directory)).rejects.toThrow('VAULT_BINDING_MISMATCH');
+    });
+
+    it('migrates v2 to v3 and durably protects the pending recovery acknowledgement', async () => {
+        const legacyBuilder = new SecurityService(store) as any;
+        const salt = crypto.randomBytes(16);
+        const legacyKey = crypto.randomBytes(32);
+        const kek = await legacyBuilder.deriveKey('legacy-master', salt);
+        const wrapped = legacyBuilder.aesEncrypt(legacyKey, kek);
+        fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+            version: 2,
+            salt: salt.toString('hex'),
+            wrappedKey: wrapped.wrappedKey,
+            iv: wrapped.iv
+        }));
+
+        const service = new SecurityService(store);
+        const result = await service.migrateLegacy('legacy-master', dbPath, directory);
+        const migratedText = fs.readFileSync(path.join(directory, 'security.json'), 'utf8');
+        const migrated = JSON.parse(migratedText);
+        expect(result.migrated).toBe(true);
+        const pendingCode = service.getPendingRecoveryCode();
+        expect(pendingCode).toMatch(/^[A-F0-9]{8}(?:-[A-F0-9]{8}){3}$/);
+        expect(migrated.version).toBe(3);
+        expect(migrated.migratedFrom).toBe(2);
+        expect(migratedText).not.toContain('legacy-master');
+        expect(migratedText).not.toContain(pendingCode!);
+        expect(fs.existsSync(`${dbPath}.pre-v3-migration`)).toBe(false);
+        expect(fs.existsSync(path.join(directory, 'security-migration.json'))).toBe(false);
+    });
+
+    it('can migrate v2 through its legacy recovery wrapper when the master password is unavailable', async () => {
+        const legacyBuilder = new SecurityService(store) as any;
+        const legacyKey = crypto.randomBytes(32);
+        const passwordSalt = crypto.randomBytes(16);
+        const recoverySalt = crypto.randomBytes(16);
+        const passwordWrapped = legacyBuilder.aesEncrypt(legacyKey, await legacyBuilder.deriveLegacyKey('old-master', passwordSalt));
+        const recoveryWrapped = legacyBuilder.aesEncrypt(legacyKey, await legacyBuilder.deriveLegacyKey('old-recovery', recoverySalt));
+        fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+            version: 2,
+            salt: passwordSalt.toString('hex'),
+            wrappedKey: passwordWrapped.wrappedKey,
+            iv: passwordWrapped.iv,
+            recovery: {
+                salt: recoverySalt.toString('hex'),
+                wrappedKey: recoveryWrapped.wrappedKey,
+                iv: recoveryWrapped.iv
+            }
+        }));
+
+        const service = new SecurityService(store);
+        const result = await service.recoverDevice('old-recovery', directory, dbPath);
+        expect(result.migrated).toBe(true);
+        expect(service.getPendingRecoveryCode()).toBeTruthy();
+        expect(JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8')).version).toBe(3);
+    });
+
+    it('keeps migration recovery acknowledgement across restart until explicitly cleared', async () => {
+        const legacyBuilder = new SecurityService(store) as any;
+        const salt = crypto.randomBytes(16);
+        const key = crypto.randomBytes(32);
+        const wrapped = legacyBuilder.aesEncrypt(key, await legacyBuilder.deriveLegacyKey('legacy', salt));
+        fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+            version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
+        }));
+        await new SecurityService(store).migrateLegacy('legacy', dbPath, directory);
+
+        const restarted = new SecurityService(store);
+        await restarted.initializeDevice(dbPath, directory);
+        const pending = restarted.getPendingRecoveryCode();
+        expect(pending).toBeTruthy();
+        expect(() => restarted.acknowledgePendingRecoveryCode('WRONG-CODE')).toThrow('INVALID_RECOVERY_ACK');
+        restarted.acknowledgePendingRecoveryCode(pending!);
+        expect(restarted.getPendingRecoveryCode()).toBeNull();
+    });
+
+    it.each([1, 2] as const)(
+        'recovers a migrated v%s vault on a new device with the final pending code and retires transition recovery',
+        async version => {
+            const legacySecret = `legacy-v${version}`;
+            if (version === 1) {
+                fs.writeFileSync(path.join(directory, 'salt.bin'), crypto.randomBytes(16));
+            } else {
+                const builder = new SecurityService(store) as any;
+                const salt = crypto.randomBytes(16);
+                const key = crypto.randomBytes(32);
+                const wrapped = builder.aesEncrypt(key, await builder.deriveLegacyKey(legacySecret, salt));
+                fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+                    version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
+                }));
+            }
+            const migrated = new SecurityService(store);
+            await migrated.migrateLegacy(legacySecret, dbPath, directory);
+            const finalCode = migrated.getPendingRecoveryCode()!;
+            migrated.closeDb();
+
+            const replacementStore = new MemoryDeviceKeyStore();
+            (replacementStore as any).maskByte = 0x33;
+            const replacement = new SecurityService(replacementStore);
+            await replacement.recoverDevice(finalCode, directory, dbPath);
+            expect(replacement.getPendingRecoveryCode()).toBeNull();
+            expect(JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8')).transitionRecovery).toBeUndefined();
+            replacement.closeDb();
+            await expect(new SecurityService(replacementStore).initializeDevice(dbPath, directory))
+                .resolves.toEqual({ migrated: false });
+        }
+    );
+
+    it.each([1, 2] as const)(
+        'recovers a migrated v%s vault on a new device with its transition secret and rotates recovery again',
+        async version => {
+            const legacySecret = `legacy-v${version}`;
+            if (version === 1) {
+                fs.writeFileSync(path.join(directory, 'salt.bin'), crypto.randomBytes(16));
+            } else {
+                const builder = new SecurityService(store) as any;
+                const salt = crypto.randomBytes(16);
+                const key = crypto.randomBytes(32);
+                const wrapped = builder.aesEncrypt(key, await builder.deriveLegacyKey(legacySecret, salt));
+                fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+                    version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
+                }));
+            }
+            const migrated = new SecurityService(store);
+            await migrated.migrateLegacy(legacySecret, dbPath, directory);
+            migrated.closeDb();
+
+            const replacementStore = new MemoryDeviceKeyStore();
+            (replacementStore as any).maskByte = 0x33;
+            const replacement = new SecurityService(replacementStore);
+            await replacement.recoverDevice(legacySecret, directory, dbPath);
+            const rotatedCode = replacement.getPendingRecoveryCode();
+            expect(rotatedCode).toMatch(/^[A-F0-9]{8}(?:-[A-F0-9]{8}){3}$/);
+            const config = JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8'));
+            expect(config.transitionRecovery?.purpose).toBe('legacy-transition');
+            expect(() => replacement.acknowledgePendingRecoveryCode('WRONG')).toThrow('INVALID_RECOVERY_ACK');
+            replacement.acknowledgePendingRecoveryCode(rotatedCode!);
+            replacement.closeDb();
+            await expect(new SecurityService(store).initializeDevice(dbPath, directory))
+                .rejects.toThrow('DEVICE_UNLOCK_FAILED');
+            await expect(new SecurityService(replacementStore).initializeDevice(dbPath, directory))
+                .resolves.toEqual({ migrated: false });
+        }
+    );
+
+    it('migrates a v1 direct-password database with a journaled rekey', async () => {
+        fs.writeFileSync(path.join(directory, 'salt.bin'), crypto.randomBytes(16));
+        const service = new SecurityService(store);
+        const result = await service.migrateLegacy('legacy-master', dbPath, directory);
+        const config = JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8'));
+
+        expect(result).toMatchObject({ migrated: true });
+        expect(config).toMatchObject({ version: 3, migratedFrom: 1 });
+        expect(fs.existsSync(path.join(directory, 'salt.bin'))).toBe(false);
+        expect(fs.existsSync(path.join(directory, 'salt.bin.migrated'))).toBe(true);
+    });
+
+    it('rolls the database back when migration fails after the snapshot', async () => {
+        const legacyBuilder = new SecurityService(store) as any;
+        const salt = crypto.randomBytes(16);
+        const legacyKey = crypto.randomBytes(32);
+        const wrapped = legacyBuilder.aesEncrypt(legacyKey, await legacyBuilder.deriveKey('legacy-master', salt));
+        fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+            version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
+        }));
+        const original = fs.readFileSync(dbPath);
+        const originalConfig = fs.readFileSync(path.join(directory, 'security.json'));
+        failInsert = true;
+
+        await expect(new SecurityService(store).migrateLegacy('legacy-master', dbPath, directory)).rejects.toThrow('forced binding failure');
+        expect(fs.readFileSync(dbPath)).toEqual(original);
+        expect(fs.readFileSync(path.join(directory, 'security.json'))).toEqual(originalConfig);
+    });
+
+    it.each(['cleanup-database-backup', 'cleanup-config-backup', 'cleanup-journal'] as const)(
+        'keeps committed migration authoritative when %s fails and reconciles on restart',
+        async cleanupStep => {
+            const legacyBuilder = new SecurityService(store) as any;
+            const salt = crypto.randomBytes(16);
+            const key = crypto.randomBytes(32);
+            const wrapped = legacyBuilder.aesEncrypt(key, await legacyBuilder.deriveLegacyKey('legacy', salt));
+            fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+                version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
             }));
-            expect(result).toEqual(Buffer.from('mocked-hash-key'));
-        });
+            let failed = false;
+            const service = new SecurityService(store, {
+                onStep: step => {
+                    if (step === cleanupStep && !failed) { failed = true; throw new Error('cleanup failure'); }
+                }
+            });
+            await expect(service.migrateLegacy('legacy', dbPath, directory)).resolves.toEqual({ migrated: true });
+            expect(JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8')).version).toBe(3);
+            service.closeDb();
+            await expect(new SecurityService(store).initializeDevice(dbPath, directory)).resolves.toEqual({ migrated: false });
+            expect(fs.existsSync(path.join(directory, 'security-migration.json'))).toBe(false);
+        }
+    );
 
-        it('should propagate errors from argon2', async () => {
-            argon2.hash.mockRejectedValue(new Error('Argon error'));
-            await expect(service.deriveKey('pass', Buffer.alloc(16))).rejects.toThrow('Argon error');
+    it('never rolls back after the atomic v3 config commit point', async () => {
+        const legacyBuilder = new SecurityService(store) as any;
+        const salt = crypto.randomBytes(16);
+        const key = crypto.randomBytes(32);
+        const wrapped = legacyBuilder.aesEncrypt(key, await legacyBuilder.deriveLegacyKey('legacy', salt));
+        fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+            version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
+        }));
+        const service = new SecurityService(store, {
+            onStep: step => { if (step === 'migration-after-config-commit') throw new Error('post-commit failure'); }
         });
+        await expect(service.migrateLegacy('legacy', dbPath, directory)).resolves.toEqual({ migrated: true });
+        expect(JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8')).version).toBe(3);
     });
 
-    describe('initDb', () => {
-        const mockKey = Buffer.from('test-key');
-        const dbPath = 'test.db';
-
-        it('should initialize database with correct pragma key', () => {
-            (service as any).initDb(dbPath, mockKey);
-
-            expect(mockPragma).toHaveBeenCalledWith(`key = "x'${mockKey.toString('hex')}'"`);
-            expect(mockPrepare).toHaveBeenCalledWith('SELECT count(*) FROM sqlite_master'); // Verification query
-            expect(service.getDb()).toBeDefined();
+    it('reconciles a failed legacy-salt cleanup without rolling back committed v1 migration', async () => {
+        fs.writeFileSync(path.join(directory, 'salt.bin'), crypto.randomBytes(16));
+        let failed = false;
+        const service = new SecurityService(store, {
+            onStep: step => {
+                if (step === 'cleanup-legacy-salt' && !failed) { failed = true; throw new Error('cleanup failure'); }
+            }
         });
-
-        it('should throw INVALID_PASSWORD on sqlite error "file is not a database"', () => {
-            // Simulate wrong password error
-            mockGet.mockImplementation(() => { throw new Error('file is not a database'); });
-
-            expect(() => (service as any).initDb(dbPath, mockKey)).toThrow('INVALID_PASSWORD');
-            expect(service.getDb()).toBeUndefined(); // Should not have set the db
-        });
-
-        it('should rethrow other errors', () => {
-            mockGet.mockImplementation(() => { throw new Error('Disk full'); });
-            expect(() => (service as any).initDb(dbPath, mockKey)).toThrow('Disk full');
-        });
+        await service.migrateLegacy('legacy-master', dbPath, directory);
+        service.closeDb();
+        await expect(new SecurityService(store).initializeDevice(dbPath, directory)).resolves.toEqual({ migrated: false });
+        expect(fs.existsSync(path.join(directory, 'salt.bin.migrated'))).toBe(true);
     });
 
-    describe('closeDb', () => {
-        it('should close the database if open', () => {
-            (service as any).initDb('path', Buffer.from('key'));
-            service.closeDb();
-            expect(mockClose).toHaveBeenCalled();
-            expect(service.getDb()).toBeNull();
-        });
+    it('reconciles an interrupted pre-commit migration by restoring its snapshots', async () => {
+        const configPath = path.join(directory, 'security.json');
+        const backupPath = `${dbPath}.pre-v3-migration`;
+        const configBackup = `${configPath}.pre-v3-migration`;
+        fs.writeFileSync(dbPath, 'partially migrated');
+        fs.writeFileSync(backupPath, 'original database');
+        fs.writeFileSync(configPath, JSON.stringify({ version: 3, incomplete: true }));
+        fs.writeFileSync(configBackup, JSON.stringify({ version: 2, salt: '00', wrappedKey: '00', iv: '00' }));
+        fs.writeFileSync(path.join(directory, 'security-migration.json'), JSON.stringify({
+            version: 1,
+            sourceVersion: 2,
+            phase: 'snapshot-created',
+            databaseBackup: backupPath,
+            configBackup,
+            startedAt: new Date().toISOString()
+        }));
 
-        it('should do nothing if db is not open', () => {
-            service.closeDb();
-            expect(mockClose).not.toHaveBeenCalled();
+        await expect(new SecurityService(store).initializeDevice(dbPath, directory)).rejects.toThrow('LEGACY_MIGRATION_REQUIRED');
+        expect(fs.readFileSync(dbPath, 'utf8')).toBe('original database');
+        expect(JSON.parse(fs.readFileSync(configPath, 'utf8')).version).toBe(2);
+        expect(fs.existsSync(path.join(directory, 'security-migration.json'))).toBe(false);
+    });
+
+    it('records rollback restoration before best-effort cleanup and never needs an already deleted snapshot', async () => {
+        const configPath = path.join(directory, 'security.json');
+        const backupPath = `${dbPath}.pre-v3-migration`;
+        const configBackup = `${configPath}.pre-v3-migration`;
+        fs.writeFileSync(dbPath, 'partially migrated');
+        fs.writeFileSync(backupPath, 'original database');
+        fs.writeFileSync(configPath, JSON.stringify({ version: 3, incomplete: true }));
+        fs.writeFileSync(configBackup, JSON.stringify({ version: 2, salt: '00', wrappedKey: '00', iv: '00' }));
+        fs.writeFileSync(path.join(directory, 'security-migration.json'), JSON.stringify({
+            version: 1,
+            sourceVersion: 2,
+            phase: 'snapshot-created',
+            databaseBackup: backupPath,
+            configBackup,
+            startedAt: new Date().toISOString()
+        }));
+        let failed = false;
+        const firstRestart = new SecurityService(store, {
+            onStep: step => {
+                if (step === 'cleanup-rollback-database-backup' && !failed) {
+                    failed = true;
+                    throw new Error('cleanup interrupted');
+                }
+            }
         });
+        await expect(firstRestart.initializeDevice(dbPath, directory)).rejects.toThrow('LEGACY_MIGRATION_REQUIRED');
+        const journal = JSON.parse(fs.readFileSync(path.join(directory, 'security-migration.json'), 'utf8'));
+        expect(journal.phase).toBe('rollback-restored');
+        // Simulate another cleanup artifact already having disappeared.
+        if (fs.existsSync(configBackup)) fs.unlinkSync(configBackup);
+
+        await expect(new SecurityService(store).initializeDevice(dbPath, directory))
+            .rejects.toThrow('LEGACY_MIGRATION_REQUIRED');
+        expect(fs.readFileSync(dbPath, 'utf8')).toBe('original database');
+        expect(fs.existsSync(path.join(directory, 'security-migration.json'))).toBe(false);
+    });
+
+    it('exposes only portable recovery metadata for backup consumers', async () => {
+        const service = new SecurityService(store);
+        await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        const metadata = service.getPortableVaultMetadata() as any;
+        expect(metadata.device).toBeUndefined();
+        expect(Object.keys(metadata).sort()).toEqual(['keyVersion', 'recovery', 'vaultId', 'version']);
+    });
+
+    it('installs portable metadata only after recovery and vault-binding validation', async () => {
+        const source = new SecurityService(store);
+        const recoveryCode = await source.setup('admin-secret', dbPath, directory);
+        source.completeProvisioning();
+        const metadata = source.getPortableVaultMetadata();
+        source.closeDb();
+
+        const restoreDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'nalamdesk-security-restore-'));
+        const restoreDbPath = path.join(restoreDirectory, 'nalamdesk.db');
+        fs.copyFileSync(dbPath, restoreDbPath);
+        databases.set(restoreDbPath, { vault: { ...databases.get(dbPath)!.vault! } });
+        try {
+            const restored = new SecurityService(store);
+            await restored.installPortableVaultMetadata(metadata, recoveryCode, restoreDbPath, restoreDirectory);
+            expect(JSON.parse(fs.readFileSync(path.join(restoreDirectory, 'security.json'), 'utf8'))).toMatchObject({
+                version: 3,
+                vaultId: metadata.vaultId
+            });
+        } finally {
+            fs.rmSync(restoreDirectory, { recursive: true, force: true });
+        }
+    });
+
+    it('retires transition recovery when portable metadata is installed with the primary code', async () => {
+        const legacySecret = 'legacy-portable-secret';
+        const builder = new SecurityService(store) as any;
+        const salt = crypto.randomBytes(16);
+        const key = crypto.randomBytes(32);
+        const wrapped = builder.aesEncrypt(key, await builder.deriveLegacyKey(legacySecret, salt));
+        fs.writeFileSync(path.join(directory, 'security.json'), JSON.stringify({
+            version: 2, salt: salt.toString('hex'), wrappedKey: wrapped.wrappedKey, iv: wrapped.iv
+        }));
+        const migrated = new SecurityService(store);
+        await migrated.migrateLegacy(legacySecret, dbPath, directory);
+        const finalCode = migrated.getPendingRecoveryCode()!;
+        const metadata = migrated.getPortableVaultMetadata();
+        expect(metadata.transitionRecovery).toBeTruthy();
+        migrated.closeDb();
+
+        const restoreDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'nalamdesk-security-transition-'));
+        const restoreDbPath = path.join(restoreDirectory, 'nalamdesk.db');
+        fs.copyFileSync(dbPath, restoreDbPath);
+        databases.set(restoreDbPath, { vault: { ...databases.get(dbPath)!.vault! } });
+        try {
+            const restored = new SecurityService(store);
+            await restored.installPortableVaultMetadata(metadata, finalCode, restoreDbPath, restoreDirectory);
+            const installed = JSON.parse(fs.readFileSync(path.join(restoreDirectory, 'security.json'), 'utf8'));
+            expect(installed.transitionRecovery).toBeUndefined();
+            expect(installed.pendingRecoveryAck).toBeUndefined();
+            restored.closeDb();
+            await expect(new SecurityService(store).recoverDevice(
+                legacySecret, restoreDirectory, restoreDbPath
+            )).rejects.toThrow('INVALID_RECOVERY_CODE');
+        } finally {
+            fs.rmSync(restoreDirectory, { recursive: true, force: true });
+        }
+    });
+
+    it('closes the database and restores the prior config when device recovery commit fails', async () => {
+        const source = new SecurityService(store);
+        const recoveryCode = await source.setup('admin-secret', dbPath, directory);
+        source.completeProvisioning();
+        source.closeDb();
+        const configPath = path.join(directory, 'security.json');
+        const before = fs.readFileSync(configPath, 'utf8');
+
+        const replacement = new SecurityService(store);
+        const save = (replacement as any).saveConfigAtomic.bind(replacement);
+        vi.spyOn(replacement as any, 'saveConfigAtomic').mockImplementation((config: any) => {
+            save(config);
+            throw new Error('forced post-commit failure');
+        });
+        await expect(replacement.recoverDevice(recoveryCode, directory, dbPath))
+            .rejects.toThrow('forced post-commit failure');
+        expect(replacement.getDb()).toBeFalsy();
+        expect(fs.readFileSync(configPath, 'utf8')).toBe(before);
+    });
+
+    it('closes the database and restores an existing config when portable install commit fails', async () => {
+        const source = new SecurityService(store);
+        const recoveryCode = await source.setup('admin-secret', dbPath, directory);
+        source.completeProvisioning();
+        const metadata = source.getPortableVaultMetadata();
+        source.closeDb();
+
+        const restoreDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'nalamdesk-security-install-failure-'));
+        const restoreDbPath = path.join(restoreDirectory, 'nalamdesk.db');
+        const restoreConfigPath = path.join(restoreDirectory, 'security.json');
+        const previous = '{"sentinel":true}';
+        fs.copyFileSync(dbPath, restoreDbPath);
+        fs.writeFileSync(restoreConfigPath, previous);
+        databases.set(restoreDbPath, { vault: { ...databases.get(dbPath)!.vault! } });
+        try {
+            const restored = new SecurityService(store);
+            const save = (restored as any).saveConfigAtomic.bind(restored);
+            vi.spyOn(restored as any, 'saveConfigAtomic').mockImplementation((config: any) => {
+                save(config);
+                throw new Error('forced portable commit failure');
+            });
+            await expect(restored.installPortableVaultMetadata(
+                metadata, recoveryCode, restoreDbPath, restoreDirectory
+            )).rejects.toThrow('forced portable commit failure');
+            expect(restored.getDb()).toBeFalsy();
+            expect(fs.readFileSync(restoreConfigPath, 'utf8')).toBe(previous);
+        } finally {
+            fs.rmSync(restoreDirectory, { recursive: true, force: true });
+        }
+    });
+
+    it('rejects hostile portable KDF parameters before deriving a key', async () => {
+        const source = new SecurityService(store);
+        const recoveryCode = await source.setup('admin-secret', dbPath, directory);
+        source.completeProvisioning();
+        const metadata = source.getPortableVaultMetadata();
+        source.closeDb();
+        metadata.recovery.kdfParams.memoryCost = Number.MAX_SAFE_INTEGER;
+
+        await expect(new SecurityService(store).installPortableVaultMetadata(
+            metadata,
+            recoveryCode,
+            dbPath,
+            directory
+        )).rejects.toThrow('INVALID_RECOVERY_ENVELOPE');
+    });
+
+    it('authenticates the recovery envelope against vault context using AAD', async () => {
+        const service = new SecurityService(store);
+        const code = await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        const metadata = service.getPortableVaultMetadata();
+        service.closeDb();
+        metadata.vaultId = crypto.randomUUID();
+        await expect(new SecurityService(store).installPortableVaultMetadata(
+            metadata, code, dbPath, directory
+        )).rejects.toThrow();
+    });
+
+    it.each(['EPERM', 'EINVAL'])(
+        'propagates Windows regular-file fsync %s failures',
+        code => {
+            const failure = Object.assign(new Error(`regular file ${code}`), { code });
+            const service = new SecurityService(store, {
+                platform: 'win32',
+                fsync: () => { throw failure; }
+            });
+            expect(() => (service as any).fsyncFile(dbPath)).toThrow(`regular file ${code}`);
+        }
+    );
+
+    it.each(['EPERM', 'EINVAL', 'ENOSYS', 'ENOTSUP'])(
+        'tolerates Windows directory fsync incompatibility %s',
+        code => {
+            const unsupported = Object.assign(new Error(`directory ${code}`), { code });
+            const service = new SecurityService(store, {
+                platform: 'win32',
+                fsync: () => { throw unsupported; }
+            });
+            (service as any).configurePaths(dbPath, directory);
+            expect(() => (service as any).fsyncDirectory()).not.toThrow();
+        }
+    );
+
+    it('propagates genuine Windows directory fsync I/O failures', () => {
+        const failure = Object.assign(new Error('directory device I/O failure'), { code: 'EIO' });
+        const service = new SecurityService(store, {
+            platform: 'win32',
+            fsync: () => { throw failure; }
+        });
+        (service as any).configurePaths(dbPath, directory);
+        expect(() => (service as any).fsyncDirectory()).toThrow('directory device I/O failure');
     });
 });

--- a/desktop/src/main/services/SecurityService.spec.ts
+++ b/desktop/src/main/services/SecurityService.spec.ts
@@ -153,6 +153,61 @@ describe('SecurityService v3', () => {
         expect(restarted.getPendingRecoveryCode()).toBeNull();
     });
 
+    it('keeps a regenerated recovery code device-encrypted until exact acknowledgement', async () => {
+        const service = new SecurityService(store);
+        const initialCode = await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        service.acknowledgePendingRecoveryCode(initialCode);
+        const before = JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8'));
+        const rotatedCode = await service.regenerateRecoveryCode();
+        expect(service.getPendingRecoveryCode()).toBe(rotatedCode);
+        const pendingText = fs.readFileSync(path.join(directory, 'security.json'), 'utf8');
+        const pending = JSON.parse(pendingText);
+        expect(pendingText).not.toContain(rotatedCode);
+        expect(pending.recovery).toEqual(before.recovery);
+        expect(pending.pendingRecoveryAck.nextRecovery).toBeTruthy();
+        service.closeDb();
+
+        const restarted = new SecurityService(store);
+        await restarted.initializeDevice(dbPath, directory);
+        expect(restarted.getPendingRecoveryCode()).toBe(rotatedCode);
+        restarted.acknowledgePendingRecoveryCode(rotatedCode);
+        expect(restarted.getPendingRecoveryCode()).toBeNull();
+        expect(JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8')).recovery)
+            .not.toEqual(before.recovery);
+    });
+
+    it('preserves transition recovery until a proposed recovery rotation is activated', async () => {
+        const service = new SecurityService(store);
+        await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        const configPath = path.join(directory, 'security.json');
+        const seeded = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+        seeded.transitionRecovery = { ...seeded.recovery, purpose: 'legacy-transition' };
+        fs.writeFileSync(configPath, JSON.stringify(seeded));
+
+        const rotatedCode = await service.regenerateRecoveryCode();
+        expect(JSON.parse(fs.readFileSync(configPath, 'utf8')).transitionRecovery).toBeTruthy();
+        service.acknowledgePendingRecoveryCode(rotatedCode);
+        expect(JSON.parse(fs.readFileSync(configPath, 'utf8')).transitionRecovery).toBeUndefined();
+    });
+
+    it('preserves the old recovery and pending proposal if activation commit fails', async () => {
+        const service = new SecurityService(store);
+        await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        const rotatedCode = await service.regenerateRecoveryCode();
+        const pendingText = fs.readFileSync(path.join(directory, 'security.json'), 'utf8');
+        vi.spyOn(service as any, 'saveConfigAtomic').mockImplementationOnce(() => {
+            throw new Error('forced activation commit failure');
+        });
+
+        expect(() => service.acknowledgePendingRecoveryCode(rotatedCode))
+            .toThrow('forced activation commit failure');
+        expect(fs.readFileSync(path.join(directory, 'security.json'), 'utf8')).toBe(pendingText);
+        expect(service.getPendingRecoveryCode()).toBe(rotatedCode);
+    });
+
     it('reconciles an already-complete provisioning journal after cleanup interruption', async () => {
         let failed = false;
         const service = new SecurityService(store, {

--- a/desktop/src/main/services/SecurityService.ts
+++ b/desktop/src/main/services/SecurityService.ts
@@ -24,7 +24,8 @@ export interface RecoveryEnvelope {
 interface PendingRecoveryAck {
     protectedPayload: string;
     createdAt: string;
-    reason: 'fresh-setup' | 'legacy-migration' | 'transition-recovery';
+    reason: 'fresh-setup' | 'legacy-migration' | 'transition-recovery' | 'recovery-rotation';
+    nextRecovery?: RecoveryEnvelope;
 }
 
 export interface TransitionRecoveryEnvelope extends RecoveryEnvelope {
@@ -309,7 +310,12 @@ export class SecurityService {
         if (!this.dek) throw new Error('VAULT_LOCKED');
         const config = this.loadConfigV3();
         const recoveryCode = this.generateRecoveryCodeString();
-        config.recovery = await this.createRecoveryEnvelope(this.dek, recoveryCode, config.vaultId, config.keyVersion);
+        const nextRecovery = await this.createRecoveryEnvelope(
+            this.dek, recoveryCode, config.vaultId, config.keyVersion
+        );
+        config.pendingRecoveryAck = this.createPendingRecoveryAck(
+            recoveryCode, config.vaultId, config.keyVersion, 'recovery-rotation', nextRecovery
+        );
         this.saveConfigAtomic(config);
         return recoveryCode;
     }
@@ -340,6 +346,11 @@ export class SecurityService {
         if (!config.pendingRecoveryAck) throw new Error('NO_PENDING_RECOVERY_CODE');
         const pending = this.getPendingRecoveryCode();
         if (!pending || !this.constantTimeEqual(pending, recoveryCode)) throw new Error('INVALID_RECOVERY_ACK');
+        if (config.pendingRecoveryAck.reason === 'recovery-rotation') {
+            if (!config.pendingRecoveryAck.nextRecovery) throw new Error('PENDING_RECOVERY_ENVELOPE_MISSING');
+            this.validateRecoveryEnvelope(config.pendingRecoveryAck.nextRecovery);
+            config.recovery = config.pendingRecoveryAck.nextRecovery;
+        }
         delete config.pendingRecoveryAck;
         delete config.transitionRecovery;
         this.saveConfigAtomic(config);
@@ -818,7 +829,8 @@ export class SecurityService {
         recoveryCode: string,
         vaultId: string,
         keyVersion: number,
-        reason: PendingRecoveryAck['reason']
+        reason: PendingRecoveryAck['reason'],
+        nextRecovery?: RecoveryEnvelope
     ): PendingRecoveryAck {
         return {
             protectedPayload: this.protectContextPayload({
@@ -829,7 +841,8 @@ export class SecurityService {
                 recoveryCode
             }),
             createdAt: new Date().toISOString(),
-            reason
+            reason,
+            ...(nextRecovery ? { nextRecovery } : {})
         };
     }
 

--- a/desktop/src/main/services/SecurityService.ts
+++ b/desktop/src/main/services/SecurityService.ts
@@ -1,403 +1,1006 @@
 import * as argon2 from 'argon2';
-// @ts-ignore - types might be missing or need specific import
+// @ts-ignore native module has no compatible default declaration
 import Database from 'better-sqlite3-multiple-ciphers';
-import * as path from 'path';
 import * as crypto from 'crypto';
 import * as fs from 'fs';
+import * as path from 'path';
+import type { DeviceKeyStore } from './DeviceKeyStore';
 
-/**
- * Security Config Interface stored in security.json
- */
-interface SecurityConfig {
-    version: number;
-    salt: string; // Hex string
-    wrappedKey: string; // Encrypted DEK (Hex string) - Encrypted with Password
-    iv: string; // IV used for wrapping key (Hex string)
-    recovery?: {
-        salt: string; // Hex string (Salt for recovery code)
-        wrappedKey: string; // Encrypted DEK (Hex string) - Encrypted with Recovery Code
-        iv: string; // IV used for recovery wrapping
+export interface RecoveryEnvelope {
+    algorithm: 'aes-256-gcm';
+    kdf: 'argon2id';
+    kdfParams: {
+        timeCost: number;
+        memoryCost: number;
+        parallelism: number;
+        hashLength: number;
     };
+    salt: string;
+    iv: string;
+    wrappedKey: string;
+    aadVersion: 1;
 }
 
+interface PendingRecoveryAck {
+    protectedPayload: string;
+    createdAt: string;
+    reason: 'fresh-setup' | 'legacy-migration' | 'transition-recovery';
+}
+
+export interface TransitionRecoveryEnvelope extends RecoveryEnvelope {
+    purpose: 'legacy-transition';
+}
+
+export interface SecurityConfigV3 {
+    version: 3;
+    vaultId: string;
+    keyVersion: number;
+    device: { provider: string; protectedPayload: string };
+    recovery: RecoveryEnvelope;
+    migratedFrom?: 1 | 2;
+    pendingRecoveryAck?: PendingRecoveryAck;
+    transitionRecovery?: TransitionRecoveryEnvelope;
+}
+
+interface SecurityConfigV2 {
+    version: 2;
+    salt: string;
+    wrappedKey: string;
+    iv: string;
+    recovery?: { salt: string; wrappedKey: string; iv: string };
+}
+
+export interface SetupStatus {
+    isSetup: boolean;
+    hasRecovery: boolean;
+    vaultState: 'not-setup' | 'ready' | 'legacy-migration-required' | 'recovery-required' | 'corrupt';
+    configVersion?: number;
+}
+
+export interface VaultUnlockResult { migrated: boolean }
+
+interface MigrationJournal {
+    version: 1;
+    sourceVersion: 1 | 2;
+    phase: 'snapshot-created' | 'database-rekeyed' | 'config-committing' | 'config-written' | 'rollback-restored';
+    databaseBackup: string;
+    configBackup?: string;
+    legacySaltPath?: string;
+    startedAt: string;
+}
+
+export interface SetupJournal {
+    version: 1;
+    phase: 'started' | 'vault-created' | 'complete';
+    databaseCreated: boolean;
+    startedAt: string;
+}
+
+export type SecurityStep =
+    | 'setup-after-journal' | 'setup-after-bind' | 'setup-after-config-commit'
+    | 'migration-after-snapshot' | 'migration-after-rekey' | 'migration-after-bind'
+    | 'migration-after-config-commit' | 'cleanup-legacy-salt' | 'cleanup-database-backup'
+    | 'cleanup-config-backup' | 'cleanup-journal' | 'cleanup-rollback-database-backup'
+    | 'cleanup-rollback-config-backup' | 'cleanup-rollback-journal' | 'cleanup-setup-journal';
+
+export interface SecurityServiceHooks {
+    onStep?: (step: SecurityStep) => void;
+    platform?: NodeJS.Platform;
+    fsync?: (fd: number) => void;
+}
+
+const CONFIG_FILE = 'security.json';
+const JOURNAL_FILE = 'security-migration.json';
+const SETUP_JOURNAL_FILE = 'security-setup.json';
+const LEGACY_SALT_FILE = 'salt.bin';
+const VAULT_TABLE = '__nalamdesk_vault';
+const RECOVERY_KDF_PARAMS = Object.freeze({ timeCost: 3, memoryCost: 65536, parallelism: 1, hashLength: 32 });
+
 /**
- * SecurityService handles database encryption using SQLCipher with a Key Wrapping Architecture.
- * 
- * V2 Architecture:
- * - Data Encryption Key (DEK): A random 32-byte key that actually encrypts the DB.
- * - Key Encryption Key (KEK): Derived from User Password (or Recovery Code).
- * - The DEK is encrypted (wrapped) by the KEK and stored in security.json.
- * 
- * This allows:
- * 1. Password Changes (Re-wrap DEK with new Password KEK) without re-encrypting the whole DB.
- * 2. Password Recovery (Unwrap DEK with Recovery Code KEK, then Re-wrap with new Password KEK).
+ * Owns the SQLCipher DEK. User passwords are intentionally absent from the v3
+ * unlock path: device unlock and user authentication are separate operations.
  */
 export class SecurityService {
     private db: any;
-    private dbPath: string = '';
-    private appUserDataPath: string = '';
-
-    // In-memory DEK (cleared on app exit)
+    private dbPath = '';
+    private appUserDataPath = '';
     private dek: Buffer | null = null;
 
-    /**
-     * Checks if the application is already set up.
-     */
-    isSetup(userDataPath: string): { isSetup: boolean, hasRecovery: boolean } {
-        const configPath = path.join(userDataPath, 'security.json');
-        const legacySaltPath = path.join(userDataPath, 'salt.bin');
+    constructor(
+        private readonly deviceKeyStore: DeviceKeyStore,
+        private readonly hooks: SecurityServiceHooks = {}
+    ) { }
 
-        if (fs.existsSync(configPath)) {
-            try {
-                const config = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as SecurityConfig;
-                return { isSetup: true, hasRecovery: !!config.recovery };
-            } catch (e) {
-                return { isSetup: true, hasRecovery: false }; // Corrupt file? Treat as setup but broken? Or just assume true.
+    isSetup(userDataPath: string): SetupStatus {
+        const configPath = path.join(userDataPath, CONFIG_FILE);
+        const legacySaltPath = path.join(userDataPath, LEGACY_SALT_FILE);
+        if (!fs.existsSync(configPath)) {
+            return fs.existsSync(legacySaltPath)
+                ? { isSetup: true, hasRecovery: false, vaultState: 'legacy-migration-required', configVersion: 1 }
+                : { isSetup: false, hasRecovery: false, vaultState: 'not-setup' };
+        }
+        try {
+            const config = JSON.parse(fs.readFileSync(configPath, 'utf8')) as SecurityConfigV3 | SecurityConfigV2;
+            if (config.version === 3) {
+                return {
+                    isSetup: true,
+                    hasRecovery: true,
+                    vaultState: this.deviceKeyStore.status().available ? 'ready' : 'recovery-required',
+                    configVersion: 3
+                };
             }
+            if (config.version === 2) {
+                return { isSetup: true, hasRecovery: !!config.recovery, vaultState: 'legacy-migration-required', configVersion: 2 };
+            }
+            return { isSetup: true, hasRecovery: false, vaultState: 'corrupt', configVersion: (config as any).version };
+        } catch {
+            return { isSetup: true, hasRecovery: false, vaultState: 'corrupt' };
         }
-
-        // If legacy salt exists, we consider it "Setup" (will migrate on login)
-        if (fs.existsSync(legacySaltPath)) {
-            return { isSetup: true, hasRecovery: false };
-        }
-
-        return { isSetup: false, hasRecovery: false };
     }
 
-    /**
-     * Fresh Setup: Generates new DEK, creates security.json, and initializes DB.
-     * Returns the Recovery Code for the user to save.
-     */
-    async setup(password: string, dbPath: string, userDataPath: string): Promise<string> {
-        this.appUserDataPath = userDataPath;
-        this.dbPath = dbPath;
-
-        // 1. Generate Random DEK
-        this.dek = crypto.randomBytes(32);
-
-        // 2. Generate Recovery Code
+    /** adminPassword remains only for caller compatibility; it never wraps the DEK. */
+    async setup(_adminPassword: string, dbPath: string, userDataPath: string): Promise<string> {
+        this.configurePaths(dbPath, userDataPath);
+        this.assertDeviceStoreAvailable();
+        this.reconcileSetupJournal();
+        if (fs.existsSync(path.join(userDataPath, CONFIG_FILE))) throw new Error('ALREADY_SETUP');
+        const databaseCreated = !fs.existsSync(dbPath) || fs.statSync(dbPath).size === 0;
+        if (!databaseCreated) throw new Error('UNCLAIMED_DATABASE_PRESENT');
+        const journal: SetupJournal = {
+            version: 1,
+            phase: 'started',
+            databaseCreated,
+            startedAt: new Date().toISOString()
+        };
+        this.saveSetupJournal(journal);
+        this.step('setup-after-journal');
+        const dek = crypto.randomBytes(32);
         const recoveryCode = this.generateRecoveryCodeString();
-
-        // 3. Create Security Config (Wrap DEK with Password AND Recovery Code)
-        const config = await this.createSecurityConfig(this.dek, password, recoveryCode);
-        this.saveConfig(config);
-
-        // 4. Initialize DB with DEK
-        this.initDb(this.dbPath, this.dek);
-
-        return recoveryCode;
-    }
-
-    /**
-     * Initialize / Unlock the encrypted database.
-     * Handles V1 -> V2 Migration transparently.
-     */
-    async initialize(password: string, dbPath: string, userDataPath: string): Promise<void> {
-        this.appUserDataPath = userDataPath;
-        this.dbPath = dbPath;
-
-        const configPath = path.join(userDataPath, 'security.json');
-        const legacySaltPath = path.join(userDataPath, 'salt.bin');
-
-        // CASE 1: V2 Setup Exists
-        if (fs.existsSync(configPath)) {
-            console.log('[Security] Loading V2 Configuration...');
-            const config = this.loadConfig();
-
-            // Unwrap DEK using Password
-            try {
-                this.dek = await this.unwrapKey(config.wrappedKey, config.iv, config.salt, password);
-                this.initDb(this.dbPath, this.dek);
-                console.log('[Security] Vault Unlocked (V2).');
-            } catch (e) {
-                console.error('[Security] Failed to unlock vault:', e);
-                throw new Error('INVALID_PASSWORD');
-            }
-            return;
-        }
-
-        // CASE 2: V1 Legacy Exists -> Migrate to V2
-        if (fs.existsSync(legacySaltPath)) {
-            console.log('[Security] Detected V1 Setup. Starting Migration to V2...');
-            await this.migrateV1toV2(password, legacySaltPath);
-            return;
-        }
-
-        // CASE 3: No Setup -> Should have called setup() instead.
-        throw new Error('NOT_SETUP');
-    }
-
-
-    /**
-     * Recover Password using Recovery Code.
-     * Sets a new password and re-wraps the DEK.
-     */
-    async recover(recoveryCode: string, newPassword: string, userDataPath: string, dbPath: string): Promise<string> {
-        this.appUserDataPath = userDataPath;
-        this.dbPath = dbPath;
-
-        const config = this.loadConfig();
-        if (!config.recovery) {
-            throw new Error('NO_RECOVERY_CODE_SET');
-        }
-
-        // 1. Unwrap DEK using Recovery Code
+        const config = await this.createV3Config(dek, recoveryCode, undefined, undefined, 'fresh-setup');
         try {
-            this.dek = await this.unwrapKey(config.recovery.wrappedKey, config.recovery.iv, config.recovery.salt, recoveryCode);
-        } catch (e) {
-            throw new Error('INVALID_RECOVERY_CODE');
-        }
-
-        // 2. Rotate Security Config (New Password KEK + New Recovery Code KEK)
-        const newRecoveryCode = this.generateRecoveryCodeString();
-
-        // Wrap DEK with NEW Password
-        const salt = crypto.randomBytes(16);
-        const kek = await this.deriveKey(newPassword, salt);
-        const { encrypted: wrappedKey, iv } = this.aesEncrypt(this.dek, kek);
-
-        // Wrap DEK with NEW Recovery Code
-        const rSalt = crypto.randomBytes(16);
-        const rKek = await this.deriveKey(newRecoveryCode, rSalt);
-        const { encrypted: rWrappedKey, iv: rIv } = this.aesEncrypt(this.dek, rKek);
-
-        const newConfig: SecurityConfig = {
-            version: 2,
-            salt: salt.toString('hex'),
-            wrappedKey: wrappedKey,
-            iv: iv,
-            recovery: {
-                salt: rSalt.toString('hex'),
-                wrappedKey: rWrappedKey,
-                iv: rIv
-            }
-        };
-
-        this.saveConfig(newConfig);
-
-        // 3. Open DB
-        this.initDb(this.dbPath, this.dek);
-        console.log('[Security] Password reset successful. Vault Unlocked. Recovery Code Rotated.');
-
-        return newRecoveryCode;
-    }
-
-    /**
-     * Helper: Generate a secure recovery code string (Format: XXXX-XXXX-XXXX-XXXX)
-     */
-    generateRecoveryCodeString(): string {
-        // Generate 16 bytes of random entropy, generic human-readable format
-        const bytes = crypto.randomBytes(10); // 20 hex chars
-        const hex = bytes.toString('hex').toUpperCase();
-        return `${hex.slice(0, 5)}-${hex.slice(5, 10)}-${hex.slice(10, 15)}-${hex.slice(15, 20)}`;
-    }
-
-    /**
-     * Regenerate Recovery Code (for Admin).
-     * Requires the current password to unlock logic (though DEK is already in memory).
-     * Re-wraps the DEK with valid Password and NEW Recovery Code.
-     */
-    async regenerateRecoveryCode(password: string): Promise<string> {
-        if (!this.dek) {
-            // Try to load/unlock if not in memory (shouldn't happen if logged in, but safety first)
-            // Or assume DEK is available if app is running and unlocked.
-            // If DEK is missing, we must fail or ask to unlock.
-            throw new Error('VAULT_LOCKED');
-        }
-
-        const config = this.loadConfig();
-
-        // Vefiry password by attempting to derive KEK and check against wrappedKey?
-        // Or just rely on the fact we are re-wrapping. 
-        // Better to re-wrap properly.
-
-        // 1. Generate NEW Recovery Code
-        const newRecoveryCode = this.generateRecoveryCodeString();
-
-        // 2. Create NEW Security Config
-        // We re-use the existing DEK (this.dek).
-        const newConfig = await this.createSecurityConfig(this.dek, password, newRecoveryCode);
-
-        this.saveConfig(newConfig);
-
-        return newRecoveryCode;
-    }
-
-    // ==================================================================================
-    //                                  PRIVATE HELPERS
-    // ==================================================================================
-
-    private async createSecurityConfig(dek: Buffer, password: string, recoveryCode: string): Promise<SecurityConfig> {
-        // 1. Wrap with Password
-        const salt = crypto.randomBytes(16);
-        const kek = await this.deriveKey(password, salt);
-        const { encrypted: wrappedKey, iv } = this.aesEncrypt(dek, kek);
-
-        // 2. Wrap with Recovery Code
-        const rSalt = crypto.randomBytes(16);
-        const rKek = await this.deriveKey(recoveryCode, rSalt);
-        const { encrypted: rWrappedKey, iv: rIv } = this.aesEncrypt(dek, rKek);
-
-        return {
-            version: 2,
-            salt: salt.toString('hex'),
-            wrappedKey: wrappedKey,
-            iv: iv,
-            recovery: {
-                salt: rSalt.toString('hex'),
-                wrappedKey: rWrappedKey,
-                iv: rIv
-            }
-        };
-    }
-
-    private async unwrapKey(wrappedKeyHex: string, ivHex: string, saltHex: string, secret: string): Promise<Buffer> {
-        const salt = Buffer.from(saltHex, 'hex');
-        const kek = await this.deriveKey(secret, salt);
-        return this.aesDecrypt(wrappedKeyHex, ivHex, kek);
-    }
-
-    /**
-     * Migrate V1 (Direct Password) to V2 (Wrapped Key)
-     * 1. Derive OLD Key from Password + Old Salt.
-     * 2. Open DB with OLD Key.
-     * 3. Change DB Key to NEW Random DEK (`PRAGMA rekey`).
-     * 4. Wrap NEW DEK with Password and Save Config.
-     */
-    private async migrateV1toV2(password: string, legacySaltPath: string): Promise<void> {
-        const salt = fs.readFileSync(legacySaltPath);
-
-        // 1. Derive V1 Key
-        const oldKey = await this.deriveKeyArgon2(password, salt); // Use raw argon2 like V1
-
-        // 2. Open DB with V1 Key to verify password
-        try {
-            this.initDb(this.dbPath, oldKey);
-        } catch (e) {
-            throw new Error('INVALID_PASSWORD'); // Pass through
-        }
-
-        console.log('[Security] V1 Key Verified. Rekeying database...');
-
-        // 3. Generate NEW Random DEK
-        this.dek = crypto.randomBytes(32);
-        const newKeyHex = this.dek.toString('hex');
-
-        // 4. PRAGMA rekey (Change DB Encryption Key)
-        this.db.pragma(`rekey = "x'${newKeyHex}'"`);
-
-        // 5. Create V2 Config (Wrap DEK)
-        // Note: We don't have a recovery code yet. User will need to generate one later.
-        const configSalt = crypto.randomBytes(16);
-        const kek = await this.deriveKey(password, configSalt);
-        const { encrypted: wrappedKey, iv } = this.aesEncrypt(this.dek, kek);
-
-        const config: SecurityConfig = {
-            version: 2,
-            salt: configSalt.toString('hex'),
-            wrappedKey: wrappedKey,
-            iv: iv,
-            // recovery: undefined // No recovery code yet
-        };
-
-        this.saveConfig(config);
-
-        // 6. Cleanup V1 Salt
-        // fs.unlinkSync(legacySaltPath); // Optional: keep for safety or backup? Let's keep it but maybe rename?
-        console.log('[Security] Migration to V2 Complete.');
-    }
-
-    private saveConfig(config: SecurityConfig) {
-        const configPath = path.join(this.appUserDataPath, 'security.json');
-        fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
-    }
-
-    private loadConfig(): SecurityConfig {
-        const configPath = path.join(this.appUserDataPath, 'security.json');
-        return JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    }
-
-    /**
-     * V2 Key Derivation (Standardized)
-     * Uses Argon2id but we can tune parameters if needed. 
-     * We keep it simple to match V1 but ensure it's consistent.
-     */
-    private async deriveKey(secret: string, salt: Buffer): Promise<Buffer> {
-        return argon2.hash(secret, {
-            type: argon2.argon2id,
-            raw: true,
-            salt: salt
-        });
-    }
-
-    /**
-     * V1 Key Derivation (Strictly for backward compat with exact V1 params if any)
-     * V1 used default params.
-     */
-    private async deriveKeyArgon2(password: string, salt: Buffer): Promise<Buffer> {
-        return argon2.hash(password, {
-            type: argon2.argon2id,
-            raw: true,
-            salt: salt
-        });
-    }
-
-    private aesEncrypt(data: Buffer, key: Buffer): { encrypted: string, iv: string } {
-        const iv = crypto.randomBytes(16); // IV for AES-256-GCM
-        const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
-        const encrypted = Buffer.concat([cipher.update(data), cipher.final()]);
-        const tag = cipher.getAuthTag();
-        // Return IV + AuthTag + EncryptedData as hex string or define a format
-        // Simple format: iv (hex) | tag (hex) | encrypted (hex)
-        // Actually, let's keep IV separate in JSON for clarity. 
-        // Combine Tag + Encrypted
-        return {
-            encrypted: Buffer.concat([tag, encrypted]).toString('hex'), // First 16 bytes is tag
-            iv: iv.toString('hex')
-        };
-    }
-
-    private aesDecrypt(encryptedHex: string, ivHex: string, key: Buffer): Buffer {
-        const encryptedAndTag = Buffer.from(encryptedHex, 'hex');
-        const tag = encryptedAndTag.subarray(0, 16);
-        const encrypted = encryptedAndTag.subarray(16);
-        const iv = Buffer.from(ivHex, 'hex');
-
-        const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
-        decipher.setAuthTag(tag);
-        return Buffer.concat([decipher.update(encrypted), decipher.final()]);
-    }
-
-    private initDb(filePath: string, key: Buffer): void {
-        try {
-            this.dbPath = filePath;
-            const isDevMode = process.env['NODE_ENV'] !== 'production';
-            const db = new Database(filePath, isDevMode ? { verbose: console.log } : {});
-
-            const hexKey = key.toString('hex');
-            db.pragma(`key = "x'${hexKey}'"`);
-
-            // Verify
-            db.prepare('SELECT count(*) FROM sqlite_master').get();
-
-            this.db = db;
-            console.log('[Security] Database opened successfully');
-        } catch (error: any) {
-            console.error('[Security] Database initialization failed:', error);
-            if (error.message && (error.message.includes('file is not a database') || error.message.includes('SqliteError'))) {
-                throw new Error('INVALID_PASSWORD');
-            }
+            this.initDb(dbPath, dek);
+            this.bindVault(config.vaultId, config.keyVersion, true);
+            this.db.pragma('wal_checkpoint(TRUNCATE)');
+            this.step('setup-after-bind');
+            this.saveConfigAtomic(config);
+            this.step('setup-after-config-commit');
+            journal.phase = 'vault-created';
+            this.saveSetupJournal(journal);
+            this.dek = dek;
+            return recoveryCode;
+        } catch (error) {
+            this.closeDb();
+            this.rollbackSetup(journal);
             throw error;
         }
     }
 
-    getDb() { return this.db; }
-    closeDb() {
-        if (this.db) {
-            this.db.close();
-            this.db = null;
-            this.dek = null; // Clear key from memory on close
+    /** Marks the entire setup pipeline (vault, schema, settings, admin) durable. */
+    completeProvisioning(): void {
+        const journal = this.loadSetupJournal();
+        if (!journal || journal.phase !== 'vault-created') throw new Error('PROVISIONING_NOT_STARTED');
+        this.db?.pragma('wal_checkpoint(TRUNCATE)');
+        journal.phase = 'complete';
+        this.saveSetupJournal(journal);
+        this.cleanupSetupJournal();
+    }
+
+    /** Rolls back only files created by the in-progress fresh provisioning. */
+    abortProvisioning(): void {
+        const journal = this.loadSetupJournal();
+        if (!journal || journal.phase === 'complete') return;
+        this.rollbackSetup(journal);
+    }
+
+    /** Reconciles an interrupted setup before setup-state is presented. */
+    reconcileProvisioning(dbPath: string, userDataPath: string): void {
+        this.configurePaths(dbPath, userDataPath);
+        this.reconcileSetupJournal();
+    }
+
+    /** Unlock v3 using only the OS-bound device envelope. */
+    async initializeDevice(dbPath: string, userDataPath: string): Promise<VaultUnlockResult> {
+        this.configurePaths(dbPath, userDataPath);
+        this.reconcileSetupJournal();
+        this.reconcileMigrationJournal();
+        const status = this.isSetup(userDataPath);
+        if (!status.isSetup) throw new Error('NOT_SETUP');
+        if (status.vaultState === 'legacy-migration-required') throw new Error('LEGACY_MIGRATION_REQUIRED');
+        if (status.vaultState === 'corrupt') throw new Error('SECURITY_CONFIG_CORRUPT');
+        this.assertDeviceStoreAvailable();
+        const config = this.loadConfigV3();
+        try {
+            const dek = this.unprotectDeviceDek(config);
+            this.initDb(dbPath, dek);
+            this.bindVault(config.vaultId, config.keyVersion, false);
+            this.dek = dek;
+            return { migrated: false };
+        } catch (error: any) {
+            this.closeDb();
+            if (error?.message === 'VAULT_BINDING_MISMATCH') throw error;
+            throw new Error('DEVICE_UNLOCK_FAILED');
         }
     }
-    getDbPath() { return this.dbPath; }
+
+    /** One-time compatibility path. The legacy secret is never retained in v3. */
+    async migrateLegacy(legacySecret: string, dbPath: string, userDataPath: string): Promise<VaultUnlockResult> {
+        this.configurePaths(dbPath, userDataPath);
+        this.assertDeviceStoreAvailable();
+        this.reconcileMigrationJournal();
+        const configPath = path.join(userDataPath, CONFIG_FILE);
+        if (fs.existsSync(configPath)) {
+            const parsed = JSON.parse(fs.readFileSync(configPath, 'utf8')) as SecurityConfigV3 | SecurityConfigV2;
+            if (parsed.version === 3) return this.initializeDevice(dbPath, userDataPath);
+            if (parsed.version !== 2) throw new Error('UNSUPPORTED_SECURITY_CONFIG');
+            return this.migrateV2(parsed, legacySecret);
+        }
+        const saltPath = path.join(userDataPath, LEGACY_SALT_FILE);
+        if (!fs.existsSync(saltPath)) throw new Error('NOT_SETUP');
+        return this.migrateV1(legacySecret, saltPath);
+    }
+
+    /** Re-enrol this device from the portable recovery envelope. */
+    async recoverDevice(recoveryCode: string, userDataPath: string, dbPath: string): Promise<VaultUnlockResult> {
+        this.configurePaths(dbPath, userDataPath);
+        this.assertDeviceStoreAvailable();
+        const status = this.isSetup(userDataPath);
+        if (status.configVersion === 2) {
+            return this.migrateLegacy(recoveryCode, dbPath, userDataPath);
+        }
+        const config = this.loadConfigV3();
+        const previousConfigText = fs.readFileSync(path.join(userDataPath, CONFIG_FILE), 'utf8');
+        let dek: Buffer;
+        let usedTransition = false;
+        this.validateRecoveryEnvelope(config.recovery);
+        try {
+            dek = await this.unwrapRecovery(config.recovery, recoveryCode, config.vaultId, config.keyVersion);
+        } catch {
+            if (config.transitionRecovery?.purpose !== 'legacy-transition') throw new Error('INVALID_RECOVERY_CODE');
+            this.validateRecoveryEnvelope(config.transitionRecovery);
+            try {
+                dek = await this.unwrapRecovery(
+                    config.transitionRecovery,
+                    recoveryCode,
+                    config.vaultId,
+                    config.keyVersion,
+                    'legacy-transition'
+                );
+                usedTransition = true;
+            } catch { throw new Error('INVALID_RECOVERY_CODE'); }
+        }
+        try {
+            this.initDb(dbPath, dek);
+            this.bindVault(config.vaultId, config.keyVersion, false);
+        } catch (error: any) {
+            this.closeDb();
+            dek.fill(0);
+            if (error?.message === 'VAULT_BINDING_MISMATCH') throw error;
+            throw new Error('INVALID_RECOVERY_CODE');
+        }
+        try {
+            const updated: SecurityConfigV3 = {
+                ...config,
+                device: this.createDeviceEnvelope(dek, config.vaultId, config.keyVersion)
+            };
+            if (usedTransition) {
+                const freshCode = this.generateRecoveryCodeString();
+                updated.recovery = await this.createRecoveryEnvelope(dek, freshCode, config.vaultId, config.keyVersion);
+                updated.transitionRecovery = await this.createTransitionRecoveryEnvelope(
+                    dek, recoveryCode, config.vaultId, config.keyVersion
+                );
+                updated.pendingRecoveryAck = this.createPendingRecoveryAck(
+                    freshCode, config.vaultId, config.keyVersion, 'transition-recovery'
+                );
+            } else {
+                // Possession of the primary code retires every transitional artifact.
+                delete updated.pendingRecoveryAck;
+                delete updated.transitionRecovery;
+            }
+            this.saveConfigAtomic(updated);
+            this.dek = dek;
+            return { migrated: false };
+        } catch (error) {
+            this.failEnrollment(dek, previousConfigText);
+            throw error;
+        }
+    }
+
+    async regenerateRecoveryCode(): Promise<string> {
+        if (!this.dek) throw new Error('VAULT_LOCKED');
+        const config = this.loadConfigV3();
+        const recoveryCode = this.generateRecoveryCodeString();
+        config.recovery = await this.createRecoveryEnvelope(this.dek, recoveryCode, config.vaultId, config.keyVersion);
+        this.saveConfigAtomic(config);
+        return recoveryCode;
+    }
+
+    /** Re-wrap the unchanged DEK for this device; independent of all user credentials. */
+    rotateDeviceEnvelope(): void {
+        if (!this.dek) throw new Error('VAULT_LOCKED');
+        this.assertDeviceStoreAvailable();
+        const config = this.loadConfigV3();
+        config.device = this.createDeviceEnvelope(this.dek, config.vaultId, config.keyVersion);
+        this.saveConfigAtomic(config);
+    }
+
+    getPendingRecoveryCode(): string | null {
+        const config = this.loadConfigV3();
+        if (!config.pendingRecoveryAck) return null;
+        const payload = this.unprotectContextPayload(config.pendingRecoveryAck.protectedPayload);
+        if (payload.version !== 1 || payload.purpose !== 'recovery-ack' ||
+            payload.vaultId !== config.vaultId || payload.keyVersion !== config.keyVersion ||
+            typeof payload.recoveryCode !== 'string') {
+            throw new Error('PENDING_RECOVERY_CONTEXT_MISMATCH');
+        }
+        return payload.recoveryCode;
+    }
+
+    acknowledgePendingRecoveryCode(recoveryCode: string): void {
+        const config = this.loadConfigV3();
+        if (!config.pendingRecoveryAck) throw new Error('NO_PENDING_RECOVERY_CODE');
+        const pending = this.getPendingRecoveryCode();
+        if (!pending || !this.constantTimeEqual(pending, recoveryCode)) throw new Error('INVALID_RECOVERY_ACK');
+        delete config.pendingRecoveryAck;
+        delete config.transitionRecovery;
+        this.saveConfigAtomic(config);
+    }
+
+    /** Frozen portable contract consumed by issue #8. */
+    getPortableVaultMetadata(): Pick<SecurityConfigV3, 'version' | 'vaultId' | 'keyVersion' | 'recovery' | 'transitionRecovery'> {
+        const { version, vaultId, keyVersion, recovery, transitionRecovery } = this.loadConfigV3();
+        return { version, vaultId, keyVersion, recovery, ...(transitionRecovery ? { transitionRecovery } : {}) };
+    }
+
+    /** Frozen restore contract consumed by issue #8. */
+    async installPortableVaultMetadata(
+        metadata: Pick<SecurityConfigV3, 'version' | 'vaultId' | 'keyVersion' | 'recovery' | 'transitionRecovery'>,
+        recoveryCode: string,
+        dbPath: string,
+        userDataPath: string
+    ): Promise<void> {
+        this.configurePaths(dbPath, userDataPath);
+        this.assertDeviceStoreAvailable();
+        const configPath = path.join(userDataPath, CONFIG_FILE);
+        const previousConfigText = fs.existsSync(configPath)
+            ? fs.readFileSync(configPath, 'utf8')
+            : undefined;
+        let dek: Buffer;
+        let usedTransition = false;
+        this.validateRecoveryEnvelope(metadata.recovery);
+        try {
+            dek = await this.unwrapRecovery(metadata.recovery, recoveryCode, metadata.vaultId, metadata.keyVersion);
+        } catch {
+            if (metadata.transitionRecovery?.purpose !== 'legacy-transition') throw new Error('INVALID_RECOVERY_CODE');
+            this.validateRecoveryEnvelope(metadata.transitionRecovery);
+            dek = await this.unwrapRecovery(
+                metadata.transitionRecovery,
+                recoveryCode,
+                metadata.vaultId,
+                metadata.keyVersion,
+                'legacy-transition'
+            );
+            usedTransition = true;
+        }
+        try {
+            this.initDb(dbPath, dek);
+            this.bindVault(metadata.vaultId, metadata.keyVersion, false);
+        } catch (error) {
+            this.closeDb();
+            dek.fill(0);
+            throw error;
+        }
+        try {
+            const config: SecurityConfigV3 = {
+                ...metadata,
+                device: this.createDeviceEnvelope(dek, metadata.vaultId, metadata.keyVersion)
+            };
+            if (usedTransition) {
+                const freshCode = this.generateRecoveryCodeString();
+                config.recovery = await this.createRecoveryEnvelope(
+                    dek, freshCode, metadata.vaultId, metadata.keyVersion
+                );
+                config.transitionRecovery = await this.createTransitionRecoveryEnvelope(
+                    dek, recoveryCode, metadata.vaultId, metadata.keyVersion
+                );
+                config.pendingRecoveryAck = this.createPendingRecoveryAck(
+                    freshCode, metadata.vaultId, metadata.keyVersion, 'transition-recovery'
+                );
+            } else {
+                delete config.pendingRecoveryAck;
+                delete config.transitionRecovery;
+            }
+            this.saveConfigAtomic(config);
+            this.dek = dek;
+        } catch (error) {
+            this.failEnrollment(dek, previousConfigText);
+            throw error;
+        }
+    }
+
+    generateRecoveryCodeString(): string {
+        const hex = crypto.randomBytes(16).toString('hex').toUpperCase();
+        return `${hex.slice(0, 8)}-${hex.slice(8, 16)}-${hex.slice(16, 24)}-${hex.slice(24, 32)}`;
+    }
+
+    async deriveKey(secret: string, salt: Buffer): Promise<Buffer> {
+        return argon2.hash(secret, {
+            type: argon2.argon2id,
+            raw: true,
+            salt,
+            ...RECOVERY_KDF_PARAMS
+        });
+    }
+
+    getDb(): any { return this.db; }
+    getDbPath(): string { return this.dbPath; }
+    getVaultId(): string | null { try { return this.loadConfigV3().vaultId; } catch { return null; } }
+
+    closeDb(): void {
+        if (this.db) this.db.close();
+        this.db = null;
+        if (this.dek) this.dek.fill(0);
+        this.dek = null;
+    }
+
+    private async migrateV2(config: SecurityConfigV2, secret: string): Promise<VaultUnlockResult> {
+        let oldDek: Buffer;
+        try {
+            oldDek = await this.unwrapLegacy(config.wrappedKey, config.iv, config.salt, secret);
+        } catch {
+            if (!config.recovery) throw new Error('INVALID_LEGACY_CREDENTIAL');
+            try {
+                oldDek = await this.unwrapLegacy(
+                    config.recovery.wrappedKey,
+                    config.recovery.iv,
+                    config.recovery.salt,
+                    secret
+                );
+            } catch { throw new Error('INVALID_LEGACY_CREDENTIAL'); }
+        }
+        try {
+            this.initDb(this.dbPath, oldDek);
+            this.db.pragma('wal_checkpoint(TRUNCATE)');
+            this.closeDb();
+        } catch {
+            this.closeDb();
+            throw new Error('INVALID_LEGACY_CREDENTIAL');
+        }
+        return this.commitLegacyMigration(2, oldDek, this.generateRecoveryCodeString(), secret, false);
+    }
+
+    private async migrateV1(secret: string, saltPath: string): Promise<VaultUnlockResult> {
+        const oldKey = await this.deriveLegacyKey(secret, fs.readFileSync(saltPath));
+        try { this.initDb(this.dbPath, oldKey); } catch { throw new Error('INVALID_LEGACY_CREDENTIAL'); }
+        this.db.pragma('wal_checkpoint(TRUNCATE)');
+        this.closeDb();
+        return this.commitLegacyMigration(1, crypto.randomBytes(32), this.generateRecoveryCodeString(), secret, true, oldKey, saltPath);
+    }
+
+    private async commitLegacyMigration(
+        sourceVersion: 1 | 2,
+        dek: Buffer,
+        recoveryCode: string,
+        legacySecret: string,
+        rekey: boolean,
+        oldKey?: Buffer,
+        saltPath?: string
+    ): Promise<VaultUnlockResult> {
+        const backup = `${this.dbPath}.pre-v3-migration`;
+        const configPath = path.join(this.appUserDataPath, CONFIG_FILE);
+        const configBackup = `${configPath}.pre-v3-migration`;
+        const journal: MigrationJournal = {
+            version: 1,
+            sourceVersion,
+            phase: 'snapshot-created',
+            databaseBackup: backup,
+            configBackup: fs.existsSync(configPath) ? configBackup : undefined,
+            legacySaltPath: saltPath,
+            startedAt: new Date().toISOString()
+        };
+        fs.copyFileSync(this.dbPath, backup);
+        this.fsyncFile(backup);
+        if (journal.configBackup) {
+            fs.copyFileSync(configPath, journal.configBackup);
+            this.fsyncFile(journal.configBackup);
+        }
+        this.saveJournal(journal);
+        this.step('migration-after-snapshot');
+        let committed = false;
+        try {
+            if (rekey) {
+                this.initDb(this.dbPath, oldKey!);
+                this.db.pragma(`rekey = "x'${dek.toString('hex')}'"`);
+                this.db.pragma('wal_checkpoint(TRUNCATE)');
+                this.closeDb();
+                journal.phase = 'database-rekeyed';
+                this.saveJournal(journal);
+                this.step('migration-after-rekey');
+            }
+            this.initDb(this.dbPath, dek);
+            const config = await this.createV3Config(dek, recoveryCode, sourceVersion, legacySecret, 'legacy-migration');
+            this.bindVault(config.vaultId, config.keyVersion, true);
+            // Make the binding durable in the main database before the config
+            // commit becomes authoritative.
+            this.db.pragma('wal_checkpoint(TRUNCATE)');
+            this.step('migration-after-bind');
+            journal.phase = 'config-committing';
+            this.saveJournal(journal);
+            this.saveConfigAtomic(config);
+            committed = true;
+            this.step('migration-after-config-commit');
+            journal.phase = 'config-written';
+            this.saveJournal(journal);
+            this.dek = dek;
+            this.cleanupCommittedMigration(journal, saltPath);
+            return { migrated: true };
+        } catch (error) {
+            if (committed || this.hasV3Config()) {
+                this.dek = dek;
+                this.cleanupCommittedMigration(journal, saltPath);
+                return { migrated: true };
+            }
+            this.closeDb();
+            this.restoreMigrationSnapshot(journal);
+            this.cleanupRollbackArtifacts(journal);
+            throw error;
+        }
+    }
+
+    private reconcileMigrationJournal(): void {
+        const journalPath = this.journalPath();
+        if (!fs.existsSync(journalPath)) return;
+        const journal = JSON.parse(fs.readFileSync(journalPath, 'utf8')) as MigrationJournal;
+        const configCommitted = this.hasV3Config();
+        if (!configCommitted) {
+            this.closeDb();
+            if (journal.phase !== 'rollback-restored') this.restoreMigrationSnapshot(journal);
+            this.cleanupRollbackArtifacts(journal);
+            return;
+        }
+        this.cleanupCommittedMigration(journal, journal.legacySaltPath);
+    }
+
+    private async createV3Config(
+        dek: Buffer,
+        recoveryCode: string,
+        migratedFrom?: 1 | 2,
+        legacySecret?: string,
+        pendingReason?: PendingRecoveryAck['reason']
+    ): Promise<SecurityConfigV3> {
+        const vaultId = crypto.randomUUID();
+        const keyVersion = 1;
+        const config: SecurityConfigV3 = {
+            version: 3,
+            vaultId,
+            keyVersion,
+            device: this.createDeviceEnvelope(dek, vaultId, keyVersion),
+            recovery: await this.createRecoveryEnvelope(dek, recoveryCode, vaultId, keyVersion)
+        };
+        if (pendingReason) {
+            config.pendingRecoveryAck = this.createPendingRecoveryAck(
+                recoveryCode, vaultId, keyVersion, pendingReason
+            );
+        }
+        if (migratedFrom && legacySecret) {
+            config.migratedFrom = migratedFrom;
+            config.transitionRecovery = await this.createTransitionRecoveryEnvelope(
+                dek, legacySecret, vaultId, keyVersion
+            );
+        }
+        return config;
+    }
+
+    private async createRecoveryEnvelope(
+        dek: Buffer,
+        code: string,
+        vaultId: string,
+        keyVersion: number,
+        purpose: 'recovery-dek' | 'legacy-transition' = 'recovery-dek'
+    ): Promise<RecoveryEnvelope> {
+        const salt = crypto.randomBytes(16);
+        const wrapped = this.aesEncrypt(
+            dek,
+            await this.deriveKey(code, salt),
+            this.recoveryAad(vaultId, keyVersion, purpose)
+        );
+        return {
+            algorithm: 'aes-256-gcm',
+            kdf: 'argon2id',
+            kdfParams: { ...RECOVERY_KDF_PARAMS },
+            aadVersion: 1,
+            salt: salt.toString('hex'),
+            ...wrapped
+        };
+    }
+
+    private async unwrapRecovery(
+        envelope: RecoveryEnvelope,
+        code: string,
+        vaultId: string,
+        keyVersion: number,
+        purpose: 'recovery-dek' | 'legacy-transition' = 'recovery-dek'
+    ): Promise<Buffer> {
+        this.validateRecoveryEnvelope(envelope);
+        const salt = Buffer.from(envelope.salt, 'hex');
+        const key = await argon2.hash(code, {
+            type: argon2.argon2id,
+            raw: true,
+            salt,
+            ...envelope.kdfParams
+        });
+        return this.aesDecrypt(envelope.wrappedKey, envelope.iv, key, this.recoveryAad(vaultId, keyVersion, purpose));
+    }
+
+    private validateRecoveryEnvelope(envelope: RecoveryEnvelope): void {
+        const params = envelope?.kdfParams;
+        const validHex = (value: unknown, bytes: number) =>
+            typeof value === 'string' && value.length === bytes * 2 && /^[0-9a-f]+$/i.test(value);
+        if (envelope?.algorithm !== 'aes-256-gcm' || envelope?.kdf !== 'argon2id' || envelope?.aadVersion !== 1 ||
+            !validHex(envelope.salt, 16) || !validHex(envelope.iv, 12) ||
+            typeof envelope.wrappedKey !== 'string' || envelope.wrappedKey.length !== 96 ||
+            !/^[0-9a-f]+$/i.test(envelope.wrappedKey) || !params ||
+            !Number.isInteger(params.timeCost) || params.timeCost < 1 || params.timeCost > 10 ||
+            !Number.isInteger(params.memoryCost) || params.memoryCost < 8192 || params.memoryCost > 1048576 ||
+            !Number.isInteger(params.parallelism) || params.parallelism < 1 || params.parallelism > 16 ||
+            params.hashLength !== 32) {
+            throw new Error('INVALID_RECOVERY_ENVELOPE');
+        }
+    }
+
+    private async unwrapLegacy(wrappedKey: string, iv: string, salt: string, secret: string): Promise<Buffer> {
+        return this.aesDecrypt(wrappedKey, iv, await this.deriveLegacyKey(secret, Buffer.from(salt, 'hex')));
+    }
+
+    private async deriveLegacyKey(secret: string, salt: Buffer): Promise<Buffer> {
+        return argon2.hash(secret, { type: argon2.argon2id, raw: true, salt });
+    }
+
+    private aesEncrypt(data: Buffer, key: Buffer, aad?: Buffer): { wrappedKey: string; iv: string } {
+        const iv = crypto.randomBytes(12);
+        const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+        if (aad) cipher.setAAD(aad);
+        const ciphertext = Buffer.concat([cipher.update(data), cipher.final()]);
+        return { wrappedKey: Buffer.concat([cipher.getAuthTag(), ciphertext]).toString('hex'), iv: iv.toString('hex') };
+    }
+
+    private aesDecrypt(value: string, ivHex: string, key: Buffer, aad?: Buffer): Buffer {
+        const valueBuffer = Buffer.from(value, 'hex');
+        const decipher = crypto.createDecipheriv('aes-256-gcm', key, Buffer.from(ivHex, 'hex'));
+        if (aad) decipher.setAAD(aad);
+        decipher.setAuthTag(valueBuffer.subarray(0, 16));
+        return Buffer.concat([decipher.update(valueBuffer.subarray(16)), decipher.final()]);
+    }
+
+    private bindVault(vaultId: string, keyVersion: number, create: boolean): void {
+        if (create) {
+            this.db.exec(`CREATE TABLE IF NOT EXISTS ${VAULT_TABLE} (singleton INTEGER PRIMARY KEY CHECK(singleton = 1), vault_id TEXT NOT NULL, key_version INTEGER NOT NULL)`);
+        }
+        let row;
+        try {
+            row = this.db.prepare(`SELECT vault_id, key_version FROM ${VAULT_TABLE} WHERE singleton = 1`).get();
+        } catch {
+            throw new Error('VAULT_BINDING_MISMATCH');
+        }
+        if (!row && create) {
+            this.db.prepare(`INSERT INTO ${VAULT_TABLE} (singleton, vault_id, key_version) VALUES (1, ?, ?)`).run(vaultId, keyVersion);
+            return;
+        }
+        if (!row || row.vault_id !== vaultId || row.key_version !== keyVersion) throw new Error('VAULT_BINDING_MISMATCH');
+    }
+
+    private initDb(filePath: string, key: Buffer): void {
+        // Never enable verbose SQL logging here: SQLCipher's key PRAGMA would
+        // disclose the live DEK to logs even in a development build.
+        const db = new Database(filePath);
+        try {
+            db.pragma(`key = "x'${key.toString('hex')}'"`);
+            db.prepare('SELECT count(*) FROM sqlite_master').get();
+            this.db = db;
+        } catch (error: any) {
+            db.close();
+            if (String(error?.message).includes('file is not a database')) throw new Error('INVALID_PASSWORD');
+            throw error;
+        }
+    }
+
+    private configurePaths(dbPath: string, userDataPath: string): void {
+        this.dbPath = dbPath;
+        this.appUserDataPath = userDataPath;
+    }
+
+    private assertDeviceStoreAvailable(): void {
+        const status = this.deviceKeyStore.status();
+        if (!status.available) throw new Error(status.reason || 'DEVICE_KEY_UNAVAILABLE');
+    }
+
+    private loadConfigV3(): SecurityConfigV3 {
+        const config = JSON.parse(fs.readFileSync(path.join(this.appUserDataPath, CONFIG_FILE), 'utf8')) as SecurityConfigV3;
+        if (config.version !== 3) throw new Error('LEGACY_MIGRATION_REQUIRED');
+        if (!config.vaultId || !Number.isInteger(config.keyVersion) || config.keyVersion < 1 ||
+            !config.device?.protectedPayload || !config.recovery?.wrappedKey || !config.recovery?.kdfParams) {
+            throw new Error('SECURITY_CONFIG_CORRUPT');
+        }
+        return config;
+    }
+
+    private saveConfigAtomic(config: SecurityConfigV3): void {
+        fs.mkdirSync(this.appUserDataPath, { recursive: true });
+        const target = path.join(this.appUserDataPath, CONFIG_FILE);
+        const temporary = `${target}.tmp`;
+        const fd = fs.openSync(temporary, 'w', 0o600);
+        try {
+            fs.writeFileSync(fd, JSON.stringify(config, null, 2), 'utf8');
+            this.fsyncDescriptor(fd);
+        } finally { fs.closeSync(fd); }
+        fs.renameSync(temporary, target);
+        this.fsyncDirectory();
+    }
+
+    private failEnrollment(dek: Buffer, previousConfigText?: string): void {
+        this.closeDb();
+        dek.fill(0);
+        const target = path.join(this.appUserDataPath, CONFIG_FILE);
+        const temporary = `${target}.tmp`;
+        if (previousConfigText === undefined) {
+            for (const file of [target, temporary]) {
+                if (fs.existsSync(file)) fs.unlinkSync(file);
+            }
+            this.fsyncDirectory();
+            return;
+        }
+        this.saveTextAtomic(target, previousConfigText);
+    }
+
+    private saveTextAtomic(target: string, text: string): void {
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        const temporary = `${target}.tmp`;
+        const fd = fs.openSync(temporary, 'w', 0o600);
+        try {
+            fs.writeFileSync(fd, text, 'utf8');
+            this.fsyncDescriptor(fd);
+        } finally { fs.closeSync(fd); }
+        fs.renameSync(temporary, target);
+        this.fsyncDirectory();
+    }
+
+    private journalPath(): string { return path.join(this.appUserDataPath, JOURNAL_FILE); }
+    private saveJournal(journal: MigrationJournal): void {
+        const target = this.journalPath();
+        const temporary = `${target}.tmp`;
+        const fd = fs.openSync(temporary, 'w', 0o600);
+        try {
+            fs.writeFileSync(fd, JSON.stringify(journal, null, 2), 'utf8');
+            this.fsyncDescriptor(fd);
+        } finally { fs.closeSync(fd); }
+        fs.renameSync(temporary, target);
+        this.fsyncDirectory();
+    }
+
+    private hasV3Config(): boolean {
+        try {
+            const config = JSON.parse(fs.readFileSync(path.join(this.appUserDataPath, CONFIG_FILE), 'utf8'));
+            return config.version === 3 && !!config.vaultId && !!config.device?.protectedPayload;
+        } catch { return false; }
+    }
+
+    private restoreMigrationSnapshot(journal: MigrationJournal): void {
+        if (!fs.existsSync(journal.databaseBackup)) throw new Error('MIGRATION_SNAPSHOT_MISSING');
+        if (journal.configBackup && !fs.existsSync(journal.configBackup)) throw new Error('MIGRATION_SNAPSHOT_MISSING');
+        for (const suffix of ['-wal', '-shm']) {
+            const sidecar = `${this.dbPath}${suffix}`;
+            if (fs.existsSync(sidecar)) fs.unlinkSync(sidecar);
+        }
+        if (fs.existsSync(journal.databaseBackup)) fs.copyFileSync(journal.databaseBackup, this.dbPath);
+        const configPath = path.join(this.appUserDataPath, CONFIG_FILE);
+        if (journal.configBackup && fs.existsSync(journal.configBackup)) {
+            fs.copyFileSync(journal.configBackup, configPath);
+        } else if (fs.existsSync(configPath)) {
+            fs.unlinkSync(configPath);
+        }
+        journal.phase = 'rollback-restored';
+        this.saveJournal(journal);
+    }
+
+    private createDeviceEnvelope(dek: Buffer, vaultId: string, keyVersion: number): SecurityConfigV3['device'] {
+        return {
+            provider: this.deviceKeyStore.status().provider,
+            protectedPayload: this.protectContextPayload({
+                version: 1,
+                purpose: 'device-dek',
+                vaultId,
+                keyVersion,
+                dek: dek.toString('base64')
+            })
+        };
+    }
+
+    private createPendingRecoveryAck(
+        recoveryCode: string,
+        vaultId: string,
+        keyVersion: number,
+        reason: PendingRecoveryAck['reason']
+    ): PendingRecoveryAck {
+        return {
+            protectedPayload: this.protectContextPayload({
+                version: 1,
+                purpose: 'recovery-ack',
+                vaultId,
+                keyVersion,
+                recoveryCode
+            }),
+            createdAt: new Date().toISOString(),
+            reason
+        };
+    }
+
+    private async createTransitionRecoveryEnvelope(
+        dek: Buffer,
+        legacySecret: string,
+        vaultId: string,
+        keyVersion: number
+    ): Promise<TransitionRecoveryEnvelope> {
+        return {
+            ...await this.createRecoveryEnvelope(
+                dek, legacySecret, vaultId, keyVersion, 'legacy-transition'
+            ),
+            purpose: 'legacy-transition'
+        };
+    }
+
+    private unprotectDeviceDek(config: SecurityConfigV3): Buffer {
+        const payload = this.unprotectContextPayload(config.device.protectedPayload);
+        if (payload.version !== 1 || payload.purpose !== 'device-dek' ||
+            payload.vaultId !== config.vaultId || payload.keyVersion !== config.keyVersion ||
+            typeof payload.dek !== 'string') {
+            throw new Error('VAULT_BINDING_MISMATCH');
+        }
+        const dek = Buffer.from(payload.dek, 'base64');
+        if (dek.length !== 32) throw new Error('INVALID_DEVICE_ENVELOPE');
+        return dek;
+    }
+
+    private protectContextPayload(payload: Record<string, unknown>): string {
+        return this.deviceKeyStore.protect(Buffer.from(JSON.stringify(payload), 'utf8')).toString('base64');
+    }
+
+    private unprotectContextPayload(value: string): any {
+        try {
+            return JSON.parse(this.deviceKeyStore.unprotect(Buffer.from(value, 'base64')).toString('utf8'));
+        } catch { throw new Error('INVALID_DEVICE_ENVELOPE'); }
+    }
+
+    private recoveryAad(
+        vaultId: string,
+        keyVersion: number,
+        purpose: 'recovery-dek' | 'legacy-transition' = 'recovery-dek'
+    ): Buffer {
+        return Buffer.from(`nalamdesk|v3|${purpose}|${vaultId}|${keyVersion}`, 'utf8');
+    }
+
+    private constantTimeEqual(left: string, right: string): boolean {
+        const leftBuffer = Buffer.from(left, 'utf8');
+        const rightBuffer = Buffer.from(right, 'utf8');
+        if (leftBuffer.length !== rightBuffer.length) {
+            // Keep a fixed-cost comparison even when lengths differ.
+            crypto.timingSafeEqual(leftBuffer, Buffer.alloc(leftBuffer.length));
+            return false;
+        }
+        return crypto.timingSafeEqual(leftBuffer, rightBuffer);
+    }
+
+    private cleanupCommittedMigration(journal: MigrationJournal, saltPath?: string): void {
+        let clean = true;
+        const attempt = (step: SecurityStep, action: () => void) => {
+            try { this.step(step); action(); } catch { clean = false; }
+        };
+        if (saltPath && fs.existsSync(saltPath)) {
+            attempt('cleanup-legacy-salt', () => fs.renameSync(saltPath, `${saltPath}.migrated`));
+        }
+        if (fs.existsSync(journal.databaseBackup)) {
+            attempt('cleanup-database-backup', () => fs.unlinkSync(journal.databaseBackup));
+        }
+        if (journal.configBackup && fs.existsSync(journal.configBackup)) {
+            attempt('cleanup-config-backup', () => fs.unlinkSync(journal.configBackup!));
+        }
+        if (clean && fs.existsSync(this.journalPath())) {
+            attempt('cleanup-journal', () => fs.unlinkSync(this.journalPath()));
+        }
+    }
+
+    private cleanupRollbackArtifacts(journal: MigrationJournal): void {
+        let clean = true;
+        const attempt = (step: SecurityStep, file?: string) => {
+            if (!file || !fs.existsSync(file)) return;
+            try { this.step(step); fs.unlinkSync(file); } catch { clean = false; }
+        };
+        attempt('cleanup-rollback-database-backup', journal.databaseBackup);
+        attempt('cleanup-rollback-config-backup', journal.configBackup);
+        if (clean) attempt('cleanup-rollback-journal', this.journalPath());
+    }
+
+    private setupJournalPath(): string { return path.join(this.appUserDataPath, SETUP_JOURNAL_FILE); }
+    private saveSetupJournal(journal: SetupJournal): void {
+        this.saveJsonAtomic(this.setupJournalPath(), journal);
+    }
+
+    private loadSetupJournal(): SetupJournal | null {
+        try { return JSON.parse(fs.readFileSync(this.setupJournalPath(), 'utf8')) as SetupJournal; }
+        catch { return null; }
+    }
+
+    private reconcileSetupJournal(): void {
+        const journalPath = this.setupJournalPath();
+        if (!fs.existsSync(journalPath)) return;
+        const journal = JSON.parse(fs.readFileSync(journalPath, 'utf8')) as SetupJournal;
+        if (journal.phase === 'complete') this.cleanupSetupJournal();
+        else this.rollbackSetup(journal);
+    }
+
+    private rollbackSetup(journal: SetupJournal): void {
+        this.closeDb();
+        if (journal.databaseCreated) {
+            for (const file of [this.dbPath, `${this.dbPath}-wal`, `${this.dbPath}-shm`]) {
+                if (fs.existsSync(file)) fs.unlinkSync(file);
+            }
+        }
+        const configPath = path.join(this.appUserDataPath, CONFIG_FILE);
+        for (const file of [configPath, `${configPath}.tmp`]) {
+            if (fs.existsSync(file)) fs.unlinkSync(file);
+        }
+        this.cleanupSetupJournal();
+    }
+
+    private cleanupSetupJournal(): void {
+        try {
+            this.step('cleanup-setup-journal');
+            if (fs.existsSync(this.setupJournalPath())) fs.unlinkSync(this.setupJournalPath());
+        } catch { /* committed setup is authoritative; reconcile cleanup on next start */ }
+    }
+
+    private saveJsonAtomic(target: string, value: unknown): void {
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        const temporary = `${target}.tmp`;
+        const fd = fs.openSync(temporary, 'w', 0o600);
+        try {
+            fs.writeFileSync(fd, JSON.stringify(value, null, 2), 'utf8');
+            this.fsyncDescriptor(fd);
+        } finally { fs.closeSync(fd); }
+        fs.renameSync(temporary, target);
+        this.fsyncDirectory();
+    }
+
+    private step(step: SecurityStep): void { this.hooks.onStep?.(step); }
+
+    private fsyncFile(filePath: string): void {
+        // Windows FlushFileBuffers requires a handle opened with write access.
+        // POSIX accepts a read-only descriptor and avoids broadening access.
+        const platform = this.hooks.platform ?? process.platform;
+        const fd = fs.openSync(filePath, platform === 'win32' ? 'r+' : 'r');
+        try { this.fsyncDescriptor(fd); } finally { fs.closeSync(fd); }
+    }
+
+    private fsyncDirectory(): void {
+        const platform = this.hooks.platform ?? process.platform;
+        try {
+            const directory = fs.openSync(this.appUserDataPath, 'r');
+            try { this.fsyncDescriptor(directory); } finally { fs.closeSync(directory); }
+        } catch (error) {
+            // Windows does not expose directory handles compatible with fsync.
+            // All other failures remain fatal so supported platforms retain
+            // the durability guarantee.
+            if (!this.isUnsupportedWindowsFsync(error, platform)) throw error;
+        }
+    }
+
+    private fsyncDescriptor(fd: number): void {
+        // Regular files are opened writable (including r+ on Windows), so an
+        // fsync failure is a real durability failure and must never be hidden.
+        (this.hooks.fsync ?? fs.fsyncSync)(fd);
+    }
+
+    private isUnsupportedWindowsFsync(error: unknown, platform: NodeJS.Platform): boolean {
+        if (platform !== 'win32' || !error || typeof error !== 'object') return false;
+        const code = (error as NodeJS.ErrnoException).code;
+        return code === 'EPERM' || code === 'EINVAL' || code === 'ENOSYS' || code === 'ENOTSUP';
+    }
 }

--- a/desktop/src/main/services/SessionService.spec.ts
+++ b/desktop/src/main/services/SessionService.spec.ts
@@ -39,4 +39,21 @@ describe('SessionService', () => {
         expect(service.getUser()).toBeNull();
         expect(service.isAuthenticated()).toBe(false);
     });
+
+    it('allowlists session fields and never retains a password hash', () => {
+        service.setUser({
+            id: 1,
+            username: 'admin',
+            role: 'admin',
+            name: 'Administrator',
+            password_reset_required: 0,
+            password: '$argon2id$secret-hash'
+        } as any);
+        const session = service.getUser() as any;
+        expect(session.password).toBeUndefined();
+        expect(session.password_reset_required).toBe(0);
+        expect(Object.keys(session).sort()).toEqual([
+            'id', 'name', 'password_reset_required', 'role', 'sessionId', 'username'
+        ]);
+    });
 });

--- a/desktop/src/main/services/SessionService.ts
+++ b/desktop/src/main/services/SessionService.ts
@@ -7,6 +7,7 @@ export interface UserSession {
     name: string;
     specialty?: string;
     license_number?: string;
+    password_reset_required?: number;
     sessionId?: string;
 }
 
@@ -18,7 +19,13 @@ export class SessionService {
             throw new Error('Invalid user session data');
         }
         this.currentUser = {
-            ...user,
+            id: user.id,
+            username: user.username,
+            role: user.role,
+            name: user.name,
+            ...(user.specialty ? { specialty: user.specialty } : {}),
+            ...(user.license_number ? { license_number: user.license_number } : {}),
+            ...(user.password_reset_required !== undefined ? { password_reset_required: user.password_reset_required } : {}),
             sessionId: crypto.randomUUID()
         };
     }

--- a/desktop/src/main/verify-security.ts
+++ b/desktop/src/main/verify-security.ts
@@ -1,5 +1,6 @@
 
 import { SecurityService } from './services/SecurityService';
+import type { DeviceKeyStore } from './services/DeviceKeyStore';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -10,11 +11,17 @@ async function testSecurity() {
     if (!fs.existsSync(userDataPath)) fs.mkdirSync(userDataPath);
     if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
 
-    const security = new SecurityService();
-    const password = 'mySecretPassword';
+    let protectedKey: Buffer | null = null;
+    const deviceStore: DeviceKeyStore = {
+        status: () => ({ available: true, provider: 'verification-memory-store' }),
+        protect: (value) => { protectedKey = Buffer.from(value); return Buffer.from(value); },
+        unprotect: () => { if (!protectedKey) throw new Error('missing key'); return Buffer.from(protectedKey); }
+    };
+    const security = new SecurityService(deviceStore);
+    const password = 'adminLoginPassword';
 
-    console.log('1. Initializing DB (Fresh)...');
-    await security.initialize(password, dbPath, userDataPath);
+    console.log('1. Creating a fresh device-bound vault...');
+    await security.setup(password, dbPath, userDataPath);
 
     const db = security.getDb();
     db.exec(`CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY, secret TEXT)`);
@@ -23,23 +30,10 @@ async function testSecurity() {
     console.log('2. Data inserted. Closing DB.');
     security.closeDb();
 
-    console.log('3. Attempting to open with WRONG password...');
-    const security2 = new SecurityService();
+    console.log('3. Cold-starting without a user password...');
     try {
-        await security2.initialize('wrongPassword', dbPath, userDataPath);
-        console.error('FAIL: Database should NOT open with wrong key!');
-    } catch (e: any) {
-        if (e.message === 'INVALID_PASSWORD') {
-            console.log('PASS: Correctly rejected wrong password.');
-        } else {
-            console.error('FAIL: Unexpected error:', e);
-        }
-    }
-
-    console.log('4. Attempting to open with CORRECT password...');
-    try {
-        const security3 = new SecurityService();
-        await security3.initialize(password, dbPath, userDataPath);
+        const security3 = new SecurityService(deviceStore);
+        await security3.initializeDevice(dbPath, userDataPath);
         const row = security3.getDb().prepare('SELECT * FROM test').get() as any;
         if (row && row.secret === 'This is a secret message') {
             console.log('PASS: Data recovered successfully:', row.secret);
@@ -48,7 +42,7 @@ async function testSecurity() {
         }
         security3.closeDb();
     } catch (e) {
-        console.error('FAIL: Could not reopen with correct key:', e);
+        console.error('FAIL: Could not reopen with the device key:', e);
     }
 
     // Cleanup

--- a/desktop/src/renderer/app/login/change-password/change-password.component.spec.ts
+++ b/desktop/src/renderer/app/login/change-password/change-password.component.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@angular/compiler';
+import { inject } from '@angular/core';
+import { ChangePasswordComponent } from './change-password.component';
+import { AuthService } from '../../services/auth.service';
+import { Router } from '@angular/router';
+
+vi.mock('@angular/core', async () => {
+    const actual = await vi.importActual('@angular/core');
+    return { ...actual as any, inject: vi.fn() };
+});
+
+describe('ChangePasswordComponent', () => {
+    let auth: any;
+    let router: any;
+    let component: ChangePasswordComponent;
+
+    beforeEach(() => {
+        auth = {
+            getUser: vi.fn(() => ({ id: 2, username: 'doctor', role: 'doctor', password_reset_required: 1 })),
+            changeLoginPassword: vi.fn()
+        };
+        router = { navigate: vi.fn() };
+        vi.mocked(inject).mockImplementation(token => token === AuthService ? auth : router);
+        localStorage.clear();
+        component = new ChangePasswordComponent();
+    });
+
+    it('requires the current credential as well as matching replacement passwords', () => {
+        component.password = 'replacement';
+        component.confirmPassword = 'replacement';
+        expect(component.isValid()).toBe(false);
+        component.currentPassword = 'temporary';
+        expect(component.isValid()).toBe(true);
+    });
+
+    it('changes only the authenticated user credential and clears every plaintext input', async () => {
+        auth.changeLoginPassword.mockResolvedValue({ success: true });
+        component.currentPassword = 'temporary';
+        component.password = 'replacement';
+        component.confirmPassword = 'replacement';
+        await component.onSubmit();
+        expect(auth.changeLoginPassword).toHaveBeenCalledWith('temporary', 'replacement');
+        expect(component.currentPassword).toBe('');
+        expect(component.password).toBe('');
+        expect(component.confirmPassword).toBe('');
+        expect(router.navigate).toHaveBeenCalledWith(['/dashboard']);
+        expect(JSON.parse(localStorage.getItem('nalamdesk_user')!)).toMatchObject({ password_reset_required: 0 });
+    });
+
+    it('clears plaintext inputs when the IPC call fails', async () => {
+        auth.changeLoginPassword.mockRejectedValue(new Error('IPC failed'));
+        component.currentPassword = 'temporary';
+        component.password = 'replacement';
+        component.confirmPassword = 'replacement';
+        await component.onSubmit();
+        expect(component.error).toBe('IPC failed');
+        expect(component.currentPassword).toBe('');
+        expect(component.password).toBe('');
+        expect(component.confirmPassword).toBe('');
+    });
+});

--- a/desktop/src/renderer/app/login/change-password/change-password.component.ts
+++ b/desktop/src/renderer/app/login/change-password/change-password.component.ts
@@ -18,6 +18,11 @@ import { AuthService } from '../../services/auth.service';
 
         <form (ngSubmit)="onSubmit()" class="space-y-4">
           <div>
+            <label class="block text-sm font-medium text-gray-700">Current Password</label>
+            <input type="password" [(ngModel)]="currentPassword" name="currentPassword" required
+                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 p-2 border">
+          </div>
+          <div>
             <label class="block text-sm font-medium text-gray-700">New Password</label>
             <input type="password" [(ngModel)]="password" name="password" required minlength="6"
                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 p-2 border">
@@ -46,6 +51,7 @@ import { AuthService } from '../../services/auth.service';
   `
 })
 export class ChangePasswordComponent {
+    currentPassword = '';
     password = '';
     confirmPassword = '';
     isLoading = false;
@@ -55,7 +61,7 @@ export class ChangePasswordComponent {
     private router = inject(Router);
 
     isValid() {
-        return this.password.length >= 6 && this.password === this.confirmPassword;
+        return !!this.currentPassword && this.password.length >= 6 && this.password === this.confirmPassword;
     }
 
     async onSubmit() {
@@ -70,8 +76,8 @@ export class ChangePasswordComponent {
                 return;
             }
 
-            const success = await this.auth.updatePassword(user.username, this.password);
-            if (success) {
+            const result = await this.auth.changeLoginPassword(this.currentPassword, this.password);
+            if (result.success) {
                 // Update local user state to reflect reset is no longer required
                 const updatedUser = { ...user, password_reset_required: 0 };
 
@@ -81,11 +87,14 @@ export class ChangePasswordComponent {
                 // Navigate to dashboard
                 this.router.navigate(['/dashboard']);
             } else {
-                this.error = 'Failed to update password';
+                this.error = result.error || 'Failed to update password';
             }
         } catch (e: any) {
             this.error = e.message || 'An error occurred';
         } finally {
+            this.currentPassword = '';
+            this.password = '';
+            this.confirmPassword = '';
             this.isLoading = false;
         }
     }

--- a/desktop/src/renderer/app/login/login.component.spec.ts
+++ b/desktop/src/renderer/app/login/login.component.spec.ts
@@ -27,6 +27,7 @@ describe('LoginComponent', () => {
         mockAuthService = {
             login: vi.fn(),
             getUser: vi.fn(),
+            acknowledgeRecoveryCode: vi.fn().mockResolvedValue(undefined),
             checkSetup: vi.fn().mockResolvedValue({ isSetup: true }) // Default to setup complete
         };
         mockRuntimeService = {
@@ -47,6 +48,18 @@ describe('LoginComponent', () => {
         mockAuthService.checkSetup.mockResolvedValue({ isSetup: true });
         await component.ngOnInit();
         expect(mockRouter.navigate).not.toHaveBeenCalled();
+    });
+
+    it('explains when a legacy administrator migration is required', async () => {
+        mockAuthService.checkSetup.mockResolvedValue({ isSetup: true, vaultState: 'legacy-migration-required' });
+        await component.ngOnInit();
+        expect(component.vaultNotice).toContain('administrator must sign in once');
+    });
+
+    it('directs the user to device recovery when the OS key is unavailable', async () => {
+        mockAuthService.checkSetup.mockResolvedValue({ isSetup: true, vaultState: 'recovery-required' });
+        await component.ngOnInit();
+        expect(component.vaultNotice).toContain('Recover Device');
     });
 
     it('should initialize with default values', () => {
@@ -81,6 +94,20 @@ describe('LoginComponent', () => {
 
         expect(component.isLoading).toBe(false);
         expect(component.error).toBe('');
+        expect(mockRouter.navigate).toHaveBeenCalledWith(['/dashboard']);
+    });
+
+    it('requires acknowledgement of the new recovery code after legacy migration', async () => {
+        component.username = 'admin';
+        component.password = 'legacy-password';
+        mockAuthService.login.mockResolvedValue({ success: true, pendingRecoveryCode: 'AAAA-BBBB-CCCC-DDDD' });
+
+        await component.onLogin();
+
+        expect(component.pendingRecoveryCode).toBe('AAAA-BBBB-CCCC-DDDD');
+        expect(mockRouter.navigate).not.toHaveBeenCalled();
+        await component.acknowledgeMigration();
+        expect(mockAuthService.acknowledgeRecoveryCode).toHaveBeenCalledWith('AAAA-BBBB-CCCC-DDDD');
         expect(mockRouter.navigate).toHaveBeenCalledWith(['/dashboard']);
     });
 

--- a/desktop/src/renderer/app/login/login.component.ts
+++ b/desktop/src/renderer/app/login/login.component.ts
@@ -17,8 +17,20 @@ import { RuntimeService } from '../services/runtime.service';
         <div *ngIf="error" class="bg-red-900/50 border border-red-500 text-red-200 px-4 py-2 rounded mb-4 text-sm">
           {{ error }}
         </div>
+        <div *ngIf="vaultNotice" class="bg-blue-950/60 border border-blue-600 text-blue-100 px-4 py-2 rounded mb-4 text-sm">
+          {{ vaultNotice }}
+        </div>
 
-        <form (ngSubmit)="onLogin()">
+        <div *ngIf="pendingRecoveryCode" class="bg-amber-950 border border-amber-500 p-4 rounded mb-4 text-sm">
+          <p class="font-bold text-amber-300 mb-2">Security upgrade complete</p>
+          <p class="text-amber-100 mb-2">Save this new recovery code before continuing. The old vault password wrapper has been removed.</p>
+          <code class="block bg-gray-950 p-2 rounded select-all break-all">{{ pendingRecoveryCode }}</code>
+          <button type="button" (click)="acknowledgeMigration()" class="mt-3 w-full bg-amber-600 hover:bg-amber-700 py-2 rounded font-bold">
+            I have saved this code
+          </button>
+        </div>
+
+        <form (ngSubmit)="onLogin()" *ngIf="!pendingRecoveryCode">
           <div class="mb-4">
             <label class="block text-gray-400 text-sm font-bold mb-2" for="username">
               Username
@@ -60,7 +72,7 @@ import { RuntimeService } from '../services/runtime.service';
         </form>
         
         <div class="mt-4 text-center flex justify-between text-xs text-gray-400">
-            <a routerLink="/recover" class="hover:text-blue-400">Forgot Password?</a>
+            <a routerLink="/recover" class="hover:text-blue-400">Recover Device</a>
             <div class="flex flex-col items-end">
                 <span>Secure Local-First Access</span>
                 <div *ngIf="runtime.lanAccessUrl" class="mt-1 flex items-center gap-1.5 bg-gray-700/50 px-2 py-0.5 rounded-md border border-gray-600/30">
@@ -82,6 +94,9 @@ export class LoginComponent implements OnInit {
   password = '';
   error = '';
   isLoading = false;
+  pendingRecoveryCode = '';
+  vaultNotice = '';
+  private pendingRoute = '/dashboard';
   isElectron = !!(globalThis as any).electron;
 
   constructor(
@@ -96,6 +111,10 @@ export class LoginComponent implements OnInit {
     const status = await this.authService.checkSetup();
     if (!status.isSetup) {
       this.router.navigate(['/setup']);
+    } else if (status.vaultState === 'legacy-migration-required') {
+      this.vaultNotice = 'Security upgrade required: the administrator must sign in once. A new recovery code will be shown.';
+    } else if (status.vaultState === 'recovery-required') {
+      this.vaultNotice = 'This device cannot access its protected vault key. Use Recover Device below.';
     }
 
     if (this.isElectron) {
@@ -119,10 +138,11 @@ export class LoginComponent implements OnInit {
           const user = this.authService.getUser();
           this.password = ''; // Clear sensitive data
 
-          if (user && user.password_reset_required) {
-            this.router.navigate(['/change-password']);
+          this.pendingRoute = user && user.password_reset_required ? '/change-password' : '/dashboard';
+          if (result.pendingRecoveryCode) {
+            this.pendingRecoveryCode = result.pendingRecoveryCode;
           } else {
-            this.router.navigate(['/dashboard']);
+            this.router.navigate([this.pendingRoute]);
           }
         } else {
           this.password = ''; // Clear sensitive data on failure too
@@ -130,6 +150,10 @@ export class LoginComponent implements OnInit {
 
           if (this.error === 'SYSTEM_LOCKED') {
             this.error = 'System Locked. Please login as Administrator to unlock.';
+          } else if (this.error === 'RECOVERY_REQUIRED') {
+            this.error = 'Device recovery is required before anyone can sign in.';
+          } else if (this.error === 'VAULT_BINDING_MISMATCH') {
+            this.error = 'The database and security metadata do not belong to the same vault.';
           }
         }
       });
@@ -140,5 +164,11 @@ export class LoginComponent implements OnInit {
         console.error(e);
       });
     }
+  }
+
+  async acknowledgeMigration() {
+    await this.authService.acknowledgeRecoveryCode(this.pendingRecoveryCode);
+    this.pendingRecoveryCode = '';
+    this.router.navigate([this.pendingRoute]);
   }
 }

--- a/desktop/src/renderer/app/login/recovery/recovery.component.ts
+++ b/desktop/src/renderer/app/login/recovery/recovery.component.ts
@@ -11,29 +11,25 @@ import { AuthService } from '../../services/auth.service';
   template: `
     <div class="min-h-screen flex items-center justify-center bg-gray-900 text-white p-6">
       <div class="bg-gray-800 p-8 rounded-lg shadow-xl w-full max-w-md border border-gray-700">
-        <h2 class="text-2xl font-bold mb-6 text-center text-red-400">Recover Password</h2>
+        <h2 class="text-2xl font-bold mb-6 text-center text-red-400">Recover This Device</h2>
         
         <div *ngIf="error" class="bg-red-900/50 border border-red-500 text-red-200 px-4 py-2 rounded mb-6 text-sm">
           {{ error }}
         </div>
         
         <div *ngIf="success" class="bg-green-100 border border-green-500 rounded p-6 mb-6">
-          <h3 class="text-green-800 font-bold text-lg mb-2">Password Reset Successful!</h3>
+          <h3 class="text-green-800 font-bold text-lg mb-2">Device Recovery Successful</h3>
           <p class="text-green-700 text-sm mb-4">
-              Your recovery code has been rotated for security. 
-              <strong>You must save this new code</strong> to recover your account in the future.
+              This device can access the clinic vault again. User passwords were not changed.
           </p>
-          
-          <div class="bg-white p-3 rounded border border-gray-300 mb-4 flex justify-between items-center">
-              <code class="text-lg font-mono font-bold text-gray-800">{{ newRecoveryCode }}</code>
-              <button (click)="copyCode()" class="text-sm text-blue-600 hover:text-blue-800 font-bold">
-                  {{ isCopied ? 'Copied!' : 'Copy' }}
-              </button>
+          <div *ngIf="newRecoveryCode" class="bg-white p-3 rounded border border-gray-300 mb-4">
+            <p class="text-red-700 text-xs mb-2">The legacy recovery wrapper was replaced. Save this new code:</p>
+            <code class="block text-lg font-mono font-bold text-gray-800 select-all break-all">{{ newRecoveryCode }}</code>
+            <button (click)="copyCode()" class="mt-2 text-sm text-blue-600 font-bold">{{ isCopied ? 'Copied!' : 'Copy' }}</button>
           </div>
-
           <div class="flex justify-center">
               <button (click)="finish()" class="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-6 rounded">
-                  I have saved this code
+                  {{ newRecoveryCode ? 'I have saved this code' : 'Return to Login' }}
               </button>
           </div>
         </div>
@@ -53,45 +49,15 @@ import { AuthService } from '../../services/auth.service';
               [disabled]="isLoading"
               autofocus
             >
-            <p class="text-xs text-gray-500 mt-1">Enter the code provided during setup.</p>
-          </div>
-
-          <!-- New Password -->
-          <div class="mb-4">
-            <label class="block text-gray-400 text-sm font-bold mb-2">
-              New Master Password
-            </label>
-            <input
-              type="password"
-              [(ngModel)]="newPassword"
-              name="newPassword"
-              class="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded text-white focus:outline-none focus:border-red-500 transition-colors"
-              placeholder="Enter new password"
-              [disabled]="isLoading"
-            >
-          </div>
-
-           <!-- Confirm Password -->
-          <div class="mb-6">
-            <label class="block text-gray-400 text-sm font-bold mb-2">
-              Confirm New Password
-            </label>
-            <input
-              type="password"
-              [(ngModel)]="confirmPassword"
-              name="confirmPassword"
-              class="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded text-white focus:outline-none focus:border-red-500 transition-colors"
-              placeholder="Confirm new password"
-              [disabled]="isLoading"
-            >
+            <p class="text-xs text-gray-500 mt-1">Enter the portable vault recovery code provided during setup.</p>
           </div>
           
           <button
             type="submit"
-            [disabled]="isLoading || !recoveryCode || !newPassword || newPassword !== confirmPassword"
+            [disabled]="isLoading || !recoveryCode"
             class="w-full bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {{ isLoading ? 'Recovering...' : 'Reset Password' }}
+            {{ isLoading ? 'Recovering...' : 'Recover Device' }}
           </button>
         </form>
         
@@ -104,13 +70,10 @@ import { AuthService } from '../../services/auth.service';
 })
 export class RecoveryComponent {
   recoveryCode = '';
-  newPassword = '';
-  confirmPassword = '';
   error = '';
   success = false;
   isLoading = false;
-
-  newRecoveryCode: string | null = null;
+  newRecoveryCode = '';
   isCopied = false;
 
   constructor(
@@ -119,24 +82,19 @@ export class RecoveryComponent {
   ) { }
 
   async onRecover() {
-    if (!this.recoveryCode || !this.newPassword) return;
-    if (this.newPassword !== this.confirmPassword) {
-      this.error = 'Passwords do not match';
-      return;
-    }
+    if (!this.recoveryCode) return;
 
     this.isLoading = true;
     this.error = '';
 
     try {
       const result = await this.authService.recover({
-        recoveryCode: this.recoveryCode.trim(),
-        newPassword: this.newPassword
+        recoveryCode: this.recoveryCode.trim()
       });
 
-      if (result.success && result.recoveryCode) {
+      if (result.success) {
         this.success = true;
-        this.newRecoveryCode = result.recoveryCode;
+        this.newRecoveryCode = result.pendingRecoveryCode || '';
         this.isLoading = false;
       } else {
         this.error = result.error || 'Recovery Failed. Check your code.';
@@ -150,15 +108,10 @@ export class RecoveryComponent {
   }
 
   async copyCode() {
-    if (this.newRecoveryCode) {
-      if (window.electron) {
-        await window.electron.clipboard.writeText(this.newRecoveryCode);
-      } else {
-        navigator.clipboard.writeText(this.newRecoveryCode);
-      }
-      this.isCopied = true;
-      setTimeout(() => this.isCopied = false, 2000);
-    }
+    if (!this.newRecoveryCode) return;
+    if (window.electron) await window.electron.clipboard.writeText(this.newRecoveryCode);
+    else await navigator.clipboard.writeText(this.newRecoveryCode);
+    this.isCopied = true;
   }
 
   finish() {

--- a/desktop/src/renderer/app/services/auth.service.spec.ts
+++ b/desktop/src/renderer/app/services/auth.service.spec.ts
@@ -30,6 +30,29 @@ describe('AuthService', () => {
             expect(window.electron.login).toHaveBeenCalledWith({ username: 'admin', password: 'pass' });
         });
 
+        it('preserves a one-time migration recovery code for acknowledgement', async () => {
+            (window as any).electron = {
+                login: vi.fn().mockResolvedValue({
+                    success: true,
+                    user: { id: 1, role: 'admin' },
+                    pendingRecoveryCode: 'AAAA-BBBB-CCCC-DDDD'
+                })
+            };
+            await expect(service.login('admin', 'legacy')).resolves.toMatchObject({
+                success: true,
+                pendingRecoveryCode: 'AAAA-BBBB-CCCC-DDDD'
+            });
+        });
+
+        it('sends the exact displayed recovery code when acknowledging', async () => {
+            (window as any).electron = {
+                acknowledgeRecoveryCode: vi.fn().mockResolvedValue({ success: true })
+            };
+            await service.acknowledgeRecoveryCode('AAAA-BBBB-CCCC-DDDD');
+            expect(window.electron.acknowledgeRecoveryCode)
+                .toHaveBeenCalledWith('AAAA-BBBB-CCCC-DDDD');
+        });
+
         it('should handle login failure', async () => {
             (window as any).electron = {
                 login: vi.fn().mockResolvedValue({ success: false, error: 'Invalid' })
@@ -48,6 +71,18 @@ describe('AuthService', () => {
             const result = await service.login('a', 'b');
             expect(result.success).toBe(false);
             expect(result.error).toBe('IPC Error');
+        });
+
+        it('never persists a password hash returned by a compromised IPC payload', async () => {
+            (window as any).electron = {
+                login: vi.fn().mockResolvedValue({
+                    success: true,
+                    user: { id: 1, username: 'admin', role: 'admin', name: 'Admin', password: '$argon2id$hash' }
+                })
+            };
+            await service.login('admin', 'pass');
+            expect((service.getUser() as any).password).toBeUndefined();
+            expect(localStorage.getItem('nalamdesk_user')).not.toContain('$argon2id$hash');
         });
     });
 

--- a/desktop/src/renderer/app/services/auth.service.spec.ts
+++ b/desktop/src/renderer/app/services/auth.service.spec.ts
@@ -84,6 +84,28 @@ describe('AuthService', () => {
             expect((service.getUser() as any).password).toBeUndefined();
             expect(localStorage.getItem('nalamdesk_user')).not.toContain('$argon2id$hash');
         });
+
+        it('uses distinct IPC contracts for login, staff reset, device, and recovery rotation', async () => {
+            (window as any).electron = {
+                changeLoginPassword: vi.fn().mockResolvedValue({ success: true }),
+                resetUserPassword: vi.fn().mockResolvedValue({ success: true }),
+                rotateDeviceEnvelope: vi.fn().mockResolvedValue({ success: true }),
+                regenerateRecoveryCode: vi.fn().mockResolvedValue({ success: true, recoveryCode: 'CODE' })
+            };
+            await service.changeLoginPassword('current', 'replacement');
+            await service.resetUserPassword(2, 'admin-current', 'temporary');
+            await service.rotateDeviceEnvelope('admin-current');
+            await service.regenerateRecoveryCode('admin-current');
+
+            expect(window.electron.changeLoginPassword).toHaveBeenCalledWith({
+                currentPassword: 'current', newPassword: 'replacement'
+            });
+            expect(window.electron.resetUserPassword).toHaveBeenCalledWith({
+                targetUserId: 2, currentAdminPassword: 'admin-current', temporaryPassword: 'temporary'
+            });
+            expect(window.electron.rotateDeviceEnvelope).toHaveBeenCalledWith('admin-current');
+            expect(window.electron.regenerateRecoveryCode).toHaveBeenCalledWith('admin-current');
+        });
     });
 
     describe('login (Web Mode)', () => {

--- a/desktop/src/renderer/app/services/auth.service.ts
+++ b/desktop/src/renderer/app/services/auth.service.ts
@@ -79,13 +79,23 @@ export class AuthService {
         return { success: false, error: 'Not supported' };
     }
 
-    async updatePassword(username: string, newPassword: string): Promise<boolean> {
-        if (window.electron && window.electron.db) {
-            const result = await window.electron.db.updateUserPassword({ username, password: newPassword });
-            return result && result.changes > 0;
-        }
-        // TODO: Web implementation
-        return false;
+    async changeLoginPassword(currentPassword: string, newPassword: string): Promise<{ success: boolean; error?: string }> {
+        if (!window.electron) return { success: false, error: 'Not supported' };
+        return window.electron.changeLoginPassword({ currentPassword, newPassword });
+    }
+
+    async resetUserPassword(
+        targetUserId: number,
+        currentAdminPassword: string,
+        temporaryPassword: string
+    ): Promise<{ success: boolean; error?: string }> {
+        if (!window.electron) return { success: false, error: 'Not supported' };
+        return window.electron.resetUserPassword({ targetUserId, currentAdminPassword, temporaryPassword });
+    }
+
+    async rotateDeviceEnvelope(currentPassword: string): Promise<{ success: boolean; error?: string }> {
+        if (!window.electron) return { success: false, error: 'Not supported' };
+        return window.electron.rotateDeviceEnvelope(currentPassword);
     }
 
     logout() {

--- a/desktop/src/renderer/app/services/auth.service.ts
+++ b/desktop/src/renderer/app/services/auth.service.ts
@@ -9,13 +9,13 @@ export class AuthService {
 
     constructor() { }
 
-    async login(username: string, password: string): Promise<{ success: boolean; error?: string }> {
+    async login(username: string, password: string): Promise<{ success: boolean; error?: string; pendingRecoveryCode?: string }> {
         if (window.electron) {
             try {
                 const result = await window.electron.login({ username, password });
                 if (result.success) {
                     this.setUser(result.user);
-                    return { success: true };
+                    return { success: true, pendingRecoveryCode: result.pendingRecoveryCode };
                 } else {
                     return { success: false, error: result.error };
                 }
@@ -43,7 +43,7 @@ export class AuthService {
         }
     }
 
-    async checkSetup(): Promise<{ isSetup: boolean, hasRecovery: boolean }> {
+    async checkSetup(): Promise<{ isSetup: boolean, hasRecovery: boolean, vaultState?: string, configVersion?: number }> {
         if (window.electron) {
             return await window.electron.checkSetup();
         } else {
@@ -60,11 +60,16 @@ export class AuthService {
         return { success: false, error: 'Web setup not supported yet' };
     }
 
-    async recover(data: any): Promise<{ success: boolean, recoveryCode?: string, error?: string }> {
+    async recover(data: { recoveryCode: string }): Promise<{ success: boolean, pendingRecoveryCode?: string, error?: string }> {
         if (window.electron) {
             return await window.electron.recover(data);
         }
         return { success: false, error: 'Web recovery not supported yet' };
+    }
+
+    async acknowledgeRecoveryCode(recoveryCode: string): Promise<void> {
+        if (!window.electron) return;
+        await window.electron.acknowledgeRecoveryCode(recoveryCode);
     }
 
     async regenerateRecoveryCode(password: string): Promise<{ success: boolean, recoveryCode?: string, error?: string }> {
@@ -99,7 +104,18 @@ export class AuthService {
     }
 
     private setUser(user: any) {
-        localStorage.setItem(this.userKey, JSON.stringify(user));
+        const safeUser = {
+            id: user?.id,
+            username: user?.username,
+            role: user?.role,
+            name: user?.name,
+            ...(user?.specialty ? { specialty: user.specialty } : {}),
+            ...(user?.license_number ? { license_number: user.license_number } : {}),
+            ...(user?.password_reset_required !== undefined
+                ? { password_reset_required: user.password_reset_required }
+                : {})
+        };
+        localStorage.setItem(this.userKey, JSON.stringify(safeUser));
     }
 
     private setToken(token: string) {

--- a/desktop/src/renderer/app/settings/settings.component.html
+++ b/desktop/src/renderer/app/settings/settings.component.html
@@ -184,15 +184,34 @@
         <div *ngIf="activeTab === 'security'" class="h-full overflow-y-auto p-4 md:p-8">
             <h2 class="text-2xl font-bold text-gray-800 mb-6">Security & Resilience</h2>
 
+            <div class="bg-white p-4 md:p-6 rounded-lg shadow-sm border border-gray-200 mb-6">
+                <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
+                    <div>
+                        <h3 class="text-lg font-medium text-gray-800">Administrator Login Password</h3>
+                        <p class="text-sm text-gray-500 max-w-lg">Changes only the administrator sign-in credential. It does not rotate the database device key or recovery code.</p>
+                    </div>
+                    <button (click)="openLoginPasswordModal()" class="btn btn-outline w-full md:w-auto">Change Login Password</button>
+                </div>
+            </div>
+
+            <div class="bg-white p-4 md:p-6 rounded-lg shadow-sm border border-gray-200 mb-6">
+                <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
+                    <div>
+                        <h3 class="text-lg font-medium text-gray-800">This Device Key Envelope</h3>
+                        <p class="text-sm text-gray-500 max-w-lg">Re-protects the unchanged database key for this device. Login passwords and the portable recovery code remain unchanged.</p>
+                    </div>
+                    <button (click)="openDeviceRotationModal()" class="btn btn-outline w-full md:w-auto">Rotate Device Envelope</button>
+                </div>
+            </div>
+
             <!-- Recovery Code -->
             <div class="bg-white p-4 md:p-6 rounded-lg shadow-sm border border-gray-200 mb-6">
                 <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
                     <div>
-                        <h3 class="text-lg font-medium text-red-600">Master Recovery Code</h3>
-                        <p class="text-sm text-gray-500 max-w-lg">Used to regain access if the admin password is lost.
-                            Store this securely offline.</p>
+                        <h3 class="text-lg font-medium text-red-600">Portable Vault Recovery Code</h3>
+                        <p class="text-sm text-gray-500 max-w-lg">Used to enrol a replacement device when its device key is unavailable. It does not reset any user's login password. Store it securely offline.</p>
                         <p class="text-xs text-red-500 mt-2 font-bold bg-red-50 inline-block px-2 py-1 rounded">⚠️
-                            Generating a new code immediately invalidates the old one.</p>
+                            The old code remains valid until you save the new code and select Done.</p>
                     </div>
                     <button (click)="openRecoveryModal()" class="btn btn-outline btn-error w-full md:w-auto">Generate
                         New Code</button>
@@ -522,24 +541,25 @@
                 </div>
             </div>
 
-            <!-- Password & Status -->
+            <!-- Credential workflow & Status -->
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4 pt-4 border-t">
                 <div>
-                    <label class="block text-sm font-medium text-gray-700">
-                        {{ editingUser.id ? 'Reset Password' : 'Password' }} <span *ngIf="!editingUser.id"
-                            class="text-red-500">*</span>
-                    </label>
+                    <ng-container *ngIf="!editingUser.id; else existingCredentialWorkflow">
+                    <label class="block text-sm font-medium text-gray-700">Temporary Password <span class="text-red-500">*</span></label>
                     <input [(ngModel)]="editingUser.password" type="password" placeholder="Set temporary password"
-                        #password="ngModel" [required]="!editingUser.id" minlength="4"
+                        #password="ngModel" [required]="!editingUser.id" minlength="6"
                         [class.border-red-500]="(password.invalid && (password.dirty || password.touched)) || (formSubmitted && !editingUser.id && !editingUser.password)"
                         class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 border p-2">
-
                     <p *ngIf="password.invalid && (password.dirty || password.touched)"
                         class="text-xs text-red-500 mt-1">
-                        Min 4 characters required.
+                        Min 6 characters required.
                     </p>
-                    <p class="text-xs text-gray-500 mt-1" *ngIf="editingUser.password && editingUser.id">User will
-                        be forced to change this on next login.</p>
+                    </ng-container>
+                    <ng-template #existingCredentialWorkflow>
+                        <label class="block text-sm font-medium text-gray-700">Login Credential</label>
+                        <button *ngIf="editingUser.id !== currentUser?.id" (click)="openUserResetModal(editingUser)" type="button" class="btn btn-outline btn-sm mt-2">Reset via Dedicated Workflow</button>
+                        <p *ngIf="editingUser.id === currentUser?.id" class="text-xs text-gray-500 mt-2">Change your own password from the Security tab. Profile edits cannot change credentials.</p>
+                    </ng-template>
                 </div>
                 <div class="flex-1">
                     <label class="flex items-center gap-2 text-sm font-medium text-gray-700 mt-6 cursor-pointer">
@@ -558,6 +578,50 @@
             <button (click)="saveUser()" class="btn btn-primary">
                 {{ editingUser.id ? 'Save Changes' : 'Add User' }}
             </button>
+        </div>
+    </div>
+</div>
+
+<!-- LOGIN PASSWORD MODAL -->
+<div *ngIf="showLoginPasswordModal" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+    <div class="bg-white rounded-lg p-6 w-full max-w-md">
+        <h3 class="text-xl font-bold mb-2">Change Administrator Login Password</h3>
+        <p class="text-sm text-gray-600 mb-4">This changes login authentication only. Vault key metadata is intentionally untouched.</p>
+        <input type="password" [(ngModel)]="currentLoginPassword" class="input input-bordered w-full mb-3" placeholder="Current login password">
+        <input type="password" [(ngModel)]="newLoginPassword" class="input input-bordered w-full mb-3" placeholder="New login password (minimum 6 characters)">
+        <input type="password" [(ngModel)]="confirmLoginPassword" class="input input-bordered w-full mb-4" placeholder="Confirm new login password">
+        <p *ngIf="confirmLoginPassword && newLoginPassword !== confirmLoginPassword" class="text-xs text-red-500 mb-3">Passwords do not match.</p>
+        <div class="flex justify-end gap-2">
+            <button (click)="showLoginPasswordModal = false" class="btn btn-ghost">Cancel</button>
+            <button (click)="changeLoginPassword()" class="btn btn-primary" [disabled]="!currentLoginPassword || newLoginPassword.length < 6 || newLoginPassword !== confirmLoginPassword || isLoading">Change Login Password</button>
+        </div>
+    </div>
+</div>
+
+<!-- USER PASSWORD RESET MODAL -->
+<div *ngIf="showUserResetModal" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+    <div class="bg-white rounded-lg p-6 w-full max-w-md">
+        <h3 class="text-xl font-bold mb-2">Reset {{ resetTarget?.name }}'s Login Password</h3>
+        <p class="text-sm text-gray-600 mb-4">Confirm your administrator credential. The target user will be required to change the temporary password.</p>
+        <input type="password" [(ngModel)]="resetAdminPassword" class="input input-bordered w-full mb-3" placeholder="Your administrator password">
+        <input type="password" [(ngModel)]="resetTemporaryPassword" class="input input-bordered w-full mb-3" placeholder="Temporary password (minimum 6 characters)">
+        <input type="password" [(ngModel)]="resetConfirmPassword" class="input input-bordered w-full mb-4" placeholder="Confirm temporary password">
+        <div class="flex justify-end gap-2">
+            <button (click)="showUserResetModal = false" class="btn btn-ghost">Cancel</button>
+            <button (click)="resetUserPassword()" class="btn btn-primary" [disabled]="!resetAdminPassword || resetTemporaryPassword.length < 6 || resetTemporaryPassword !== resetConfirmPassword || isLoading">Set Temporary Password</button>
+        </div>
+    </div>
+</div>
+
+<!-- DEVICE ENVELOPE MODAL -->
+<div *ngIf="showDeviceRotationModal" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+    <div class="bg-white rounded-lg p-6 w-full max-w-md">
+        <h3 class="text-xl font-bold mb-2">Rotate This Device Envelope</h3>
+        <p class="text-sm text-gray-600 mb-4">Confirm the administrator login password. The database key is re-protected for this device without changing it.</p>
+        <input type="password" [(ngModel)]="currentDevicePassword" class="input input-bordered w-full mb-4" placeholder="Administrator login password">
+        <div class="flex justify-end gap-2">
+            <button (click)="showDeviceRotationModal = false" class="btn btn-ghost">Cancel</button>
+            <button (click)="rotateDeviceEnvelope()" class="btn btn-primary" [disabled]="!currentDevicePassword || isLoading">Rotate Device Envelope</button>
         </div>
     </div>
 </div>
@@ -602,8 +666,9 @@
                 <button (click)="copyRecoveryCode()" class="btn btn-xs btn-outline mt-2">{{ isCopied ? 'Copied!' : 'Copy
                     to Clipboard' }}</button>
             </div>
+            <p class="text-xs text-gray-500 mb-3">Selecting Done activates this exact code and invalidates the old one. If you close the app first, the old code remains valid and this code will be shown again after the next administrator login.</p>
             <div class="flex justify-center"><button (click)="closeRecoveryModal()"
-                    class="btn btn-primary">Done</button></div>
+                    class="btn btn-primary" [disabled]="isLoading">{{ isLoading ? 'Confirming...' : 'Done' }}</button></div>
         </div>
     </div>
 </div>

--- a/desktop/src/renderer/app/settings/settings.component.html
+++ b/desktop/src/renderer/app/settings/settings.component.html
@@ -586,9 +586,9 @@
     <div class="bg-white rounded-lg p-6 w-full max-w-md">
         <h3 class="text-xl font-bold mb-4">Generate Recovery Code</h3>
         <div *ngIf="!newRecoveryCode">
-            <p class="text-sm text-gray-600 mb-4">Enter Master Password to confirm.</p>
+            <p class="text-sm text-gray-600 mb-4">Enter the administrator login password to confirm.</p>
             <input type="password" [(ngModel)]="confirmPassword" class="input input-bordered w-full mb-4"
-                placeholder="Master Password">
+                placeholder="Administrator Password">
             <div class="flex justify-end gap-2">
                 <button (click)="showRecoveryModal = false" class="btn btn-ghost">Cancel</button>
                 <button (click)="generateRecoveryCode()" class="btn btn-error"

--- a/desktop/src/renderer/app/settings/settings.component.spec.ts
+++ b/desktop/src/renderer/app/settings/settings.component.spec.ts
@@ -25,14 +25,25 @@ vi.mock('../shared/components/date-picker/date-picker.component', () => ({ DateP
 describe('SettingsComponent Validation', () => {
     let component: SettingsComponent;
     let mockNgZone: any;
+    let mockAuth: any;
+    let mockData: any;
 
     beforeEach(() => {
         // Mock inject to return dummies
+        mockAuth = {
+            getUser: vi.fn(() => ({ id: 1, username: 'admin', role: 'admin' })),
+            changeLoginPassword: vi.fn(), resetUserPassword: vi.fn(), rotateDeviceEnvelope: vi.fn(),
+            acknowledgeRecoveryCode: vi.fn()
+        };
+        mockData = { invoke: vi.fn() };
         vi.mocked(inject).mockImplementation((token) => {
-            return { invoke: vi.fn(), getUser: vi.fn(), navigate: vi.fn() };
+            if (token === AuthService) return mockAuth;
+            if (token === DataService) return mockData;
+            return { navigate: vi.fn() };
         });
 
         mockNgZone = { run: vi.fn((fn) => fn()) };
+        vi.stubGlobal('alert', vi.fn());
         component = new SettingsComponent(mockNgZone);
         component.isElectron = false;
     });
@@ -46,7 +57,7 @@ describe('SettingsComponent Validation', () => {
 
     it('should validate username length', () => {
         expect(component.validateUser({ username: 'ab' })).toContain('Username must be at least 3 characters.');
-        expect(component.validateUser({ username: 'abc', name: 'Valid', role: 'doc', password: '1234' }).length).toBe(0);
+        expect(component.validateUser({ username: 'abc', name: 'Valid', role: 'doc', password: '123456' }).length).toBe(0);
     });
 
     it('should validate mobile', () => {
@@ -54,5 +65,54 @@ describe('SettingsComponent Validation', () => {
         const valid = component.validateUser({ mobile: '9876543210' });
         const hasMobileErr = valid.some(e => e.includes('Mobile'));
         expect(hasMobileErr).toBe(false);
+    });
+
+    it('runs administrator self-change through the dedicated verified workflow and clears inputs', async () => {
+        mockAuth.changeLoginPassword.mockResolvedValue({ success: true });
+        component.currentLoginPassword = 'current-secret';
+        component.newLoginPassword = 'replacement-secret';
+        component.confirmLoginPassword = 'replacement-secret';
+        component.showLoginPasswordModal = true;
+        await component.changeLoginPassword();
+        expect(mockAuth.changeLoginPassword).toHaveBeenCalledWith('current-secret', 'replacement-secret');
+        expect(component.currentLoginPassword).toBe('');
+        expect(component.newLoginPassword).toBe('');
+        expect(component.showLoginPasswordModal).toBe(false);
+    });
+
+    it('runs staff reset through the separate admin-confirmed workflow', async () => {
+        mockAuth.resetUserPassword.mockResolvedValue({ success: true });
+        component.resetTarget = { id: 2, username: 'doctor' };
+        component.resetAdminPassword = 'admin-secret';
+        component.resetTemporaryPassword = 'temporary-secret';
+        component.resetConfirmPassword = 'temporary-secret';
+        await component.resetUserPassword();
+        expect(mockAuth.resetUserPassword).toHaveBeenCalledWith(2, 'admin-secret', 'temporary-secret');
+        expect(component.resetAdminPassword).toBe('');
+        expect(component.resetTemporaryPassword).toBe('');
+    });
+
+    it('does not put a password field into an existing user edit model', () => {
+        component.editUser({ id: 1, username: 'admin', role: 'admin', name: 'Administrator' });
+        expect(Object.prototype.hasOwnProperty.call(component.editingUser, 'password')).toBe(false);
+    });
+
+    it('acknowledges the exact displayed recovery code only when Done is selected', async () => {
+        mockAuth.acknowledgeRecoveryCode.mockResolvedValue(undefined);
+        component.showRecoveryModal = true;
+        component.newRecoveryCode = 'AAAA-BBBB-CCCC-DDDD';
+        await component.closeRecoveryModal();
+        expect(mockAuth.acknowledgeRecoveryCode).toHaveBeenCalledWith('AAAA-BBBB-CCCC-DDDD');
+        expect(component.newRecoveryCode).toBeNull();
+        expect(component.showRecoveryModal).toBe(false);
+    });
+
+    it('keeps an unacknowledged recovery code visible when confirmation fails', async () => {
+        mockAuth.acknowledgeRecoveryCode.mockRejectedValue(new Error('interrupted'));
+        component.showRecoveryModal = true;
+        component.newRecoveryCode = 'AAAA-BBBB-CCCC-DDDD';
+        await component.closeRecoveryModal();
+        expect(component.newRecoveryCode).toBe('AAAA-BBBB-CCCC-DDDD');
+        expect(component.showRecoveryModal).toBe(true);
     });
 });

--- a/desktop/src/renderer/app/settings/settings.component.ts
+++ b/desktop/src/renderer/app/settings/settings.component.ts
@@ -60,7 +60,18 @@ export class SettingsComponent implements OnInit {
 
   // Security / Backup
   showRecoveryModal = false;
+  showLoginPasswordModal = false;
+  showDeviceRotationModal = false;
+  showUserResetModal = false;
   confirmPassword = '';
+  currentLoginPassword = '';
+  newLoginPassword = '';
+  confirmLoginPassword = '';
+  currentDevicePassword = '';
+  resetTarget: any = null;
+  resetAdminPassword = '';
+  resetTemporaryPassword = '';
+  resetConfirmPassword = '';
   newRecoveryCode: string | null = null;
   isCopied = false;
   isLoading = false;
@@ -347,8 +358,8 @@ export class SettingsComponent implements OnInit {
       errors.push('Invalid email format.');
     }
 
-    if (!user.id && (!user.password || user.password.length < 4)) {
-      errors.push('Password must be at least 4 characters.');
+    if (!user.id && (!user.password || user.password.length < 6)) {
+      errors.push('Password must be at least 6 characters.');
     }
 
     return errors;
@@ -378,6 +389,88 @@ export class SettingsComponent implements OnInit {
       } else {
         alert('Error saving user: ' + msg);
       }
+    }
+  }
+
+  openLoginPasswordModal() {
+    this.currentLoginPassword = '';
+    this.newLoginPassword = '';
+    this.confirmLoginPassword = '';
+    this.showLoginPasswordModal = true;
+  }
+
+  async changeLoginPassword() {
+    if (!this.currentLoginPassword || this.newLoginPassword.length < 6 ||
+      this.newLoginPassword !== this.confirmLoginPassword) return;
+    this.isLoading = true;
+    try {
+      const result = await this.authService.changeLoginPassword(
+        this.currentLoginPassword, this.newLoginPassword
+      );
+      if (result.success) {
+        this.showLoginPasswordModal = false;
+        alert('Administrator login password changed. Vault and recovery keys were not changed.');
+      } else alert(result.error || 'Failed to change login password');
+    } catch (error: any) {
+      alert(error?.message || 'Failed to change login password');
+    } finally {
+      this.currentLoginPassword = '';
+      this.newLoginPassword = '';
+      this.confirmLoginPassword = '';
+      this.isLoading = false;
+    }
+  }
+
+  openUserResetModal(user: any) {
+    this.resetTarget = user;
+    this.resetAdminPassword = '';
+    this.resetTemporaryPassword = '';
+    this.resetConfirmPassword = '';
+    this.showUserResetModal = true;
+  }
+
+  async resetUserPassword() {
+    if (!this.resetTarget || !this.resetAdminPassword || this.resetTemporaryPassword.length < 6 ||
+      this.resetTemporaryPassword !== this.resetConfirmPassword) return;
+    this.isLoading = true;
+    try {
+      const result = await this.authService.resetUserPassword(
+        this.resetTarget.id, this.resetAdminPassword, this.resetTemporaryPassword
+      );
+      if (result.success) {
+        this.showUserResetModal = false;
+        this.editingUser = null;
+        alert('Temporary login password set. The user must change it after signing in.');
+      } else alert(result.error || 'Failed to reset login password');
+    } catch (error: any) {
+      alert(error?.message || 'Failed to reset login password');
+    } finally {
+      this.resetAdminPassword = '';
+      this.resetTemporaryPassword = '';
+      this.resetConfirmPassword = '';
+      this.isLoading = false;
+    }
+  }
+
+  openDeviceRotationModal() {
+    this.currentDevicePassword = '';
+    this.showDeviceRotationModal = true;
+  }
+
+  async rotateDeviceEnvelope() {
+    if (!this.currentDevicePassword) return;
+    this.isLoading = true;
+    try {
+      const result = await this.authService.rotateDeviceEnvelope(this.currentDevicePassword);
+      if (result.success) {
+        this.showDeviceRotationModal = false;
+        alert('This device key envelope was rotated. Login passwords and recovery code were not changed.');
+      } else alert(result.error || 'Failed to rotate this device key envelope');
+    } catch (error: any) {
+      alert(error?.message || 'Failed to rotate this device key envelope');
+    } finally {
+      this.currentDevicePassword = '';
+      this.isLoading = false;
     }
   }
 
@@ -423,8 +516,21 @@ export class SettingsComponent implements OnInit {
     this.newRecoveryCode = null;
     this.showRecoveryModal = true;
   }
-  closeRecoveryModal() {
-    this.showRecoveryModal = false;
+  async closeRecoveryModal() {
+    if (!this.newRecoveryCode) {
+      this.showRecoveryModal = false;
+      return;
+    }
+    this.isLoading = true;
+    try {
+      await this.authService.acknowledgeRecoveryCode(this.newRecoveryCode);
+      this.newRecoveryCode = null;
+      this.showRecoveryModal = false;
+    } catch (error: any) {
+      alert(error?.message || 'Could not confirm the recovery code. It will be shown again after the next administrator login.');
+    } finally {
+      this.isLoading = false;
+    }
   }
   async generateRecoveryCode() {
     if (!this.confirmPassword) return;
@@ -432,11 +538,15 @@ export class SettingsComponent implements OnInit {
     try {
       const res = await this.authService.regenerateRecoveryCode(this.confirmPassword) as any;
       this.ngZone.run(() => {
-        this.isLoading = false;
         if (res.success && res.recoveryCode) this.newRecoveryCode = res.recoveryCode;
         else alert(res.error || 'Failed');
       });
-    } catch { this.isLoading = false; }
+    } catch (error: any) {
+      alert(error?.message || 'Failed to rotate recovery code');
+    } finally {
+      this.confirmPassword = '';
+      this.isLoading = false;
+    }
   }
   async copyRecoveryCode() {
     if (this.newRecoveryCode) {

--- a/desktop/src/renderer/app/setup/setup.component.ts
+++ b/desktop/src/renderer/app/setup/setup.component.ts
@@ -78,9 +78,9 @@ import { jsPDF } from 'jspdf';
                 This setup wizard will help you:
                 </p>
                 <ul class="list-disc list-inside text-gray-400 mb-8 space-y-2">
-                <li>Secure your patient data with a Master Password.</li>
+                <li>Create the administrator login and a device-protected local vault.</li>
                 <li>Configure your Clinic details.</li>
-                <li>Generate a Recovery Code (Essential for password reset).</li>
+                <li>Generate a Recovery Code for restoring the encrypted vault on a new device.</li>
                 </ul>
                 <button (click)="step = 2" class="px-6 py-2 bg-blue-600 hover:bg-blue-700 rounded text-white font-medium">
                 Get Started
@@ -88,17 +88,17 @@ import { jsPDF } from 'jspdf';
             </ng-template>
           </div>
 
-          <!-- Step 2: Master Password -->
+          <!-- Step 2: Administrator password -->
           <div *ngIf="step === 2">
-            <h3 class="text-xl font-semibold mb-4 text-white">Create Master Password</h3>
+            <h3 class="text-xl font-semibold mb-4 text-white">Create Administrator Password</h3>
             <div class="bg-yellow-900/30 border border-yellow-700 text-yellow-200 p-4 rounded mb-6 text-sm">
-              <span class="font-bold">IMPORTANT:</span> This password encrypts your database. 
-              If you lose it, you can ONLY restore access using the Recovery Code generated in Step 4.
+              <span class="font-bold">IMPORTANT:</span> This password signs in the administrator.
+              The local vault is protected by this device, and recovery uses the separate Recovery Code generated in Step 4.
             </div>
 
             <div class="space-y-4">
               <div>
-                <label class="block text-gray-400 text-sm mb-1">Master Password</label>
+                <label class="block text-gray-400 text-sm mb-1">Administrator Password</label>
                 <input type="password" [(ngModel)]="password" class="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white">
               </div>
               <div>
@@ -159,7 +159,7 @@ import { jsPDF } from 'jspdf';
                  {{ recoveryCode }}
                </div>
                <p class="text-red-400 text-xs mt-3">
-                 SAVE THIS CODE! It is the ONLY way to reset your password if lost.
+                 SAVE THIS CODE! It is required to recover the encrypted vault on a new or reset device.
                </p>
             </div>
 
@@ -273,7 +273,7 @@ export class SetupComponent implements OnInit {
 
     doc.setFontSize(12);
     doc.setTextColor(50, 50, 50);
-    doc.text("Keep this document safe. This code allows you to reset your Master Password.", 20, 40);
+    doc.text("Keep this document safe. This code restores access to your encrypted clinic vault.", 20, 40);
 
     doc.setDrawColor(200, 200, 200);
     doc.setFillColor(245, 245, 245);
@@ -292,7 +292,7 @@ export class SetupComponent implements OnInit {
     doc.save("nalamdesk-recovery-code.pdf");
   }
 
-  goToDashboard() {
+  async goToDashboard() {
     // Setup automatically calls ensureAdminUser which sets up DB.
     // But we are not technically "logged in" via session service yet in the Renderer (AuthService).
     // We should probably auto-login or redirect to login page (but nicely).
@@ -300,12 +300,12 @@ export class SetupComponent implements OnInit {
     // OR, since we just made the password, we can auto-login behind the scenes.
 
     // Auto-login attempt
-    this.authService.login('admin', this.password).then(res => {
-      if (res.success) {
-        this.router.navigate(['/dashboard']);
-      } else {
-        this.router.navigate(['/login']);
-      }
-    });
+    const res = await this.authService.login('admin', this.password);
+    if (res.success) {
+      await this.authService.acknowledgeRecoveryCode(this.recoveryCode);
+      this.router.navigate(['/dashboard']);
+    } else {
+      this.router.navigate(['/login']);
+    }
   }
 }

--- a/desktop/src/renderer/types.d.ts
+++ b/desktop/src/renderer/types.d.ts
@@ -11,6 +11,9 @@ declare global {
             recover: (data: { recoveryCode: string }) => Promise<{ success: boolean; pendingRecoveryCode?: string; error?: string }>;
             acknowledgeRecoveryCode: (recoveryCode: string) => Promise<{ success: boolean }>;
             regenerateRecoveryCode: (password: string) => Promise<{ success: boolean; recoveryCode?: string; error?: string }>;
+            rotateDeviceEnvelope: (currentPassword: string) => Promise<{ success: boolean; error?: string }>;
+            changeLoginPassword: (data: { currentPassword: string; newPassword: string }) => Promise<{ success: boolean; error?: string }>;
+            resetUserPassword: (data: { targetUserId: number; currentAdminPassword: string; temporaryPassword: string }) => Promise<{ success: boolean; error?: string }>;
             db: {
                 getPatients: (query: string) => Promise<any[]>;
                 savePatient: (patient: any) => Promise<any>;
@@ -29,7 +32,6 @@ declare global {
                 getUsers: () => Promise<any[]>;
                 saveUser: (user: any) => Promise<any>;
                 deleteUser: (id: number) => Promise<any>;
-                updateUserPassword: (data: any) => Promise<any>;
                 // Queue
                 getQueue: () => Promise<any[]>;
                 addToQueue: (data: { patientId: number, priority: number }) => Promise<any>;

--- a/desktop/src/renderer/types.d.ts
+++ b/desktop/src/renderer/types.d.ts
@@ -3,12 +3,13 @@ export { };
 declare global {
     interface Window {
         electron: {
-            login: (credentials: { username: string, password: string }) => Promise<{ success: boolean; user?: any; error?: string }>;
-            checkSetup: () => Promise<{ isSetup: boolean; hasRecovery: boolean }>;
+            login: (credentials: { username: string, password: string }) => Promise<{ success: boolean; user?: any; error?: string; pendingRecoveryCode?: string }>;
+            checkSetup: () => Promise<{ isSetup: boolean; hasRecovery: boolean; vaultState?: string; configVersion?: number }>;
             getRecoveryStatus: () => Promise<{ isSetup: boolean; hasRecovery: boolean; hasBackups: boolean; backups?: any[] }>;
             restoreSystemBackup: (path: string) => Promise<void>;
             setup: (data: any) => Promise<{ success: boolean; recoveryCode?: string; error?: string }>;
-            recover: (data: any) => Promise<{ success: boolean; recoveryCode?: string; error?: string }>;
+            recover: (data: { recoveryCode: string }) => Promise<{ success: boolean; pendingRecoveryCode?: string; error?: string }>;
+            acknowledgeRecoveryCode: (recoveryCode: string) => Promise<{ success: boolean }>;
             regenerateRecoveryCode: (password: string) => Promise<{ success: boolean; recoveryCode?: string; error?: string }>;
             db: {
                 getPatients: (query: string) => Promise<any[]>;


### PR DESCRIPTION
## Summary

- remove password mutation from every generic existing-user edit path
- add dedicated verified workflows for self login-password changes and administrator resets
- journal login credential rotation inside SQLCipher with deterministic rollback after interruption
- keep login-password, device-envelope, and recovery-secret rotations explicitly separate
- make recovery-code rotation two-phase so the current code remains authoritative until exact acknowledgement activates the replacement
- reauthorize device/recovery rotations against the persisted active administrator instead of a cached session role

Closes #6.

## Dependency and migration notes

- Stacked on #25 / issue #7 (`d3e1e80`), whose device and recovery envelope contract this PR uses.
- On the current #7-only stack this adds the credential journal as migration v7.
- Independent issue #5 also owns migration v7. After #5 and #7 land, this branch must be rebased onto updated `master`, this migration renumbered to the next sequential version, and combined migration-order tests rerun before merge.
- Existing users, Argon2 hashes, clinic data, SQLCipher DEK, device envelope, and portable recovery envelope are preserved by migration.

## Security considerations

- Login passwords authenticate users only and never read or write vault key metadata.
- The journal resides inside the encrypted database and stores only previous/replacement Argon2 hashes and reset state; plaintext credentials are never persisted or returned.
- Generic edits reject any password field for an existing user, including admin.
- Self changes require the current user password; resets of another user require the current persisted active administrator password.
- Device/recovery rotations require session ID and username to match the persisted active admin row and freshly verify its current Argon2 password.
- A proposed recovery code is device-encrypted and its wrapped envelope remains pending; the old recovery remains valid until exact acknowledgement atomically promotes the new envelope.
- Submitted credential fields are cleared from renderer state after success and failure.

## Validation

- Full main suite: 136 passed, 27 intentional Electron/host skips
- Full renderer suite: 174 passed
- Real Electron/SQLCipher security suite: 27/27 passed
- Focused final security review suite: 56/56 passed
- Main TypeScript compilation passed
- Angular production build passed (existing CommonJS warnings only)
- Diff checks passed

## Smoke evidence

- fresh same-process setup binds the credential service without restart
- login password change survives cold restart without changing `security.json`
- invalid current credentials leave no journal or mutation
- interruptions after prepare/apply restore the previous hash on unlock
- completion makes the replacement credential authoritative
- staff reset requires persisted administrator confirmation and forces user change
- device, login, and recovery rotations remain independent
- before recovery acknowledgement the old code works and proposed code does not; after acknowledgement the inverse is true
- demoted, deactivated, or mismatched stale admin sessions cannot rotate vault metadata

## Rollback

- Before merge: close the PR; no production data has changed.
- After migration but before a credential operation: the new journal table is additive and existing credentials are unchanged.
- Interrupted pre-completion login rotation automatically restores the previous hash/reset flag on next unlock.
- Interrupted recovery rotation keeps the prior recovery envelope authoritative until explicit activation.
- To roll back the application binary, preserve the encrypted database and matching `security.json` together.

## Approval

- Do not merge without explicit owner approval.
