### PR TITLE
fix(desktop): journal credential rotation

### DIFF
--- a/desktop/scripts/run-security-integration.js
+++ b/desktop/scripts/run-security-integration.js
@@ -9,6 +9,7 @@ const result = spawnSync(electron, [
     '-c',
     'vitest.config.main.js',
     'src/main/services/SecurityService.integration.spec.ts',
+    'src/main/services/CredentialRotationService.integration.spec.ts',
     '--reporter=default'
 ], {
     cwd: process.cwd(),

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -13,6 +13,9 @@ import { GoogleDriveService } from './services/GoogleDriveService';
 import { CloudSyncService } from './services/CloudSyncService';
 import { buildAuthenticatedLoginResult } from './services/AuthResult';
 import { ProvisioningService } from './services/ProvisioningService';
+import { CredentialRotationService } from './services/CredentialRotationService';
+import { verifyPersistedActiveAdmin } from './services/AdminCredentialVerifier';
+import { acknowledgeRecoveryCodeForActiveAdmin } from './services/RecoveryCodeAcknowledgement';
 import { ApiServer } from '../server/app';
 import {
     DEV_APP_NAME,
@@ -102,6 +105,7 @@ ipcMain.handle('utils:getRuntimeInfo', () => ({
 // Services
 const securityService = new SecurityService(new ElectronSafeStorageDeviceKeyStore());
 const databaseService = new DatabaseService();
+const credentialRotationService = new CredentialRotationService();
 const provisioningService = new ProvisioningService(securityService, databaseService);
 const googleDriveService = new GoogleDriveService();
 const cloudSyncService = new CloudSyncService(databaseService);
@@ -303,6 +307,8 @@ ipcMain.handle('auth:setup', async (event, { password, clinicDetails, adminDetai
         const recoveryCode = await provisioningService.provision(
             password, clinicDetails, dbPath, userDataPath
         );
+        credentialRotationService.setDb(securityService.getDb());
+        credentialRotationService.reconcileInterruptedRotation();
 
         console.log('[Auth] Setup Complete.');
         return { success: true, recoveryCode };
@@ -324,9 +330,12 @@ ipcMain.handle('auth:recover', async (event, { recoveryCode }) => {
         await securityService.recoverDevice(recoveryCode, userDataPath, dbPath);
 
         // 2. Set DB
-        databaseService.setDb(securityService.getDb());
+        const db = securityService.getDb();
+        databaseService.setDb(db);
 
         await databaseService.migrate();
+        credentialRotationService.setDb(db);
+        credentialRotationService.reconcileInterruptedRotation();
         return {
             success: true,
             pendingRecoveryCode: securityService.getPendingRecoveryCode() || undefined
@@ -340,10 +349,7 @@ ipcMain.handle('auth:recover', async (event, { recoveryCode }) => {
 ipcMain.handle('auth:regenerateRecoveryCode', async (event, { password }) => {
     try {
         const user = sessionService.getUser();
-        if (!user || user.role !== 'admin') throw new Error('Forbidden');
-        const argon2 = await import('argon2');
-        const admin = await databaseService.getUserByUsername('admin');
-        if (!admin || !password || !await argon2.verify(admin.password, password)) throw new Error('INVALID_CREDENTIALS');
+        if (!await verifyPersistedActiveAdmin(user, databaseService, password)) throw new Error('INVALID_CREDENTIALS');
 
         console.log('[Auth] Regenerating Recovery Code...');
         const recoveryCode = await securityService.regenerateRecoveryCode();
@@ -354,10 +360,47 @@ ipcMain.handle('auth:regenerateRecoveryCode', async (event, { password }) => {
     }
 });
 
-ipcMain.handle('auth:acknowledgeRecoveryCode', (_event, { recoveryCode }) => {
+ipcMain.handle('auth:rotateDeviceEnvelope', async (_event, { currentPassword }) => {
+    try {
+        const user = sessionService.getUser();
+        if (!await verifyPersistedActiveAdmin(user, databaseService, currentPassword)) {
+            throw new Error('INVALID_CREDENTIALS');
+        }
+        securityService.rotateDeviceEnvelope();
+        return { success: true };
+    } catch (e: any) {
+        return { success: false, error: e.message };
+    }
+});
+
+ipcMain.handle('auth:changeLoginPassword', async (_event, { currentPassword, newPassword }) => {
+    try {
+        const user = sessionService.getUser();
+        if (!user) throw new Error('Unauthorized');
+        await credentialRotationService.changeOwnPassword(user.id, currentPassword, newPassword);
+        sessionService.setUser({ ...user, password_reset_required: 0 });
+        return { success: true };
+    } catch (e: any) {
+        return { success: false, error: e.message };
+    }
+});
+
+ipcMain.handle('auth:resetUserPassword', async (_event, { targetUserId, currentAdminPassword, temporaryPassword }) => {
+    try {
+        const user = sessionService.getUser();
+        if (!user || user.role !== 'admin') throw new Error('Forbidden');
+        await credentialRotationService.resetUserPassword(
+            user.id, currentAdminPassword, targetUserId, temporaryPassword
+        );
+        return { success: true };
+    } catch (e: any) {
+        return { success: false, error: e.message };
+    }
+});
+
+ipcMain.handle('auth:acknowledgeRecoveryCode', async (_event, { recoveryCode }) => {
     const user = sessionService.getUser();
-    if (!user || user.role !== 'admin') throw new Error('Forbidden');
-    securityService.acknowledgePendingRecoveryCode(recoveryCode);
+    acknowledgeRecoveryCodeForActiveAdmin(user, databaseService, securityService, recoveryCode);
     return { success: true };
 });
 
@@ -367,7 +410,13 @@ ipcMain.handle('clipboard:writeText', (event, text) => {
 });
 
 async function tryUnlockDatabase(legacySecret: string): Promise<{ error?: string; migrated?: boolean }> {
-    if (securityService.getDb()) return {};
+    if (securityService.getDb()) {
+        const openDb = securityService.getDb();
+        databaseService.setDb(openDb);
+        credentialRotationService.setDb(openDb);
+        credentialRotationService.reconcileInterruptedRotation();
+        return {};
+    }
 
     try {
         const userDataPath = app.getPath('userData');
@@ -383,10 +432,13 @@ async function tryUnlockDatabase(legacySecret: string): Promise<{ error?: string
             // migration. It is not part of the v3 device unlock contract.
             result = await securityService.migrateLegacy(legacySecret, dbPath, userDataPath);
         }
-        databaseService.setDb(securityService.getDb());
+        const db = securityService.getDb();
+        databaseService.setDb(db);
 
         // Ensure schema is up to date (safe idempotent)
         await databaseService.migrate();
+        credentialRotationService.setDb(db);
+        credentialRotationService.reconcileInterruptedRotation();
         return { migrated: result.migrated };
     } catch (e: any) {
         if (e.message === 'NOT_SETUP') return { error: 'SETUP_REQUIRED' };
@@ -595,7 +647,7 @@ ipcMain.handle('db:saveUser', (_, userData) => {
     const user = sessionService.getUser();
     if (!user) throw new Error('Unauthorized');
     if (user.role !== 'admin') throw new Error('Forbidden');
-    return databaseService.saveUser(userData);
+    return databaseService.saveUser(userData, user.id);
 });
 ipcMain.handle('db:deleteUser', (_, id) => {
     const user = sessionService.getUser();

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -2,7 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron';
 
 console.log('Preload script loaded!');
 contextBridge.exposeInMainWorld('electron', {
-    login: (password: string) => ipcRenderer.invoke('auth:login', password),
+    login: (credentials: { username: string; password: string }) => ipcRenderer.invoke('auth:login', credentials),
     checkSetup: () => ipcRenderer.invoke('auth:checkSetup'),
     getRecoveryStatus: () => ipcRenderer.invoke('auth:getRecoveryStatus'),
     restoreSystemBackup: (path: string) => ipcRenderer.invoke('auth:restoreSystemBackup', path),
@@ -10,6 +10,9 @@ contextBridge.exposeInMainWorld('electron', {
     recover: (data: any) => ipcRenderer.invoke('auth:recover', data),
     acknowledgeRecoveryCode: (recoveryCode: string) => ipcRenderer.invoke('auth:acknowledgeRecoveryCode', { recoveryCode }),
     regenerateRecoveryCode: (password: string) => ipcRenderer.invoke('auth:regenerateRecoveryCode', { password }),
+    rotateDeviceEnvelope: (currentPassword: string) => ipcRenderer.invoke('auth:rotateDeviceEnvelope', { currentPassword }),
+    changeLoginPassword: (data: { currentPassword: string; newPassword: string }) => ipcRenderer.invoke('auth:changeLoginPassword', data),
+    resetUserPassword: (data: { targetUserId: number; currentAdminPassword: string; temporaryPassword: string }) => ipcRenderer.invoke('auth:resetUserPassword', data),
     // ...
     backup: {
         selectPath: () => ipcRenderer.invoke('backup:selectPath'),
@@ -44,7 +47,6 @@ contextBridge.exposeInMainWorld('electron', {
         getUsers: () => ipcRenderer.invoke('db:getUsers'),
         saveUser: (user: any) => ipcRenderer.invoke('db:saveUser', user),
         deleteUser: (id: number) => ipcRenderer.invoke('db:deleteUser', id),
-        updateUserPassword: (data: any) => ipcRenderer.invoke('db:updateUserPassword', data),
         // Queue
         getQueue: () => ipcRenderer.invoke('db:getQueue'),
         addToQueue: (data: { patientId: number, priority: number }) => ipcRenderer.invoke('db:addToQueue', data),

--- a/desktop/src/main/schema/migrations.spec.ts
+++ b/desktop/src/main/schema/migrations.spec.ts
@@ -33,8 +33,21 @@ describe('Database Migrations', () => {
             });
         });
 
-        it('should have 7 migrations total', () => {
-            expect(MIGRATIONS).toHaveLength(7);
+        it('should have 8 migrations total', () => {
+            expect(MIGRATIONS).toHaveLength(8);
+        });
+    });
+
+    describe('Migration v8 (Credential Rotation Journal)', () => {
+        it('stores only hashes and constrains the recoverable phases', () => {
+            MIGRATIONS[7].up(mockDb);
+            const sql = executedSql.join('\n');
+            expect(sql).toContain('credential_rotation_journal');
+            expect(sql).toContain("phase IN ('prepared', 'applied')");
+            expect(sql).toContain('previous_hash');
+            expect(sql).toContain('replacement_hash');
+            expect(sql).not.toContain('current_password');
+            expect(sql).not.toContain('new_password');
         });
     });
 

--- a/desktop/src/main/schema/migrations.ts
+++ b/desktop/src/main/schema/migrations.ts
@@ -388,5 +388,22 @@ export const MIGRATIONS = [
                     .run(JSON.stringify([...permissions]), 'doctor');
             }
         }
+    },
+    {
+        version: 8,
+        up: (db: any) => {
+            console.log('Running Migration v8 (Credential Rotation Journal)...');
+            db.exec(`
+                CREATE TABLE IF NOT EXISTS credential_rotation_journal (
+                    id INTEGER PRIMARY KEY CHECK (id = 1),
+                    username TEXT NOT NULL,
+                    previous_hash TEXT NOT NULL,
+                    replacement_hash TEXT NOT NULL,
+                    previous_reset_required INTEGER NOT NULL DEFAULT 0,
+                    phase TEXT NOT NULL CHECK (phase IN ('prepared', 'applied')),
+                    started_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+                );
+            `);
+        }
     }
 ];

--- a/desktop/src/main/services/AdminCredentialVerifier.spec.ts
+++ b/desktop/src/main/services/AdminCredentialVerifier.spec.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as argon2 from 'argon2';
+import { isPersistedActiveAdminSession, verifyPersistedActiveAdmin } from './AdminCredentialVerifier';
+
+vi.mock('argon2', () => ({
+    verify: vi.fn(async (hash: string, password: string) => hash === 'admin-hash' && password === 'current')
+}));
+
+describe('verifyPersistedActiveAdmin', () => {
+    const session = { id: 1, username: 'admin', role: 'admin', name: 'Administrator' } as any;
+    let persisted: any;
+    let database: any;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        persisted = { id: 1, username: 'admin', role: 'admin', active: 1, password: 'admin-hash' };
+        database = { getUserByUsername: vi.fn(() => persisted) };
+    });
+
+    it('accepts only a matching persisted active administrator with the current password', async () => {
+        await expect(verifyPersistedActiveAdmin(session, database, 'current')).resolves.toBe(true);
+        expect(argon2.verify).toHaveBeenCalledWith('admin-hash', 'current');
+    });
+
+    it.each([
+        ['demoted', { role: 'doctor' }],
+        ['deactivated', { active: 0 }],
+        ['id mismatch', { id: 99 }],
+        ['username mismatch', { username: 'other-admin' }]
+    ])('rejects a stale session when the persisted administrator is %s', async (_label, change) => {
+        persisted = { ...persisted, ...change };
+        expect(isPersistedActiveAdminSession(session, database)).toBe(false);
+        await expect(verifyPersistedActiveAdmin(session, database, 'current')).resolves.toBe(false);
+        expect(argon2.verify).not.toHaveBeenCalled();
+    });
+
+    it('rejects an invalid current password and malformed password hashes', async () => {
+        await expect(verifyPersistedActiveAdmin(session, database, 'wrong')).resolves.toBe(false);
+        vi.mocked(argon2.verify).mockRejectedValueOnce(new Error('malformed hash'));
+        await expect(verifyPersistedActiveAdmin(session, database, 'current')).resolves.toBe(false);
+    });
+});

--- a/desktop/src/main/services/AdminCredentialVerifier.ts
+++ b/desktop/src/main/services/AdminCredentialVerifier.ts
@@ -1,0 +1,39 @@
+import * as argon2 from 'argon2';
+import type { UserSession } from './SessionService';
+import type { DatabaseService } from './DatabaseService';
+
+function getPersistedActiveAdmin(sessionUser: UserSession | null, databaseService: DatabaseService): any | null {
+    if (!sessionUser) return null;
+    const persisted = databaseService.getUserByUsername(sessionUser.username);
+    if (!persisted || persisted.id !== sessionUser.id || persisted.username !== sessionUser.username ||
+        persisted.active !== 1 || persisted.role !== 'admin') {
+        return null;
+    }
+    return persisted;
+}
+
+/** Reject stale privileged sessions after role, activation, or identity changes. */
+export function isPersistedActiveAdminSession(
+    sessionUser: UserSession | null,
+    databaseService: DatabaseService
+): boolean {
+    return getPersistedActiveAdmin(sessionUser, databaseService) !== null;
+}
+
+/** Re-authorize sensitive vault metadata changes against current DB state. */
+export async function verifyPersistedActiveAdmin(
+    sessionUser: UserSession | null,
+    databaseService: DatabaseService,
+    password: string
+): Promise<boolean> {
+    if (!sessionUser || typeof password !== 'string' || password.length === 0) return false;
+    const persisted = getPersistedActiveAdmin(sessionUser, databaseService);
+    if (!persisted || typeof persisted.password !== 'string') {
+        return false;
+    }
+    try {
+        return await argon2.verify(persisted.password, password);
+    } catch {
+        return false;
+    }
+}

--- a/desktop/src/main/services/CredentialRotationService.integration.spec.ts
+++ b/desktop/src/main/services/CredentialRotationService.integration.spec.ts
@@ -137,6 +137,26 @@ describe.skipIf(!process.versions.electron)('CredentialRotationService SQLCipher
         });
     });
 
+    it.each([
+        ['demoted', "UPDATE users SET role = 'doctor' WHERE id = 1"],
+        ['deactivated', 'UPDATE users SET active = 0 WHERE id = 1']
+    ])('rejects a staff reset when the administrator is %s during password hashing', async (_state, sql) => {
+        const doctor = database.getUserByUsername('doctor');
+        const rotations = new CredentialRotationService({
+            onStep: step => {
+                if (step === 'after-hash') security.getDb().prepare(sql).run();
+            }
+        });
+        rotations.setDb(security.getDb());
+
+        await expect(rotations.resetUserPassword(1, 'admin-current', doctor.id, 'doctor-temporary'))
+            .rejects.toThrow('CREDENTIAL_CHANGED_CONCURRENTLY');
+        expect(await database.validateUser('doctor', 'doctor-current')).toMatchObject({ success: true });
+        expect(await database.validateUser('doctor', 'doctor-temporary')).toMatchObject({ success: false });
+        expect(security.getDb().prepare('SELECT COUNT(*) AS count FROM credential_rotation_journal').get())
+            .toEqual({ count: 0 });
+    });
+
     it('lets a forced-reset user change their own temporary credential and clears the reset flag', async () => {
         const doctor = database.getUserByUsername('doctor');
         const rotations = new CredentialRotationService();

--- a/desktop/src/main/services/CredentialRotationService.integration.spec.ts
+++ b/desktop/src/main/services/CredentialRotationService.integration.spec.ts
@@ -1,0 +1,239 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as argon2 from 'argon2';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { DeviceKeyStore } from './DeviceKeyStore';
+import { SecurityService } from './SecurityService';
+import { DatabaseService } from './DatabaseService';
+import { CredentialRotationService, CredentialRotationStep } from './CredentialRotationService';
+
+class IntegrationDeviceStore implements DeviceKeyStore {
+    constructor(private readonly mask: number) { }
+    status() { return { available: true, provider: 'credential-integration-store' }; }
+    protect(value: Buffer) { return Buffer.from(value.map(byte => byte ^ this.mask)); }
+    unprotect(value: Buffer) { return this.protect(value); }
+}
+
+describe.skipIf(!process.versions.electron)('CredentialRotationService SQLCipher integration', () => {
+    let directory: string;
+    let dbPath: string;
+    let store: IntegrationDeviceStore;
+    let security: SecurityService;
+    let database: DatabaseService;
+    let recoveryCode: string;
+
+    beforeEach(async () => {
+        directory = fs.mkdtempSync(path.join(os.tmpdir(), 'nalamdesk-credential-integration-'));
+        dbPath = path.join(directory, 'nalamdesk.db');
+        store = new IntegrationDeviceStore(0x45);
+        security = new SecurityService(store);
+        recoveryCode = await security.setup('not-used-for-vault', dbPath, directory);
+        database = new DatabaseService();
+        database.setDb(security.getDb());
+        await database.migrate({ skipBackup: true });
+        await database.ensureAdminUser('admin-current');
+        await database.saveUser({
+            username: 'doctor', password: 'doctor-current', role: 'doctor', name: 'Doctor'
+        });
+        security.completeProvisioning();
+    });
+
+    afterEach(() => {
+        security?.closeDb();
+        fs.rmSync(directory, { recursive: true, force: true });
+    });
+
+    const restart = async () => {
+        security.closeDb();
+        security = new SecurityService(store);
+        await security.initializeDevice(dbPath, directory);
+        database = new DatabaseService();
+        database.setDb(security.getDb());
+        await database.migrate({ skipBackup: true });
+        const rotations = new CredentialRotationService();
+        rotations.setDb(security.getDb());
+        rotations.reconcileInterruptedRotation();
+        return rotations;
+    };
+
+    it('binds a freshly provisioned same-process vault and changes login across restart without changing vault metadata', async () => {
+        const configBefore = fs.readFileSync(path.join(directory, 'security.json'));
+        const rotations = new CredentialRotationService();
+        rotations.setDb(security.getDb());
+        await rotations.changeOwnPassword(1, 'admin-current', 'admin-replacement');
+
+        await restart();
+        expect(await database.validateUser('admin', 'admin-current')).toMatchObject({ success: false });
+        expect(await database.validateUser('admin', 'admin-replacement')).toMatchObject({ success: true });
+        expect(fs.readFileSync(path.join(directory, 'security.json'))).toEqual(configBefore);
+    });
+
+    it('rejects an invalid current credential without creating a journal', async () => {
+        const rotations = new CredentialRotationService();
+        rotations.setDb(security.getDb());
+        await expect(rotations.changeOwnPassword(1, 'wrong-current', 'admin-replacement'))
+            .rejects.toThrow('INVALID_CREDENTIALS');
+        expect(security.getDb().prepare('SELECT COUNT(*) AS count FROM credential_rotation_journal').get())
+            .toEqual({ count: 0 });
+        expect(await database.validateUser('admin', 'admin-current')).toMatchObject({ success: true });
+    });
+
+    it('migrates an existing encrypted v7 database without changing clinic data or credentials', async () => {
+        security.getDb().exec(`
+            CREATE TABLE preserved_clinic_data(value TEXT);
+            INSERT INTO preserved_clinic_data VALUES ('preserved');
+            DROP TABLE credential_rotation_journal;
+        `);
+        security.getDb().pragma('user_version = 7');
+        await database.migrate({ skipBackup: true });
+        expect(security.getDb().prepare('SELECT value FROM preserved_clinic_data').get())
+            .toEqual({ value: 'preserved' });
+        expect(await database.validateUser('admin', 'admin-current')).toMatchObject({ success: true });
+        expect(security.getDb().pragma('user_version', { simple: true })).toBe(8);
+    });
+
+    it.each(['after-prepare', 'after-apply'] as CredentialRotationStep[])(
+        'rolls back an interruption at %s on the next encrypted-database unlock',
+        async interruptedStep => {
+            const rotations = new CredentialRotationService({
+                onStep: step => { if (step === interruptedStep) throw new Error('simulated process death'); }
+            });
+            rotations.setDb(security.getDb());
+            await expect(rotations.changeOwnPassword(1, 'admin-current', 'admin-replacement'))
+                .rejects.toThrow('simulated process death');
+
+            await restart();
+            expect(await database.validateUser('admin', 'admin-current')).toMatchObject({ success: true });
+            expect(await database.validateUser('admin', 'admin-replacement')).toMatchObject({ success: false });
+            expect(security.getDb().prepare('SELECT COUNT(*) AS count FROM credential_rotation_journal').get())
+                .toEqual({ count: 0 });
+        }
+    );
+
+    it('keeps the completed credential authoritative if notification fails after the commit boundary', async () => {
+        const rotations = new CredentialRotationService({
+            onStep: step => { if (step === 'after-complete') throw new Error('post-commit notification failure'); }
+        });
+        rotations.setDb(security.getDb());
+        await expect(rotations.changeOwnPassword(1, 'admin-current', 'admin-replacement'))
+            .rejects.toThrow('post-commit notification failure');
+        await restart();
+        expect(await database.validateUser('admin', 'admin-current')).toMatchObject({ success: false });
+        expect(await database.validateUser('admin', 'admin-replacement')).toMatchObject({ success: true });
+    });
+
+    it('requires the current admin credential for a separate staff reset workflow', async () => {
+        const doctor = database.getUserByUsername('doctor');
+        const rotations = new CredentialRotationService();
+        rotations.setDb(security.getDb());
+        await expect(rotations.resetUserPassword(1, 'wrong', doctor.id, 'doctor-temporary'))
+            .rejects.toThrow('INVALID_CREDENTIALS');
+        await rotations.resetUserPassword(1, 'admin-current', doctor.id, 'doctor-temporary');
+        await restart();
+        expect(await database.validateUser('doctor', 'doctor-current')).toMatchObject({ success: false });
+        expect(await database.validateUser('doctor', 'doctor-temporary')).toMatchObject({
+            success: true, user: { password_reset_required: 1 }
+        });
+    });
+
+    it('lets a forced-reset user change their own temporary credential and clears the reset flag', async () => {
+        const doctor = database.getUserByUsername('doctor');
+        const rotations = new CredentialRotationService();
+        rotations.setDb(security.getDb());
+        await rotations.changeOwnPassword(doctor.id, 'doctor-current', 'doctor-permanent');
+        await restart();
+        expect(await database.validateUser('doctor', 'doctor-permanent')).toMatchObject({
+            success: true, user: { password_reset_required: 0 }
+        });
+    });
+
+    it('rejects existing-user password fields through the real encrypted generic edit path', async () => {
+        const admin = database.getUserByUsername('admin');
+        await expect(database.saveUser({
+            ...admin,
+            password: 'generic-bypass-attempt'
+        }, admin.id)).rejects.toThrow('GENERIC_PASSWORD_CHANGE_FORBIDDEN');
+        expect(await database.validateUser('admin', 'admin-current')).toMatchObject({ success: true });
+        expect(await database.validateUser('admin', 'generic-bypass-attempt')).toMatchObject({ success: false });
+    });
+
+    it('keeps login, device-envelope, and recovery rotations independent and recoverable', async () => {
+        const rotations = new CredentialRotationService();
+        rotations.setDb(security.getDb());
+        await rotations.changeOwnPassword(1, 'admin-current', 'admin-replacement');
+
+        security.rotateDeviceEnvelope();
+        const afterDevice = fs.readFileSync(path.join(directory, 'security.json'));
+        expect(JSON.parse(afterDevice.toString())).toMatchObject({ version: 3 });
+        expect(await database.validateUser('admin', 'admin-replacement')).toMatchObject({ success: true });
+
+        const newRecoveryCode = await security.regenerateRecoveryCode();
+        expect(security.getPendingRecoveryCode()).toBe(newRecoveryCode);
+        const afterRecovery = fs.readFileSync(path.join(directory, 'security.json'));
+        expect(afterRecovery).not.toEqual(afterDevice);
+        expect(await database.validateUser('admin', 'admin-replacement')).toMatchObject({ success: true });
+        security.acknowledgePendingRecoveryCode(newRecoveryCode);
+
+        security.closeDb();
+        const replacementStore = new IntegrationDeviceStore(0x72);
+        security = new SecurityService(replacementStore);
+        await expect(security.recoverDevice(recoveryCode, directory, dbPath)).rejects.toThrow('INVALID_RECOVERY_CODE');
+        await security.recoverDevice(newRecoveryCode, directory, dbPath);
+        database = new DatabaseService();
+        database.setDb(security.getDb());
+        expect(await database.validateUser('admin', 'admin-replacement')).toMatchObject({ success: true });
+    });
+
+    it('keeps the old recovery authoritative until the proposed code is acknowledged', async () => {
+        const before = JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8'));
+        const proposedCode = await security.regenerateRecoveryCode();
+        const pending = JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8'));
+        expect(pending.recovery).toEqual(before.recovery);
+        expect(pending.pendingRecoveryAck.nextRecovery).toBeTruthy();
+        expect(JSON.stringify(pending)).not.toContain(proposedCode);
+        expect(security.getPortableVaultMetadata().recovery).toEqual(before.recovery);
+
+        security.closeDb();
+        const replacementStore = new IntegrationDeviceStore(0x73);
+        security = new SecurityService(replacementStore);
+        await expect(security.recoverDevice(proposedCode, directory, dbPath))
+            .rejects.toThrow('INVALID_RECOVERY_CODE');
+        await expect(security.recoverDevice(recoveryCode, directory, dbPath))
+            .resolves.toEqual({ migrated: false });
+    });
+
+    it('keeps a rotated recovery code pending across restart until exact acknowledgement', async () => {
+        const before = JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8'));
+        const rotatedCode = await security.regenerateRecoveryCode();
+        const configText = fs.readFileSync(path.join(directory, 'security.json'), 'utf8');
+        expect(configText).not.toContain(rotatedCode);
+        await restart();
+        expect(security.getPendingRecoveryCode()).toBe(rotatedCode);
+        expect(() => security.acknowledgePendingRecoveryCode(`${rotatedCode}X`))
+            .toThrow('INVALID_RECOVERY_ACK');
+        expect(security.getPendingRecoveryCode()).toBe(rotatedCode);
+        const afterWrongAck = JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8'));
+        expect(afterWrongAck.recovery).toEqual(before.recovery);
+        expect(afterWrongAck.pendingRecoveryAck).toBeTruthy();
+        security.acknowledgePendingRecoveryCode(rotatedCode);
+        expect(security.getPendingRecoveryCode()).toBeNull();
+        const activated = JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8'));
+        expect(activated.recovery).not.toEqual(before.recovery);
+        expect(activated.pendingRecoveryAck).toBeUndefined();
+    });
+
+    it('never stores submitted plaintext credentials in the journal', async () => {
+        const rotations = new CredentialRotationService({
+            onStep: step => { if (step === 'after-prepare') throw new Error('inspect journal'); }
+        });
+        rotations.setDb(security.getDb());
+        await expect(rotations.changeOwnPassword(1, 'admin-current', 'plaintext-sentinel'))
+            .rejects.toThrow('inspect journal');
+        const journal = security.getDb().prepare('SELECT * FROM credential_rotation_journal').get();
+        expect(JSON.stringify(journal)).not.toContain('admin-current');
+        expect(JSON.stringify(journal)).not.toContain('plaintext-sentinel');
+        expect(await argon2.verify(journal.previous_hash, 'admin-current')).toBe(true);
+        expect(await argon2.verify(journal.replacement_hash, 'plaintext-sentinel')).toBe(true);
+    });
+});

--- a/desktop/src/main/services/CredentialRotationService.integration.spec.ts
+++ b/desktop/src/main/services/CredentialRotationService.integration.spec.ts
@@ -157,6 +157,26 @@ describe.skipIf(!process.versions.electron)('CredentialRotationService SQLCipher
             .toEqual({ count: 0 });
     });
 
+    it('rejects a self-service rotation when the user is deactivated during password hashing', async () => {
+        const doctor = database.getUserByUsername('doctor');
+        const rotations = new CredentialRotationService({
+            onStep: step => {
+                if (step === 'after-hash') {
+                    security.getDb().prepare('UPDATE users SET active = 0 WHERE id = ?').run(doctor.id);
+                }
+            }
+        });
+        rotations.setDb(security.getDb());
+
+        await expect(rotations.changeOwnPassword(doctor.id, 'doctor-current', 'doctor-replacement'))
+            .rejects.toThrow('CREDENTIAL_CHANGED_CONCURRENTLY');
+        const stored = security.getDb().prepare('SELECT password FROM users WHERE id = ?').get(doctor.id);
+        expect(await argon2.verify(stored.password, 'doctor-current')).toBe(true);
+        expect(await argon2.verify(stored.password, 'doctor-replacement')).toBe(false);
+        expect(security.getDb().prepare('SELECT COUNT(*) AS count FROM credential_rotation_journal').get())
+            .toEqual({ count: 0 });
+    });
+
     it('lets a forced-reset user change their own temporary credential and clears the reset flag', async () => {
         const doctor = database.getUserByUsername('doctor');
         const rotations = new CredentialRotationService();

--- a/desktop/src/main/services/CredentialRotationService.ts
+++ b/desktop/src/main/services/CredentialRotationService.ts
@@ -1,0 +1,177 @@
+import * as argon2 from 'argon2';
+
+export type CredentialRotationStep = 'after-prepare' | 'after-apply' | 'after-complete';
+
+export interface CredentialRotationHooks {
+    onStep?: (step: CredentialRotationStep) => void;
+}
+
+interface RotationJournal {
+    username: string;
+    previous_hash: string;
+    replacement_hash: string;
+    previous_reset_required: number;
+    phase: 'prepared' | 'applied';
+}
+
+const MIN_PASSWORD_LENGTH = 6;
+
+/**
+ * Changes login credentials inside the encrypted database. Login credentials
+ * intentionally never participate in the device or recovery envelope paths.
+ * The journal contains Argon2 hashes only and rolls an interrupted apply back
+ * to the previously accepted credential on the next unlock.
+ */
+export class CredentialRotationService {
+    private db: any;
+
+    constructor(private readonly hooks: CredentialRotationHooks = {}) { }
+
+    setDb(db: any): void {
+        this.db = db;
+    }
+
+    async changeOwnPassword(
+        actorId: number,
+        currentPassword: string,
+        newPassword: string
+    ): Promise<void> {
+        const actor = this.getActiveUser(actorId);
+        await this.rotate(actor, currentPassword, newPassword, false, actorId);
+    }
+
+    async resetUserPassword(
+        adminId: number,
+        currentAdminPassword: string,
+        targetUserId: number,
+        temporaryPassword: string
+    ): Promise<void> {
+        const admin = this.getActiveUser(adminId);
+        if (admin.role !== 'admin') throw new Error('FORBIDDEN');
+        if (admin.id === targetUserId) throw new Error('USE_SELF_PASSWORD_CHANGE');
+        if (!await argon2.verify(admin.password, currentAdminPassword)) {
+            throw new Error('INVALID_CREDENTIALS');
+        }
+        const target = this.getActiveUser(targetUserId);
+        await this.rotate(target, undefined, temporaryPassword, true, adminId, {
+            id: admin.id,
+            password: admin.password
+        });
+    }
+
+    /** Restore the old login hash after any interrupted pre-completion phase. */
+    reconcileInterruptedRotation(): void {
+        this.assertReady();
+        const journal = this.db.prepare(`
+            SELECT username, previous_hash, replacement_hash, previous_reset_required, phase
+            FROM credential_rotation_journal WHERE id = 1
+        `).get() as RotationJournal | undefined;
+        if (!journal) return;
+
+        this.db.transaction(() => {
+            const user = this.db.prepare('SELECT password FROM users WHERE username = ?').get(journal.username);
+            if (!user) throw new Error('CREDENTIAL_JOURNAL_USER_MISSING');
+            if (journal.phase === 'applied') {
+                if (user.password === journal.replacement_hash) {
+                    this.db.prepare(`
+                        UPDATE users SET password = ?, password_reset_required = ? WHERE username = ?
+                    `).run(journal.previous_hash, journal.previous_reset_required, journal.username);
+                } else if (user.password !== journal.previous_hash) {
+                    throw new Error('CREDENTIAL_JOURNAL_STATE_MISMATCH');
+                }
+            } else if (journal.phase !== 'prepared') {
+                throw new Error('CREDENTIAL_JOURNAL_CORRUPT');
+            }
+            this.db.prepare('DELETE FROM credential_rotation_journal WHERE id = 1').run();
+        })();
+    }
+
+    private async rotate(
+        target: any,
+        currentPassword: string | undefined,
+        newPassword: string,
+        forceReset: boolean,
+        actingUserId: number,
+        expectedAuthorizer?: { id: number; password: string }
+    ): Promise<void> {
+        this.assertPassword(newPassword);
+        this.reconcileInterruptedRotation();
+        if (currentPassword !== undefined && !await argon2.verify(target.password, currentPassword)) {
+            throw new Error('INVALID_CREDENTIALS');
+        }
+        if (await argon2.verify(target.password, newPassword)) {
+            throw new Error('PASSWORD_UNCHANGED');
+        }
+
+        const replacementHash = await argon2.hash(newPassword);
+        if (expectedAuthorizer) {
+            const currentAuthorizer = this.db.prepare('SELECT password FROM users WHERE id = ?')
+                .get(expectedAuthorizer.id);
+            if (!currentAuthorizer || currentAuthorizer.password !== expectedAuthorizer.password) {
+                throw new Error('CREDENTIAL_CHANGED_CONCURRENTLY');
+            }
+        }
+        this.db.prepare(`
+            INSERT INTO credential_rotation_journal(
+                id, username, previous_hash, replacement_hash, previous_reset_required, phase, started_at
+            ) VALUES (1, ?, ?, ?, ?, 'prepared', CURRENT_TIMESTAMP)
+        `).run(target.username, target.password, replacementHash, target.password_reset_required ?? 0);
+        this.step('after-prepare');
+
+        this.db.transaction(() => {
+            const result = this.db.prepare(`
+                UPDATE users SET password = ?, password_reset_required = ?
+                WHERE id = ? AND password = ?
+            `).run(replacementHash, forceReset ? 1 : 0, target.id, target.password);
+            if (result.changes !== 1) throw new Error('CREDENTIAL_CHANGED_CONCURRENTLY');
+            this.db.prepare(`
+                UPDATE credential_rotation_journal SET phase = 'applied' WHERE id = 1
+            `).run();
+        })();
+        this.step('after-apply');
+
+        try {
+            this.db.transaction(() => {
+                this.db.prepare('DELETE FROM credential_rotation_journal WHERE id = 1').run();
+                this.db.prepare(`
+                    INSERT INTO audit_logs(action, table_name, record_id, user_id, details)
+                    VALUES (?, 'users', ?, ?, ?)
+                `).run(
+                    forceReset ? 'USER_PASSWORD_RESET' : 'LOGIN_PASSWORD_CHANGE',
+                    target.id,
+                    actingUserId,
+                    forceReset ? `Reset login password for ${target.username}` : `Changed login password for ${target.username}`
+                );
+            })();
+        } catch (error) {
+            // A normal completion error is recoverable without waiting for a
+            // restart. A true process interruption is reconciled on unlock.
+            this.reconcileInterruptedRotation();
+            throw error;
+        }
+        this.step('after-complete');
+    }
+
+    private getActiveUser(id: number): any {
+        this.assertReady();
+        const user = this.db.prepare(`
+            SELECT id, username, password, role, active, password_reset_required FROM users WHERE id = ?
+        `).get(id);
+        if (!user || user.active !== 1) throw new Error('ACCESS_DENIED');
+        return user;
+    }
+
+    private assertPassword(password: string): void {
+        if (typeof password !== 'string' || password.length < MIN_PASSWORD_LENGTH) {
+            throw new Error('PASSWORD_TOO_SHORT');
+        }
+    }
+
+    private assertReady(): void {
+        if (!this.db) throw new Error('VAULT_LOCKED');
+    }
+
+    private step(step: CredentialRotationStep): void {
+        this.hooks.onStep?.(step);
+    }
+}

--- a/desktop/src/main/services/CredentialRotationService.ts
+++ b/desktop/src/main/services/CredentialRotationService.ts
@@ -1,6 +1,6 @@
 import * as argon2 from 'argon2';
 
-export type CredentialRotationStep = 'after-prepare' | 'after-apply' | 'after-complete';
+export type CredentialRotationStep = 'after-hash' | 'after-prepare' | 'after-apply' | 'after-complete';
 
 export interface CredentialRotationHooks {
     onStep?: (step: CredentialRotationStep) => void;
@@ -104,10 +104,14 @@ export class CredentialRotationService {
         }
 
         const replacementHash = await argon2.hash(newPassword);
+        this.step('after-hash');
         if (expectedAuthorizer) {
-            const currentAuthorizer = this.db.prepare('SELECT password FROM users WHERE id = ?')
+            const currentAuthorizer = this.db.prepare('SELECT password, role, active FROM users WHERE id = ?')
                 .get(expectedAuthorizer.id);
-            if (!currentAuthorizer || currentAuthorizer.password !== expectedAuthorizer.password) {
+            if (!currentAuthorizer
+                || currentAuthorizer.password !== expectedAuthorizer.password
+                || currentAuthorizer.role !== 'admin'
+                || currentAuthorizer.active !== 1) {
                 throw new Error('CREDENTIAL_CHANGED_CONCURRENTLY');
             }
         }

--- a/desktop/src/main/services/CredentialRotationService.ts
+++ b/desktop/src/main/services/CredentialRotationService.ts
@@ -122,16 +122,21 @@ export class CredentialRotationService {
         `).run(target.username, target.password, replacementHash, target.password_reset_required ?? 0);
         this.step('after-prepare');
 
-        this.db.transaction(() => {
-            const result = this.db.prepare(`
-                UPDATE users SET password = ?, password_reset_required = ?
-                WHERE id = ? AND password = ?
-            `).run(replacementHash, forceReset ? 1 : 0, target.id, target.password);
-            if (result.changes !== 1) throw new Error('CREDENTIAL_CHANGED_CONCURRENTLY');
-            this.db.prepare(`
-                UPDATE credential_rotation_journal SET phase = 'applied' WHERE id = 1
-            `).run();
-        })();
+        try {
+            this.db.transaction(() => {
+                const result = this.db.prepare(`
+                    UPDATE users SET password = ?, password_reset_required = ?
+                    WHERE id = ? AND password = ? AND active = 1
+                `).run(replacementHash, forceReset ? 1 : 0, target.id, target.password);
+                if (result.changes !== 1) throw new Error('CREDENTIAL_CHANGED_CONCURRENTLY');
+                this.db.prepare(`
+                    UPDATE credential_rotation_journal SET phase = 'applied' WHERE id = 1
+                `).run();
+            })();
+        } catch (error) {
+            this.reconcileInterruptedRotation();
+            throw error;
+        }
         this.step('after-apply');
 
         try {

--- a/desktop/src/main/services/DatabaseService.spec.ts
+++ b/desktop/src/main/services/DatabaseService.spec.ts
@@ -101,6 +101,21 @@ describe('DatabaseService', () => {
             expect(mockStatement.run).toHaveBeenCalled();
         });
 
+        it.each(['admin', 'doctor'])('rejects generic password mutation for an existing %s', async username => {
+            mockStatement.get.mockReturnValue({ id: 1, username, role: username === 'admin' ? 'admin' : 'doctor' });
+            await expect(service.saveUser({
+                id: 1, username, role: username === 'admin' ? 'admin' : 'doctor', name: username,
+                password: 'malicious-change'
+            })).rejects.toThrow('GENERIC_PASSWORD_CHANGE_FORBIDDEN');
+            expect(mockDb.prepare).not.toHaveBeenCalledWith(expect.stringContaining('password = @password'));
+        });
+
+        it('does not overwrite an existing admin credential during provisioning retries', async () => {
+            mockStatement.get.mockReturnValue({ id: 1 });
+            await service.ensureAdminUser('different-password');
+            expect(mockStatement.run).not.toHaveBeenCalled();
+        });
+
         it('should validate user credentials correctly', async () => {
             mockStatement.get.mockReturnValue({
                 id: 1,

--- a/desktop/src/main/services/DatabaseService.ts
+++ b/desktop/src/main/services/DatabaseService.ts
@@ -93,15 +93,15 @@ export class DatabaseService {
     }
 
     async ensureAdminUser(password: string) {
-        const hash = await import('argon2').then(a => a.hash(password));
         const admin = this.db.prepare('SELECT id FROM users WHERE username = ?').get('admin');
         if (!admin) {
+            const hash = await import('argon2').then(a => a.hash(password));
             this.db.prepare('INSERT INTO users (username, password, role, name) VALUES (?, ?, ?, ?)').run('admin', hash, 'admin', 'Administrator');
             console.log('Default admin user created.');
         } else {
-            // Update admin password to match current DB key - ensures they are always in sync
-            this.db.prepare('UPDATE users SET password = ? WHERE username = ?').run(hash, 'admin');
-            console.log('Admin password synced with DB key.');
+            // Existing login credentials are never changed by provisioning or
+            // database-key operations. CredentialRotationService owns changes.
+            console.log('Administrator already provisioned; login password preserved.');
         }
 
         // Migration: Add doctor fields to users if missing
@@ -159,29 +159,20 @@ export class DatabaseService {
         };
 
         const result = user.id
-            ? await this.updateExistingUser(safeUser, user, argon2, actingUserId)
+            ? await this.updateExistingUser(safeUser, user, actingUserId)
             : await this.insertNewUser(safeUser, argon2, actingUserId);
 
         return result;
     }
 
-    private async updateExistingUser(safeUser: any, user: any, argon2: any, actingUserId?: number) {
+    private async updateExistingUser(safeUser: any, user: any, actingUserId?: number) {
         const existing = this.db.prepare('SELECT * FROM users WHERE id = ?').get(user.id);
         if (!existing) throw new Error('User not found');
-
-        const includePassword = !!user.password;
-        const forceReset = includePassword && (
-            (actingUserId && actingUserId !== user.id) || user.force_reset
-        );
-
-        if (includePassword) {
-            safeUser.password = await argon2.hash(user.password);
-        }
-        if (forceReset) {
-            safeUser.password_reset_required = 1;
+        if (Object.prototype.hasOwnProperty.call(user, 'password')) {
+            throw new Error('GENERIC_PASSWORD_CHANGE_FORBIDDEN');
         }
 
-        const query = this.buildUpdateQuery(includePassword, forceReset);
+        const query = this.buildUpdateQuery();
         const result = this.db.prepare(query).run(safeUser);
 
         if (actingUserId) {
@@ -190,18 +181,12 @@ export class DatabaseService {
         return result;
     }
 
-    private buildUpdateQuery(includePassword: boolean, forceReset: boolean): string {
+    private buildUpdateQuery(): string {
         const baseCols = `role = @role, name = @name, active = @active, specialty = @specialty, license_number = @license_number,
             mobile = @mobile, email = @email, designation = @designation, joining_date = @joining_date,
             address = @address, emergency_contact_name = @emergency_contact_name, emergency_contact_phone = @emergency_contact_phone`;
 
-        if (!includePassword) {
-            return `UPDATE users SET ${baseCols} WHERE id = @id`;
-        }
-        if (forceReset) {
-            return `UPDATE users SET ${baseCols}, password = @password, password_reset_required = 1 WHERE id = @id`;
-        }
-        return `UPDATE users SET ${baseCols}, password = @password WHERE id = @id`;
+        return `UPDATE users SET ${baseCols} WHERE id = @id`;
     }
 
     private async insertNewUser(safeUser: any, argon2: any, actingUserId?: number) {
@@ -253,13 +238,6 @@ export class DatabaseService {
             this.logAudit('USER_DELETE', 'users', id, actingUserId, `Deleted user ${id}`);
         }
         return result;
-    }
-
-    async updateUserPassword(username: string, newPassword: string) {
-        const argon2 = await import('argon2');
-        const hash = await argon2.hash(newPassword);
-        // This is self-service password change, so we clear the reset_required flag
-        return this.db.prepare('UPDATE users SET password = ?, password_reset_required = 0 WHERE username = ?').run(hash, username);
     }
 
     // ... existing methods ...

--- a/desktop/src/main/services/EncounterIntegrity.spec.ts
+++ b/desktop/src/main/services/EncounterIntegrity.spec.ts
@@ -344,7 +344,7 @@ describe('migration v7 compatibility', () => {
             expect(migrated.status).toBe('finished');
             expect(migrated.started_at).toBeTruthy();
             expect(migrated.completed_at).toBeTruthy();
-            expect(db.pragma('user_version', { simple: true })).toBe(7);
+            expect(db.pragma('user_version', { simple: true })).toBe(8);
         } finally {
             db.close();
         }
@@ -377,7 +377,7 @@ describe('migration v7 compatibility', () => {
 
             await expect(service.migrate()).resolves.toBeUndefined();
             expect(db.prepare('SELECT count(*) count FROM encounter_requests').get().count).toBe(0);
-            expect(db.pragma('user_version', { simple: true })).toBe(7);
+            expect(db.pragma('user_version', { simple: true })).toBe(8);
         } finally {
             db.close();
         }

--- a/desktop/src/main/services/RecoveryCodeAcknowledgement.spec.ts
+++ b/desktop/src/main/services/RecoveryCodeAcknowledgement.spec.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { acknowledgeRecoveryCodeForActiveAdmin } from './RecoveryCodeAcknowledgement';
+
+describe('acknowledgeRecoveryCodeForActiveAdmin', () => {
+    const session = { id: 1, username: 'admin', role: 'admin', name: 'Administrator' } as any;
+    const exactCode = 'AAAA-BBBB-CCCC-DDDD';
+    let persisted: any;
+    let database: any;
+    let state: { recovery: string; pending: string | null };
+    let security: any;
+
+    beforeEach(() => {
+        persisted = { id: 1, username: 'admin', role: 'admin', active: 1, password: 'hash' };
+        database = { getUserByUsername: vi.fn(() => persisted) };
+        state = { recovery: 'old-envelope', pending: exactCode };
+        security = {
+            acknowledgePendingRecoveryCode: vi.fn((code: string) => {
+                if (code !== state.pending) throw new Error('INVALID_RECOVERY_ACK');
+                state = { recovery: 'next-envelope', pending: null };
+            })
+        };
+    });
+
+    it.each([
+        ['demoted', { role: 'doctor' }],
+        ['deactivated', { active: 0 }],
+        ['id mismatch', { id: 99 }],
+        ['username mismatch', { username: 'other-admin' }]
+    ])('does not promote recovery for a %s stale session', (_label, change) => {
+        persisted = { ...persisted, ...change };
+        expect(() => acknowledgeRecoveryCodeForActiveAdmin(
+            session, database, security, exactCode
+        )).toThrow('Forbidden');
+        expect(state).toEqual({ recovery: 'old-envelope', pending: exactCode });
+        expect(security.acknowledgePendingRecoveryCode).not.toHaveBeenCalled();
+    });
+
+    it('promotes the pending recovery for a matching active administrator with the exact code', () => {
+        acknowledgeRecoveryCodeForActiveAdmin(session, database, security, exactCode);
+        expect(state).toEqual({ recovery: 'next-envelope', pending: null });
+        expect(security.acknowledgePendingRecoveryCode).toHaveBeenCalledWith(exactCode);
+    });
+});

--- a/desktop/src/main/services/RecoveryCodeAcknowledgement.ts
+++ b/desktop/src/main/services/RecoveryCodeAcknowledgement.ts
@@ -1,0 +1,15 @@
+import type { UserSession } from './SessionService';
+import type { DatabaseService } from './DatabaseService';
+import type { SecurityService } from './SecurityService';
+import { isPersistedActiveAdminSession } from './AdminCredentialVerifier';
+
+/** Commit a pending recovery rotation only for an administrator still active in the database. */
+export function acknowledgeRecoveryCodeForActiveAdmin(
+    sessionUser: UserSession | null,
+    databaseService: DatabaseService,
+    securityService: SecurityService,
+    recoveryCode: string
+): void {
+    if (!isPersistedActiveAdminSession(sessionUser, databaseService)) throw new Error('Forbidden');
+    securityService.acknowledgePendingRecoveryCode(recoveryCode);
+}

--- a/desktop/src/main/services/SecurityService.spec.ts
+++ b/desktop/src/main/services/SecurityService.spec.ts
@@ -153,6 +153,61 @@ describe('SecurityService v3', () => {
         expect(restarted.getPendingRecoveryCode()).toBeNull();
     });
 
+    it('keeps a regenerated recovery code device-encrypted until exact acknowledgement', async () => {
+        const service = new SecurityService(store);
+        const initialCode = await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        service.acknowledgePendingRecoveryCode(initialCode);
+        const before = JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8'));
+        const rotatedCode = await service.regenerateRecoveryCode();
+        expect(service.getPendingRecoveryCode()).toBe(rotatedCode);
+        const pendingText = fs.readFileSync(path.join(directory, 'security.json'), 'utf8');
+        const pending = JSON.parse(pendingText);
+        expect(pendingText).not.toContain(rotatedCode);
+        expect(pending.recovery).toEqual(before.recovery);
+        expect(pending.pendingRecoveryAck.nextRecovery).toBeTruthy();
+        service.closeDb();
+
+        const restarted = new SecurityService(store);
+        await restarted.initializeDevice(dbPath, directory);
+        expect(restarted.getPendingRecoveryCode()).toBe(rotatedCode);
+        restarted.acknowledgePendingRecoveryCode(rotatedCode);
+        expect(restarted.getPendingRecoveryCode()).toBeNull();
+        expect(JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8')).recovery)
+            .not.toEqual(before.recovery);
+    });
+
+    it('preserves transition recovery until a proposed recovery rotation is activated', async () => {
+        const service = new SecurityService(store);
+        await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        const configPath = path.join(directory, 'security.json');
+        const seeded = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+        seeded.transitionRecovery = { ...seeded.recovery, purpose: 'legacy-transition' };
+        fs.writeFileSync(configPath, JSON.stringify(seeded));
+
+        const rotatedCode = await service.regenerateRecoveryCode();
+        expect(JSON.parse(fs.readFileSync(configPath, 'utf8')).transitionRecovery).toBeTruthy();
+        service.acknowledgePendingRecoveryCode(rotatedCode);
+        expect(JSON.parse(fs.readFileSync(configPath, 'utf8')).transitionRecovery).toBeUndefined();
+    });
+
+    it('preserves the old recovery and pending proposal if activation commit fails', async () => {
+        const service = new SecurityService(store);
+        await service.setup('admin-secret', dbPath, directory);
+        service.completeProvisioning();
+        const rotatedCode = await service.regenerateRecoveryCode();
+        const pendingText = fs.readFileSync(path.join(directory, 'security.json'), 'utf8');
+        vi.spyOn(service as any, 'saveConfigAtomic').mockImplementationOnce(() => {
+            throw new Error('forced activation commit failure');
+        });
+
+        expect(() => service.acknowledgePendingRecoveryCode(rotatedCode))
+            .toThrow('forced activation commit failure');
+        expect(fs.readFileSync(path.join(directory, 'security.json'), 'utf8')).toBe(pendingText);
+        expect(service.getPendingRecoveryCode()).toBe(rotatedCode);
+    });
+
     it('reconciles an already-complete provisioning journal after cleanup interruption', async () => {
         let failed = false;
         const service = new SecurityService(store, {
@@ -384,7 +439,7 @@ describe('SecurityService v3', () => {
         expect(fs.existsSync(path.join(directory, 'salt.bin.migrated'))).toBe(true);
     });
 
-    it('retires transitional recovery artifacts when regenerating the primary code', async () => {
+    it('retires transitional recovery artifacts when the regenerated code is acknowledged', async () => {
         fs.writeFileSync(path.join(directory, 'salt.bin'), crypto.randomBytes(16));
         const service = new SecurityService(store);
         await service.migrateLegacy('legacy-master', dbPath, directory);
@@ -394,11 +449,17 @@ describe('SecurityService v3', () => {
         expect(migratedConfig.transitionRecovery).toBeTruthy();
 
         const replacementCode = await service.regenerateRecoveryCode();
-        const updatedConfig = JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8'));
+        const proposedConfig = JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8'));
 
         expect(replacementCode).toMatch(/^[A-F0-9]{8}(?:-[A-F0-9]{8}){3}$/);
-        expect(updatedConfig.pendingRecoveryAck).toBeUndefined();
-        expect(updatedConfig.transitionRecovery).toBeUndefined();
+        expect(proposedConfig.pendingRecoveryAck?.reason).toBe('recovery-rotation');
+        expect(proposedConfig.transitionRecovery).toBeTruthy();
+        expect(service.getPendingRecoveryCode()).toBe(replacementCode);
+
+        service.acknowledgePendingRecoveryCode(replacementCode);
+        const activatedConfig = JSON.parse(fs.readFileSync(path.join(directory, 'security.json'), 'utf8'));
+        expect(activatedConfig.pendingRecoveryAck).toBeUndefined();
+        expect(activatedConfig.transitionRecovery).toBeUndefined();
         expect(service.getPendingRecoveryCode()).toBeNull();
     });
 

--- a/desktop/src/main/services/SecurityService.ts
+++ b/desktop/src/main/services/SecurityService.ts
@@ -24,7 +24,8 @@ export interface RecoveryEnvelope {
 interface PendingRecoveryAck {
     protectedPayload: string;
     createdAt: string;
-    reason: 'fresh-setup' | 'legacy-migration' | 'transition-recovery';
+    reason: 'fresh-setup' | 'legacy-migration' | 'transition-recovery' | 'recovery-rotation';
+    nextRecovery?: RecoveryEnvelope;
 }
 
 export interface TransitionRecoveryEnvelope extends RecoveryEnvelope {
@@ -309,9 +310,12 @@ export class SecurityService {
         if (!this.dek) throw new Error('VAULT_LOCKED');
         const config = this.loadConfigV3();
         const recoveryCode = this.generateRecoveryCodeString();
-        config.recovery = await this.createRecoveryEnvelope(this.dek, recoveryCode, config.vaultId, config.keyVersion);
-        delete config.pendingRecoveryAck;
-        delete config.transitionRecovery;
+        const nextRecovery = await this.createRecoveryEnvelope(
+            this.dek, recoveryCode, config.vaultId, config.keyVersion
+        );
+        config.pendingRecoveryAck = this.createPendingRecoveryAck(
+            recoveryCode, config.vaultId, config.keyVersion, 'recovery-rotation', nextRecovery
+        );
         this.saveConfigAtomic(config);
         return recoveryCode;
     }
@@ -342,6 +346,11 @@ export class SecurityService {
         if (!config.pendingRecoveryAck) throw new Error('NO_PENDING_RECOVERY_CODE');
         const pending = this.getPendingRecoveryCode();
         if (!pending || !this.constantTimeEqual(pending, recoveryCode)) throw new Error('INVALID_RECOVERY_ACK');
+        if (config.pendingRecoveryAck.reason === 'recovery-rotation') {
+            if (!config.pendingRecoveryAck.nextRecovery) throw new Error('PENDING_RECOVERY_ENVELOPE_MISSING');
+            this.validateRecoveryEnvelope(config.pendingRecoveryAck.nextRecovery);
+            config.recovery = config.pendingRecoveryAck.nextRecovery;
+        }
         delete config.pendingRecoveryAck;
         delete config.transitionRecovery;
         this.saveConfigAtomic(config);
@@ -820,7 +829,8 @@ export class SecurityService {
         recoveryCode: string,
         vaultId: string,
         keyVersion: number,
-        reason: PendingRecoveryAck['reason']
+        reason: PendingRecoveryAck['reason'],
+        nextRecovery?: RecoveryEnvelope
     ): PendingRecoveryAck {
         return {
             protectedPayload: this.protectContextPayload({
@@ -831,7 +841,8 @@ export class SecurityService {
                 recoveryCode
             }),
             createdAt: new Date().toISOString(),
-            reason
+            reason,
+            ...(nextRecovery ? { nextRecovery } : {})
         };
     }
 

--- a/desktop/src/renderer/app/login/change-password/change-password.component.spec.ts
+++ b/desktop/src/renderer/app/login/change-password/change-password.component.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@angular/compiler';
+import { inject } from '@angular/core';
+import { ChangePasswordComponent } from './change-password.component';
+import { AuthService } from '../../services/auth.service';
+import { Router } from '@angular/router';
+
+vi.mock('@angular/core', async () => {
+    const actual = await vi.importActual('@angular/core');
+    return { ...actual as any, inject: vi.fn() };
+});
+
+describe('ChangePasswordComponent', () => {
+    let auth: any;
+    let router: any;
+    let component: ChangePasswordComponent;
+
+    beforeEach(() => {
+        auth = {
+            getUser: vi.fn(() => ({ id: 2, username: 'doctor', role: 'doctor', password_reset_required: 1 })),
+            changeLoginPassword: vi.fn()
+        };
+        router = { navigate: vi.fn() };
+        vi.mocked(inject).mockImplementation(token => token === AuthService ? auth : router);
+        localStorage.clear();
+        component = new ChangePasswordComponent();
+    });
+
+    it('requires the current credential as well as matching replacement passwords', () => {
+        component.password = 'replacement';
+        component.confirmPassword = 'replacement';
+        expect(component.isValid()).toBe(false);
+        component.currentPassword = 'temporary';
+        expect(component.isValid()).toBe(true);
+    });
+
+    it('changes only the authenticated user credential and clears every plaintext input', async () => {
+        auth.changeLoginPassword.mockResolvedValue({ success: true });
+        component.currentPassword = 'temporary';
+        component.password = 'replacement';
+        component.confirmPassword = 'replacement';
+        await component.onSubmit();
+        expect(auth.changeLoginPassword).toHaveBeenCalledWith('temporary', 'replacement');
+        expect(component.currentPassword).toBe('');
+        expect(component.password).toBe('');
+        expect(component.confirmPassword).toBe('');
+        expect(router.navigate).toHaveBeenCalledWith(['/dashboard']);
+        expect(JSON.parse(localStorage.getItem('nalamdesk_user')!)).toMatchObject({ password_reset_required: 0 });
+    });
+
+    it('clears plaintext inputs when the IPC call fails', async () => {
+        auth.changeLoginPassword.mockRejectedValue(new Error('IPC failed'));
+        component.currentPassword = 'temporary';
+        component.password = 'replacement';
+        component.confirmPassword = 'replacement';
+        await component.onSubmit();
+        expect(component.error).toBe('IPC failed');
+        expect(component.currentPassword).toBe('');
+        expect(component.password).toBe('');
+        expect(component.confirmPassword).toBe('');
+    });
+});

--- a/desktop/src/renderer/app/login/change-password/change-password.component.ts
+++ b/desktop/src/renderer/app/login/change-password/change-password.component.ts
@@ -18,6 +18,11 @@ import { AuthService } from '../../services/auth.service';
 
         <form (ngSubmit)="onSubmit()" class="space-y-4">
           <div>
+            <label class="block text-sm font-medium text-gray-700">Current Password</label>
+            <input type="password" [(ngModel)]="currentPassword" name="currentPassword" required
+                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 p-2 border">
+          </div>
+          <div>
             <label class="block text-sm font-medium text-gray-700">New Password</label>
             <input type="password" [(ngModel)]="password" name="password" required minlength="6"
                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 p-2 border">
@@ -46,6 +51,7 @@ import { AuthService } from '../../services/auth.service';
   `
 })
 export class ChangePasswordComponent {
+    currentPassword = '';
     password = '';
     confirmPassword = '';
     isLoading = false;
@@ -55,7 +61,7 @@ export class ChangePasswordComponent {
     private router = inject(Router);
 
     isValid() {
-        return this.password.length >= 6 && this.password === this.confirmPassword;
+        return !!this.currentPassword && this.password.length >= 6 && this.password === this.confirmPassword;
     }
 
     async onSubmit() {
@@ -70,8 +76,8 @@ export class ChangePasswordComponent {
                 return;
             }
 
-            const success = await this.auth.updatePassword(user.username, this.password);
-            if (success) {
+            const result = await this.auth.changeLoginPassword(this.currentPassword, this.password);
+            if (result.success) {
                 // Update local user state to reflect reset is no longer required
                 const updatedUser = { ...user, password_reset_required: 0 };
 
@@ -81,11 +87,14 @@ export class ChangePasswordComponent {
                 // Navigate to dashboard
                 this.router.navigate(['/dashboard']);
             } else {
-                this.error = 'Failed to update password';
+                this.error = result.error || 'Failed to update password';
             }
         } catch (e: any) {
             this.error = e.message || 'An error occurred';
         } finally {
+            this.currentPassword = '';
+            this.password = '';
+            this.confirmPassword = '';
             this.isLoading = false;
         }
     }

--- a/desktop/src/renderer/app/services/auth.service.spec.ts
+++ b/desktop/src/renderer/app/services/auth.service.spec.ts
@@ -90,6 +90,28 @@ describe('AuthService', () => {
             expect((service.getUser() as any).password).toBeUndefined();
             expect(localStorage.getItem('nalamdesk_user')).not.toContain('$argon2id$hash');
         });
+
+        it('uses distinct IPC contracts for login, staff reset, device, and recovery rotation', async () => {
+            (window as any).electron = {
+                changeLoginPassword: vi.fn().mockResolvedValue({ success: true }),
+                resetUserPassword: vi.fn().mockResolvedValue({ success: true }),
+                rotateDeviceEnvelope: vi.fn().mockResolvedValue({ success: true }),
+                regenerateRecoveryCode: vi.fn().mockResolvedValue({ success: true, recoveryCode: 'CODE' })
+            };
+            await service.changeLoginPassword('current', 'replacement');
+            await service.resetUserPassword(2, 'admin-current', 'temporary');
+            await service.rotateDeviceEnvelope('admin-current');
+            await service.regenerateRecoveryCode('admin-current');
+
+            expect(window.electron.changeLoginPassword).toHaveBeenCalledWith({
+                currentPassword: 'current', newPassword: 'replacement'
+            });
+            expect(window.electron.resetUserPassword).toHaveBeenCalledWith({
+                targetUserId: 2, currentAdminPassword: 'admin-current', temporaryPassword: 'temporary'
+            });
+            expect(window.electron.rotateDeviceEnvelope).toHaveBeenCalledWith('admin-current');
+            expect(window.electron.regenerateRecoveryCode).toHaveBeenCalledWith('admin-current');
+        });
     });
 
     describe('login (Web Mode)', () => {

--- a/desktop/src/renderer/app/services/auth.service.ts
+++ b/desktop/src/renderer/app/services/auth.service.ts
@@ -79,13 +79,23 @@ export class AuthService {
         return { success: false, error: 'Not supported' };
     }
 
-    async updatePassword(username: string, newPassword: string): Promise<boolean> {
-        if (window.electron && window.electron.db) {
-            const result = await window.electron.db.updateUserPassword({ username, password: newPassword });
-            return result && result.changes > 0;
-        }
-        // TODO: Web implementation
-        return false;
+    async changeLoginPassword(currentPassword: string, newPassword: string): Promise<{ success: boolean; error?: string }> {
+        if (!window.electron) return { success: false, error: 'Not supported' };
+        return window.electron.changeLoginPassword({ currentPassword, newPassword });
+    }
+
+    async resetUserPassword(
+        targetUserId: number,
+        currentAdminPassword: string,
+        temporaryPassword: string
+    ): Promise<{ success: boolean; error?: string }> {
+        if (!window.electron) return { success: false, error: 'Not supported' };
+        return window.electron.resetUserPassword({ targetUserId, currentAdminPassword, temporaryPassword });
+    }
+
+    async rotateDeviceEnvelope(currentPassword: string): Promise<{ success: boolean; error?: string }> {
+        if (!window.electron) return { success: false, error: 'Not supported' };
+        return window.electron.rotateDeviceEnvelope(currentPassword);
     }
 
     logout() {

--- a/desktop/src/renderer/app/settings/settings.component.html
+++ b/desktop/src/renderer/app/settings/settings.component.html
@@ -184,15 +184,34 @@
         <div *ngIf="activeTab === 'security'" class="h-full overflow-y-auto p-4 md:p-8">
             <h2 class="text-2xl font-bold text-gray-800 mb-6">Security & Resilience</h2>
 
+            <div class="bg-white p-4 md:p-6 rounded-lg shadow-sm border border-gray-200 mb-6">
+                <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
+                    <div>
+                        <h3 class="text-lg font-medium text-gray-800">Administrator Login Password</h3>
+                        <p class="text-sm text-gray-500 max-w-lg">Changes only the administrator sign-in credential. It does not rotate the database device key or recovery code.</p>
+                    </div>
+                    <button (click)="openLoginPasswordModal()" class="btn btn-outline w-full md:w-auto">Change Login Password</button>
+                </div>
+            </div>
+
+            <div class="bg-white p-4 md:p-6 rounded-lg shadow-sm border border-gray-200 mb-6">
+                <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
+                    <div>
+                        <h3 class="text-lg font-medium text-gray-800">This Device Key Envelope</h3>
+                        <p class="text-sm text-gray-500 max-w-lg">Re-protects the unchanged database key for this device. Login passwords and the portable recovery code remain unchanged.</p>
+                    </div>
+                    <button (click)="openDeviceRotationModal()" class="btn btn-outline w-full md:w-auto">Rotate Device Envelope</button>
+                </div>
+            </div>
+
             <!-- Recovery Code -->
             <div class="bg-white p-4 md:p-6 rounded-lg shadow-sm border border-gray-200 mb-6">
                 <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
                     <div>
-                        <h3 class="text-lg font-medium text-red-600">Master Recovery Code</h3>
-                        <p class="text-sm text-gray-500 max-w-lg">Used to regain access if the admin password is lost.
-                            Store this securely offline.</p>
+                        <h3 class="text-lg font-medium text-red-600">Portable Vault Recovery Code</h3>
+                        <p class="text-sm text-gray-500 max-w-lg">Used to enrol a replacement device when its device key is unavailable. It does not reset any user's login password. Store it securely offline.</p>
                         <p class="text-xs text-red-500 mt-2 font-bold bg-red-50 inline-block px-2 py-1 rounded">⚠️
-                            Generating a new code immediately invalidates the old one.</p>
+                            The old code remains valid until you save the new code and select Done.</p>
                     </div>
                     <button (click)="openRecoveryModal()" class="btn btn-outline btn-error w-full md:w-auto">Generate
                         New Code</button>
@@ -522,24 +541,25 @@
                 </div>
             </div>
 
-            <!-- Password & Status -->
+            <!-- Credential workflow & Status -->
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4 pt-4 border-t">
                 <div>
-                    <label class="block text-sm font-medium text-gray-700">
-                        {{ editingUser.id ? 'Reset Password' : 'Password' }} <span *ngIf="!editingUser.id"
-                            class="text-red-500">*</span>
-                    </label>
+                    <ng-container *ngIf="!editingUser.id; else existingCredentialWorkflow">
+                    <label class="block text-sm font-medium text-gray-700">Temporary Password <span class="text-red-500">*</span></label>
                     <input [(ngModel)]="editingUser.password" type="password" placeholder="Set temporary password"
-                        #password="ngModel" [required]="!editingUser.id" minlength="4"
+                        #password="ngModel" [required]="!editingUser.id" minlength="6"
                         [class.border-red-500]="(password.invalid && (password.dirty || password.touched)) || (formSubmitted && !editingUser.id && !editingUser.password)"
                         class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 border p-2">
-
                     <p *ngIf="password.invalid && (password.dirty || password.touched)"
                         class="text-xs text-red-500 mt-1">
-                        Min 4 characters required.
+                        Min 6 characters required.
                     </p>
-                    <p class="text-xs text-gray-500 mt-1" *ngIf="editingUser.password && editingUser.id">User will
-                        be forced to change this on next login.</p>
+                    </ng-container>
+                    <ng-template #existingCredentialWorkflow>
+                        <label class="block text-sm font-medium text-gray-700">Login Credential</label>
+                        <button *ngIf="editingUser.id !== currentUser?.id" (click)="openUserResetModal(editingUser)" type="button" class="btn btn-outline btn-sm mt-2">Reset via Dedicated Workflow</button>
+                        <p *ngIf="editingUser.id === currentUser?.id" class="text-xs text-gray-500 mt-2">Change your own password from the Security tab. Profile edits cannot change credentials.</p>
+                    </ng-template>
                 </div>
                 <div class="flex-1">
                     <label class="flex items-center gap-2 text-sm font-medium text-gray-700 mt-6 cursor-pointer">
@@ -558,6 +578,50 @@
             <button (click)="saveUser()" class="btn btn-primary">
                 {{ editingUser.id ? 'Save Changes' : 'Add User' }}
             </button>
+        </div>
+    </div>
+</div>
+
+<!-- LOGIN PASSWORD MODAL -->
+<div *ngIf="showLoginPasswordModal" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+    <div class="bg-white rounded-lg p-6 w-full max-w-md">
+        <h3 class="text-xl font-bold mb-2">Change Administrator Login Password</h3>
+        <p class="text-sm text-gray-600 mb-4">This changes login authentication only. Vault key metadata is intentionally untouched.</p>
+        <input type="password" [(ngModel)]="currentLoginPassword" class="input input-bordered w-full mb-3" placeholder="Current login password">
+        <input type="password" [(ngModel)]="newLoginPassword" class="input input-bordered w-full mb-3" placeholder="New login password (minimum 6 characters)">
+        <input type="password" [(ngModel)]="confirmLoginPassword" class="input input-bordered w-full mb-4" placeholder="Confirm new login password">
+        <p *ngIf="confirmLoginPassword && newLoginPassword !== confirmLoginPassword" class="text-xs text-red-500 mb-3">Passwords do not match.</p>
+        <div class="flex justify-end gap-2">
+            <button (click)="showLoginPasswordModal = false" class="btn btn-ghost">Cancel</button>
+            <button (click)="changeLoginPassword()" class="btn btn-primary" [disabled]="!currentLoginPassword || newLoginPassword.length < 6 || newLoginPassword !== confirmLoginPassword || isLoading">Change Login Password</button>
+        </div>
+    </div>
+</div>
+
+<!-- USER PASSWORD RESET MODAL -->
+<div *ngIf="showUserResetModal" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+    <div class="bg-white rounded-lg p-6 w-full max-w-md">
+        <h3 class="text-xl font-bold mb-2">Reset {{ resetTarget?.name }}'s Login Password</h3>
+        <p class="text-sm text-gray-600 mb-4">Confirm your administrator credential. The target user will be required to change the temporary password.</p>
+        <input type="password" [(ngModel)]="resetAdminPassword" class="input input-bordered w-full mb-3" placeholder="Your administrator password">
+        <input type="password" [(ngModel)]="resetTemporaryPassword" class="input input-bordered w-full mb-3" placeholder="Temporary password (minimum 6 characters)">
+        <input type="password" [(ngModel)]="resetConfirmPassword" class="input input-bordered w-full mb-4" placeholder="Confirm temporary password">
+        <div class="flex justify-end gap-2">
+            <button (click)="showUserResetModal = false" class="btn btn-ghost">Cancel</button>
+            <button (click)="resetUserPassword()" class="btn btn-primary" [disabled]="!resetAdminPassword || resetTemporaryPassword.length < 6 || resetTemporaryPassword !== resetConfirmPassword || isLoading">Set Temporary Password</button>
+        </div>
+    </div>
+</div>
+
+<!-- DEVICE ENVELOPE MODAL -->
+<div *ngIf="showDeviceRotationModal" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+    <div class="bg-white rounded-lg p-6 w-full max-w-md">
+        <h3 class="text-xl font-bold mb-2">Rotate This Device Envelope</h3>
+        <p class="text-sm text-gray-600 mb-4">Confirm the administrator login password. The database key is re-protected for this device without changing it.</p>
+        <input type="password" [(ngModel)]="currentDevicePassword" class="input input-bordered w-full mb-4" placeholder="Administrator login password">
+        <div class="flex justify-end gap-2">
+            <button (click)="showDeviceRotationModal = false" class="btn btn-ghost">Cancel</button>
+            <button (click)="rotateDeviceEnvelope()" class="btn btn-primary" [disabled]="!currentDevicePassword || isLoading">Rotate Device Envelope</button>
         </div>
     </div>
 </div>
@@ -603,8 +667,9 @@
                 <button (click)="copyRecoveryCode()" class="btn btn-xs btn-outline mt-2">{{ isCopied ? 'Copied!' : 'Copy
                     to Clipboard' }}</button>
             </div>
+            <p class="text-xs text-gray-500 mb-3">Selecting Done activates this exact code and invalidates the old one. If you close the app first, the old code remains valid and this code will be shown again after the next administrator login.</p>
             <div class="flex justify-center"><button (click)="closeRecoveryModal()"
-                    class="btn btn-primary">Done</button></div>
+                    class="btn btn-primary" [disabled]="isLoading">{{ isLoading ? 'Confirming...' : 'Done' }}</button></div>
         </div>
     </div>
 </div>

--- a/desktop/src/renderer/app/settings/settings.component.spec.ts
+++ b/desktop/src/renderer/app/settings/settings.component.spec.ts
@@ -25,14 +25,25 @@ vi.mock('../shared/components/date-picker/date-picker.component', () => ({ DateP
 describe('SettingsComponent Validation', () => {
     let component: SettingsComponent;
     let mockNgZone: any;
+    let mockAuth: any;
+    let mockData: any;
 
     beforeEach(() => {
         // Mock inject to return dummies
+        mockAuth = {
+            getUser: vi.fn(() => ({ id: 1, username: 'admin', role: 'admin' })),
+            changeLoginPassword: vi.fn(), resetUserPassword: vi.fn(), rotateDeviceEnvelope: vi.fn(),
+            acknowledgeRecoveryCode: vi.fn()
+        };
+        mockData = { invoke: vi.fn() };
         vi.mocked(inject).mockImplementation((token) => {
-            return { invoke: vi.fn(), getUser: vi.fn(), navigate: vi.fn() };
+            if (token === AuthService) return mockAuth;
+            if (token === DataService) return mockData;
+            return { navigate: vi.fn() };
         });
 
         mockNgZone = { run: vi.fn((fn) => fn()) };
+        vi.stubGlobal('alert', vi.fn());
         component = new SettingsComponent(mockNgZone);
         component.isElectron = false;
     });
@@ -46,7 +57,7 @@ describe('SettingsComponent Validation', () => {
 
     it('should validate username length', () => {
         expect(component.validateUser({ username: 'ab' })).toContain('Username must be at least 3 characters.');
-        expect(component.validateUser({ username: 'abc', name: 'Valid', role: 'doc', password: '1234' }).length).toBe(0);
+        expect(component.validateUser({ username: 'abc', name: 'Valid', role: 'doc', password: '123456' }).length).toBe(0);
     });
 
     it('should validate mobile', () => {
@@ -54,5 +65,54 @@ describe('SettingsComponent Validation', () => {
         const valid = component.validateUser({ mobile: '9876543210' });
         const hasMobileErr = valid.some(e => e.includes('Mobile'));
         expect(hasMobileErr).toBe(false);
+    });
+
+    it('runs administrator self-change through the dedicated verified workflow and clears inputs', async () => {
+        mockAuth.changeLoginPassword.mockResolvedValue({ success: true });
+        component.currentLoginPassword = 'current-secret';
+        component.newLoginPassword = 'replacement-secret';
+        component.confirmLoginPassword = 'replacement-secret';
+        component.showLoginPasswordModal = true;
+        await component.changeLoginPassword();
+        expect(mockAuth.changeLoginPassword).toHaveBeenCalledWith('current-secret', 'replacement-secret');
+        expect(component.currentLoginPassword).toBe('');
+        expect(component.newLoginPassword).toBe('');
+        expect(component.showLoginPasswordModal).toBe(false);
+    });
+
+    it('runs staff reset through the separate admin-confirmed workflow', async () => {
+        mockAuth.resetUserPassword.mockResolvedValue({ success: true });
+        component.resetTarget = { id: 2, username: 'doctor' };
+        component.resetAdminPassword = 'admin-secret';
+        component.resetTemporaryPassword = 'temporary-secret';
+        component.resetConfirmPassword = 'temporary-secret';
+        await component.resetUserPassword();
+        expect(mockAuth.resetUserPassword).toHaveBeenCalledWith(2, 'admin-secret', 'temporary-secret');
+        expect(component.resetAdminPassword).toBe('');
+        expect(component.resetTemporaryPassword).toBe('');
+    });
+
+    it('does not put a password field into an existing user edit model', () => {
+        component.editUser({ id: 1, username: 'admin', role: 'admin', name: 'Administrator' });
+        expect(Object.prototype.hasOwnProperty.call(component.editingUser, 'password')).toBe(false);
+    });
+
+    it('acknowledges the exact displayed recovery code only when Done is selected', async () => {
+        mockAuth.acknowledgeRecoveryCode.mockResolvedValue(undefined);
+        component.showRecoveryModal = true;
+        component.newRecoveryCode = 'AAAA-BBBB-CCCC-DDDD';
+        await component.closeRecoveryModal();
+        expect(mockAuth.acknowledgeRecoveryCode).toHaveBeenCalledWith('AAAA-BBBB-CCCC-DDDD');
+        expect(component.newRecoveryCode).toBeNull();
+        expect(component.showRecoveryModal).toBe(false);
+    });
+
+    it('keeps an unacknowledged recovery code visible when confirmation fails', async () => {
+        mockAuth.acknowledgeRecoveryCode.mockRejectedValue(new Error('interrupted'));
+        component.showRecoveryModal = true;
+        component.newRecoveryCode = 'AAAA-BBBB-CCCC-DDDD';
+        await component.closeRecoveryModal();
+        expect(component.newRecoveryCode).toBe('AAAA-BBBB-CCCC-DDDD');
+        expect(component.showRecoveryModal).toBe(true);
     });
 });

--- a/desktop/src/renderer/app/settings/settings.component.ts
+++ b/desktop/src/renderer/app/settings/settings.component.ts
@@ -60,7 +60,18 @@ export class SettingsComponent implements OnInit {
 
   // Security / Backup
   showRecoveryModal = false;
+  showLoginPasswordModal = false;
+  showDeviceRotationModal = false;
+  showUserResetModal = false;
   confirmPassword = '';
+  currentLoginPassword = '';
+  newLoginPassword = '';
+  confirmLoginPassword = '';
+  currentDevicePassword = '';
+  resetTarget: any = null;
+  resetAdminPassword = '';
+  resetTemporaryPassword = '';
+  resetConfirmPassword = '';
   newRecoveryCode: string | null = null;
   isCopied = false;
   isLoading = false;
@@ -347,8 +358,8 @@ export class SettingsComponent implements OnInit {
       errors.push('Invalid email format.');
     }
 
-    if (!user.id && (!user.password || user.password.length < 4)) {
-      errors.push('Password must be at least 4 characters.');
+    if (!user.id && (!user.password || user.password.length < 6)) {
+      errors.push('Password must be at least 6 characters.');
     }
 
     return errors;
@@ -378,6 +389,88 @@ export class SettingsComponent implements OnInit {
       } else {
         alert('Error saving user: ' + msg);
       }
+    }
+  }
+
+  openLoginPasswordModal() {
+    this.currentLoginPassword = '';
+    this.newLoginPassword = '';
+    this.confirmLoginPassword = '';
+    this.showLoginPasswordModal = true;
+  }
+
+  async changeLoginPassword() {
+    if (!this.currentLoginPassword || this.newLoginPassword.length < 6 ||
+      this.newLoginPassword !== this.confirmLoginPassword) return;
+    this.isLoading = true;
+    try {
+      const result = await this.authService.changeLoginPassword(
+        this.currentLoginPassword, this.newLoginPassword
+      );
+      if (result.success) {
+        this.showLoginPasswordModal = false;
+        alert('Administrator login password changed. Vault and recovery keys were not changed.');
+      } else alert(result.error || 'Failed to change login password');
+    } catch (error: any) {
+      alert(error?.message || 'Failed to change login password');
+    } finally {
+      this.currentLoginPassword = '';
+      this.newLoginPassword = '';
+      this.confirmLoginPassword = '';
+      this.isLoading = false;
+    }
+  }
+
+  openUserResetModal(user: any) {
+    this.resetTarget = user;
+    this.resetAdminPassword = '';
+    this.resetTemporaryPassword = '';
+    this.resetConfirmPassword = '';
+    this.showUserResetModal = true;
+  }
+
+  async resetUserPassword() {
+    if (!this.resetTarget || !this.resetAdminPassword || this.resetTemporaryPassword.length < 6 ||
+      this.resetTemporaryPassword !== this.resetConfirmPassword) return;
+    this.isLoading = true;
+    try {
+      const result = await this.authService.resetUserPassword(
+        this.resetTarget.id, this.resetAdminPassword, this.resetTemporaryPassword
+      );
+      if (result.success) {
+        this.showUserResetModal = false;
+        this.editingUser = null;
+        alert('Temporary login password set. The user must change it after signing in.');
+      } else alert(result.error || 'Failed to reset login password');
+    } catch (error: any) {
+      alert(error?.message || 'Failed to reset login password');
+    } finally {
+      this.resetAdminPassword = '';
+      this.resetTemporaryPassword = '';
+      this.resetConfirmPassword = '';
+      this.isLoading = false;
+    }
+  }
+
+  openDeviceRotationModal() {
+    this.currentDevicePassword = '';
+    this.showDeviceRotationModal = true;
+  }
+
+  async rotateDeviceEnvelope() {
+    if (!this.currentDevicePassword) return;
+    this.isLoading = true;
+    try {
+      const result = await this.authService.rotateDeviceEnvelope(this.currentDevicePassword);
+      if (result.success) {
+        this.showDeviceRotationModal = false;
+        alert('This device key envelope was rotated. Login passwords and recovery code were not changed.');
+      } else alert(result.error || 'Failed to rotate this device key envelope');
+    } catch (error: any) {
+      alert(error?.message || 'Failed to rotate this device key envelope');
+    } finally {
+      this.currentDevicePassword = '';
+      this.isLoading = false;
     }
   }
 
@@ -423,8 +516,21 @@ export class SettingsComponent implements OnInit {
     this.newRecoveryCode = null;
     this.showRecoveryModal = true;
   }
-  closeRecoveryModal() {
-    this.showRecoveryModal = false;
+  async closeRecoveryModal() {
+    if (!this.newRecoveryCode) {
+      this.showRecoveryModal = false;
+      return;
+    }
+    this.isLoading = true;
+    try {
+      await this.authService.acknowledgeRecoveryCode(this.newRecoveryCode);
+      this.newRecoveryCode = null;
+      this.showRecoveryModal = false;
+    } catch (error: any) {
+      alert(error?.message || 'Could not confirm the recovery code. It will be shown again after the next administrator login.');
+    } finally {
+      this.isLoading = false;
+    }
   }
   async generateRecoveryCode() {
     if (!this.confirmPassword) return;
@@ -432,11 +538,15 @@ export class SettingsComponent implements OnInit {
     try {
       const res = await this.authService.regenerateRecoveryCode(this.confirmPassword) as any;
       this.ngZone.run(() => {
-        this.isLoading = false;
         if (res.success && res.recoveryCode) this.newRecoveryCode = res.recoveryCode;
         else alert(res.error || 'Failed');
       });
-    } catch { this.isLoading = false; }
+    } catch (error: any) {
+      alert(error?.message || 'Failed to rotate recovery code');
+    } finally {
+      this.confirmPassword = '';
+      this.isLoading = false;
+    }
   }
   async copyRecoveryCode() {
     if (this.newRecoveryCode) {

--- a/desktop/src/renderer/types.d.ts
+++ b/desktop/src/renderer/types.d.ts
@@ -11,6 +11,9 @@ declare global {
             recover: (data: { recoveryCode: string }) => Promise<{ success: boolean; pendingRecoveryCode?: string; error?: string }>;
             acknowledgeRecoveryCode: (recoveryCode: string) => Promise<{ success: boolean }>;
             regenerateRecoveryCode: (password: string) => Promise<{ success: boolean; recoveryCode?: string; error?: string }>;
+            rotateDeviceEnvelope: (currentPassword: string) => Promise<{ success: boolean; error?: string }>;
+            changeLoginPassword: (data: { currentPassword: string; newPassword: string }) => Promise<{ success: boolean; error?: string }>;
+            resetUserPassword: (data: { targetUserId: number; currentAdminPassword: string; temporaryPassword: string }) => Promise<{ success: boolean; error?: string }>;
             db: {
                 getPatients: (query: string) => Promise<any[]>;
                 savePatient: (patient: any) => Promise<any>;
@@ -36,7 +39,6 @@ declare global {
                 getUsers: () => Promise<any[]>;
                 saveUser: (user: any) => Promise<any>;
                 deleteUser: (id: number) => Promise<any>;
-                updateUserPassword: (data: any) => Promise<any>;
                 // Queue
                 getQueue: () => Promise<any[]>;
                 addToQueue: (data: { patientId: number, priority: number }) => Promise<any>;


### PR DESCRIPTION
## Summary

- remove password mutation from generic existing-user edits
- add verified self-service password changes and administrator resets
- journal credential rotation inside SQLCipher with deterministic interruption recovery
- keep login-password, device-envelope, and recovery-secret rotations separate
- make recovery-code rotation two-phase until exact acknowledgement
- reauthorize sensitive rotations against the persisted active administrator
- append the credential journal as schema migration v8 after encounter integrity v7

Closes #6.
Supersedes #27, which GitHub closed when its stacked base branch was merged and deleted.

## Validation

- Full main suite: 161 passed, 27 intentional Electron skips
- Full renderer suite: 193 passed
- Real Electron and SQLCipher suite: 27 passed
- Focused vault suite: 46 passed
- Focused renderer suite: 22 passed
- Renderer and main TypeScript checks passed
- Angular production build passed
- Diff checks passed

## Migration notes

The branch is rebased directly onto master at c6c71f4. Encounter integrity remains migration v7 and credential rotation is migration v8. The v7 to v8 encrypted-database upgrade preserves clinic data and existing Argon2 credentials.

## Approval

Do not merge without explicit owner approval.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR separates login-password rotation from device-envelope and recovery-secret rotation, adds an SQLCipher-backed credential journal with deterministic interruption recovery, and reauthorizes sensitive administrator operations against persisted account state.
- Adds self-service password changes and administrator-initiated temporary password resets.
- Rejects password mutation through generic existing-user edits.
- Adds migration v8 for the credential-rotation journal.
- Makes recovery-code replacement pending until exact acknowledgement.
- Adds focused unit, renderer, and real SQLCipher integration coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains in the previously reported credential-rotation paths.

The administrator reset path now rechecks persisted role and activation state after password hashing, while credential updates atomically require the target account to remain active with its original password hash; no blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| desktop/src/main/services/CredentialRotationService.ts | Implements verified password rotation, persisted administrator reauthorization, atomic target-state checks, journaling, rollback, and audit logging; the previously reported races are addressed. |
| desktop/src/main/services/CredentialRotationService.integration.spec.ts | Exercises real SQLCipher migration, interruption recovery, credential separation, administrator revocation, target deactivation, and plaintext-exposure boundaries. |
| desktop/src/main/services/DatabaseService.ts | Removes implicit existing-user password changes and preserves existing administrator credentials during provisioning retries. |
| desktop/src/main/services/SecurityService.ts | Introduces separate device-envelope and two-phase recovery-secret rotation behavior. |
| desktop/src/main/services/AdminCredentialVerifier.ts | Revalidates administrator identity, role, activation state, and password against persisted database state. |
| desktop/src/main/schema/migrations.ts | Appends schema migration v8 for the single-entry credential-rotation journal. |
| desktop/src/main/main.ts | Wires rotation and recovery operations into authenticated IPC paths and reconciles interrupted rotations after database unlock. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Request credential rotation] --> B[Load active user]
    B --> C[Verify current credential]
    C --> D[Hash replacement password]
    D --> E{Administrator reset?}
    E -- Yes --> F[Recheck persisted active admin]
    E -- No --> G[Prepare journal]
    F --> G
    G --> H[Atomically update active target and mark applied]
    H --> I[Delete journal and append audit log]
    J[Unlock after interruption] --> K{Journal exists?}
    K -- No --> L[Continue normally]
    K -- Yes --> M[Restore previous credential when applied]
    M --> N[Delete journal]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: reject rotation for deactivated use..."](https://github.com/sankara-sabapathy/nalamdesk/commit/77a80c9625b3e41f324240305faa64940ff63116) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56168485)</sub>

<!-- /greptile_comment -->