### PR TITLE
fix(ci): Feature CI artifacts on master and Drive restore build

### DIFF
--- a/.github/workflows/feature-ci.yml
+++ b/.github/workflows/feature-ci.yml
@@ -1,8 +1,13 @@
 name: Feature Branch CI
 
-# Only run on pull requests to avoid duplicate runs
-# When a PR is open, both push and pull_request would trigger otherwise
+# PRs targeting master still run Feature CI. Also run on push to master so
+# squash-merges produce Electron artifacts. Restricting push to master avoids
+# duplicate runs on feature-branch commits (those already fire via pull_request).
+# Automated Release stays workflow_dispatch-only and is not used here.
 on:
+  push:
+    branches:
+      - master
   pull_request:
     branches:
       - master

--- a/desktop/src/main/services/GoogleDriveService.ts
+++ b/desktop/src/main/services/GoogleDriveService.ts
@@ -143,7 +143,7 @@ export class GoogleDriveService {
         }
     }
 
-    async downloadFile(fileId: string, destPath: string) {
+    async downloadFile(fileId: string, destPath: string): Promise<void> {
         if (!this.tokens) throw new Error('Not authenticated');
 
         const dest = fs.createWriteStream(destPath);
@@ -155,7 +155,7 @@ export class GoogleDriveService {
         return new Promise((resolve, reject) => {
             res.data
                 .on('end', () => {
-                    resolve(true);
+                    resolve();
                 })
                 .on('error', (err: unknown) => {
                     reject(err);

--- a/desktop/src/main/services/GoogleDriveService.ts
+++ b/desktop/src/main/services/GoogleDriveService.ts
@@ -16,8 +16,6 @@ export class GoogleDriveService {
     private clientId: string = '';
     private clientSecret: string = '';
 
-    constructor() { }
-
     configureCredentials(clientId: string, clientSecret: string) {
         this.clientId = clientId;
         this.clientSecret = clientSecret;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Feature Branch CI run [#91](https://github.com/sankara-sabapathy/nalamdesk/actions/runs/33623156384) was **not** cancelled by the PR 29 merge. Ubuntu `build-check` failed first (`tsc -p tsconfig.main.json`); macOS/Windows then cancelled via matrix fail-fast. The squash merge landed at 11:16:53Z, about five minutes after the run finished.

The TypeScript error is in the merged master code (SHA `549a90d`, from PR 29 head `891385d`):

```
src/main/main.ts(872,48): error TS2322: Type 'Promise<unknown>' is not assignable to type 'Promise<void>'.
```

`runDriveRestore` expects `downloadFile` to return `Promise<void>`, but `GoogleDriveService.downloadFile` used an untyped `Promise` that resolved `true`.

Master also never produced Electron artifacts after the merge: `.github/workflows/feature-ci.yml` triggered only on `pull_request`. Automated Release remains `workflow_dispatch` only and is not enabled here.

## Changes

- Type `GoogleDriveService.downloadFile` as `Promise<void>` and `resolve()` so Feature CI can compile the Drive restore path.
- Remove the unused empty `GoogleDriveService` constructor (Sonar `typescript:S6647`) so new-code maintainability stays A after touching that file.
- Trigger Feature CI on `push` to `master` as well as PRs targeting master. Push is limited to `master` so feature-branch commits do not double-run. Same `upload-artifact` pattern (`nalamdesk-ubuntu-latest` / `macos` / `windows`, exe/AppImage/deb/dmg).

## Test plan

- [x] Feature CI started on this PR.
- [x] Latest Feature CI ([run 33625902597](https://github.com/sankara-sabapathy/nalamdesk/actions/runs/33625902597)) succeeded on ubuntu/mac/windows and uploaded `nalamdesk-ubuntu-latest`, `nalamdesk-macos-latest`, `nalamdesk-windows-latest`.
- [x] SonarCloud Quality Gate passed (0 new issues).
- [x] Automated Release did **not** start (still `workflow_dispatch` only; last master run is still from 2026-08-22).
- [x] PR left open; not merged.

Do not merge this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bbc1be4a-8acc-484a-ae63-c95b9f6381d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbc1be4a-8acc-484a-ae63-c95b9f6381d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes the Drive download implementation's return type and enables Feature CI artifacts after pushes to master.
- Aligns `GoogleDriveService.downloadFile` with the existing `Promise<void>` restore contract.
- Adds a master push trigger to the existing cross-platform build, analysis, and artifact workflow.

<h3>Confidence Score: 5/5</h3>

The reviewed changes introduce no identified blocking failure, although the PR description explicitly requests that the PR not be merged.

The new workflow event is compatible with every existing job, and the Drive download result remains behaviorally compatible because all callers only await completion.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/feature-ci.yml | Adds a master push trigger without introducing dependencies on pull-request-only event data or conflicting workflow behavior. |
| desktop/src/main/services/GoogleDriveService.ts | Correctly aligns the download method with its existing void-returning asynchronous contract and removes an empty constructor. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(desktop): drop unused GoogleDriveSer..."](https://github.com/sankara-sabapathy/nalamdesk/commit/0be38577320b07f8b32b97d8aded6218a0c94068) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59879873)</sub>

<!-- /greptile_comment -->