### PR TITLE
fix(desktop): HTTP queue IPC unpacking and visit LIVE/read-only gating

### DIFF
--- a/desktop/src/main/ipc-db-args.spec.ts
+++ b/desktop/src/main/ipc-db-args.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+import { invokeDbMethod, resolveDbMethodArgs } from '../shared/ipc-db-args';
+
+/**
+ * Renderer DataService.invoke() always POSTs/IPC-invokes an args array.
+ * Queue writes send a single object (or a bare id) — the same shape on
+ * Electron IPC and HTTP /api/ipc.
+ */
+const rendererQueuePayloads = {
+    addToQueue: [{ patientId: 42, priority: 2 }],
+    updateQueueStatus: [{ id: 9, status: 'waiting' }],
+    updateQueueStatusByPatientId: [{ patientId: 42, status: 'waiting' }],
+    removeFromQueue: [9]
+} as const;
+
+describe('IPC DatabaseService argument unpacking', () => {
+    it('unpacks addToQueue object args and appends the authenticated user id', () => {
+        expect(resolveDbMethodArgs('addToQueue', rendererQueuePayloads.addToQueue, 7))
+            .toEqual([42, 2, 7]);
+    });
+
+    it('unpacks updateQueueStatus object args and appends the authenticated user id', () => {
+        expect(resolveDbMethodArgs('updateQueueStatus', rendererQueuePayloads.updateQueueStatus, 7))
+            .toEqual([9, 'waiting', 7]);
+    });
+
+    it('unpacks updateQueueStatusByPatientId object args and appends the authenticated user id', () => {
+        expect(resolveDbMethodArgs('updateQueueStatusByPatientId', rendererQueuePayloads.updateQueueStatusByPatientId, 7))
+            .toEqual([42, 'waiting', 7]);
+    });
+
+    it('appends the authenticated user id to removeFromQueue', () => {
+        expect(resolveDbMethodArgs('removeFromQueue', rendererQueuePayloads.removeFromQueue, 7))
+            .toEqual([9, 7]);
+    });
+
+    it('does not bind the renderer object as patient_id / actingUserId', () => {
+        const args = resolveDbMethodArgs('addToQueue', rendererQueuePayloads.addToQueue, 7);
+        expect(args[0]).toBe(42);
+        expect(args[0]).not.toEqual({ patientId: 42, priority: 2 });
+        expect(args[2]).toBe(7);
+    });
+
+    it('appends user id for encounter commands without unpacking the payload object', () => {
+        const input = { patientId: 42, queueEntryId: 9, startRequestId: 'req-1' };
+        expect(resolveDbMethodArgs('beginConsultation', [input], 7)).toEqual([input, 7]);
+        expect(resolveDbMethodArgs('getActiveConsultation', [42], 7)).toEqual([42, 7]);
+    });
+
+    it('leaves read methods unchanged', () => {
+        expect(resolveDbMethodArgs('getQueue', [], 7)).toEqual([]);
+        expect(resolveDbMethodArgs('getPatients', [''], 7)).toEqual(['']);
+    });
+
+    it('invokes DatabaseService with Electron/HTTP-identical unpacked args', () => {
+        const db = {
+            addToQueue: vi.fn(),
+            updateQueueStatus: vi.fn(),
+            updateQueueStatusByPatientId: vi.fn(),
+            removeFromQueue: vi.fn()
+        };
+
+        invokeDbMethod(db, 'addToQueue', rendererQueuePayloads.addToQueue, 7);
+        invokeDbMethod(db, 'updateQueueStatus', rendererQueuePayloads.updateQueueStatus, 7);
+        invokeDbMethod(db, 'updateQueueStatusByPatientId', rendererQueuePayloads.updateQueueStatusByPatientId, 7);
+        invokeDbMethod(db, 'removeFromQueue', rendererQueuePayloads.removeFromQueue, 7);
+
+        expect(db.addToQueue).toHaveBeenCalledWith(42, 2, 7);
+        expect(db.updateQueueStatus).toHaveBeenCalledWith(9, 'waiting', 7);
+        expect(db.updateQueueStatusByPatientId).toHaveBeenCalledWith(42, 'waiting', 7);
+        expect(db.removeFromQueue).toHaveBeenCalledWith(9, 7);
+    });
+});

--- a/desktop/src/main/ipc-db-args.spec.ts
+++ b/desktop/src/main/ipc-db-args.spec.ts
@@ -52,6 +52,16 @@ describe('IPC DatabaseService argument unpacking', () => {
         expect(resolveDbMethodArgs('getPatients', [''], 7)).toEqual(['']);
     });
 
+    it('does not bind a non-object payload as patient_id', () => {
+        expect(resolveDbMethodArgs('addToQueue', [null], 7)).toEqual([undefined, undefined, 7]);
+        expect(resolveDbMethodArgs('addToQueue', ['1'], 7)).toEqual([undefined, undefined, 7]);
+    });
+
+    it('throws when the database method is missing', () => {
+        expect(() => invokeDbMethod({}, 'addToQueue', [{ patientId: 1, priority: 1 }], 7))
+            .toThrow('Method not implemented: addToQueue');
+    });
+
     it('invokes DatabaseService with Electron/HTTP-identical unpacked args', () => {
         const db = {
             addToQueue: vi.fn(),

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -21,6 +21,7 @@ import { CredentialRotationService } from './services/CredentialRotationService'
 import { verifyPersistedActiveAdmin } from './services/AdminCredentialVerifier';
 import { acknowledgeRecoveryCodeForActiveAdmin } from './services/RecoveryCodeAcknowledgement';
 import { ApiServer } from '../server/app';
+import { invokeDbMethod } from '../shared/ipc-db-args';
 import {
     DEV_APP_NAME,
     getApiPort,
@@ -720,25 +721,25 @@ handleDb('db:getQueue', () => {
     if (!user) throw new Error('Unauthorized');
     return databaseService.getQueue();
 });
-handleDb('db:addToQueue', (_, { patientId, priority }) => {
+handleDb('db:addToQueue', (_, data) => {
     const user = sessionService.getUser();
     if (!user) throw new Error('Unauthorized');
-    return databaseService.addToQueue(patientId, priority, user.id);
+    return invokeDbMethod(databaseService, 'addToQueue', [data], user.id);
 });
-handleDb('db:updateQueueStatus', (_, { id, status }) => {
+handleDb('db:updateQueueStatus', (_, data) => {
     const user = sessionService.getUser();
     if (!user) throw new Error('Unauthorized');
-    return databaseService.updateQueueStatus(id, status, user.id);
+    return invokeDbMethod(databaseService, 'updateQueueStatus', [data], user.id);
 });
-handleDb('db:updateQueueStatusByPatientId', (_, { patientId, status }) => {
+handleDb('db:updateQueueStatusByPatientId', (_, data) => {
     const user = sessionService.getUser();
     if (!user) throw new Error('Unauthorized');
-    return databaseService.updateQueueStatusByPatientId(patientId, status, user.id);
+    return invokeDbMethod(databaseService, 'updateQueueStatusByPatientId', [data], user.id);
 });
 handleDb('db:removeFromQueue', (_, id) => {
     const user = sessionService.getUser();
     if (!user) throw new Error('Unauthorized');
-    return databaseService.removeFromQueue(id, user.id);
+    return invokeDbMethod(databaseService, 'removeFromQueue', [id], user.id);
 });
 
 // Audit IPC Handlers

--- a/desktop/src/main/preload.spec.ts
+++ b/desktop/src/main/preload.spec.ts
@@ -26,4 +26,13 @@ describe('preload bridge surface', () => {
         await api.backup.selectRestoreBundle();
         expect(electron.invoke).toHaveBeenCalledWith('backup:selectRestoreBundle');
     });
+
+    it('sends queue writes with the renderer object payload Electron IPC unpacks', async () => {
+        await api.db.addToQueue({ patientId: 42, priority: 2 });
+        await api.db.updateQueueStatus({ id: 9, status: 'waiting' });
+        await api.db.removeFromQueue(9);
+        expect(electron.invoke).toHaveBeenCalledWith('db:addToQueue', { patientId: 42, priority: 2 });
+        expect(electron.invoke).toHaveBeenCalledWith('db:updateQueueStatus', { id: 9, status: 'waiting' });
+        expect(electron.invoke).toHaveBeenCalledWith('db:removeFromQueue', 9);
+    });
 });

--- a/desktop/src/renderer/app/patients/patient-details/patient-details.component.spec.ts
+++ b/desktop/src/renderer/app/patients/patient-details/patient-details.component.spec.ts
@@ -88,6 +88,50 @@ describe('PatientDetailsComponent', () => {
         });
     });
 
+    it('adds a missing queue entry then begins consultation', async () => {
+        let queued = false;
+        mockDataService.invoke.mockImplementation((endpoint: string) => {
+            if (endpoint === 'getQueue') {
+                return Promise.resolve(queued ? [{ id: 50, patient_id: 123, status: 'waiting' }] : []);
+            }
+            if (endpoint === 'addToQueue') {
+                queued = true;
+                return Promise.resolve({ lastInsertRowid: 50 });
+            }
+            if (endpoint === 'beginConsultation') return Promise.resolve({ id: 70, patient_id: 123 });
+            return Promise.resolve(null);
+        });
+        component.patientId = 123;
+        await component.startConsult();
+        expect(mockDataService.invoke).toHaveBeenCalledWith('addToQueue', { patientId: 123, priority: 1 });
+        expect(mockDataService.invoke).toHaveBeenCalledWith('beginConsultation', expect.objectContaining({
+            patientId: 123,
+            queueEntryId: 50,
+            startRequestId: expect.any(String)
+        }));
+        expect(mockRouter.navigate).toHaveBeenCalledWith(['/visit', 123], {
+            state: { isConsulting: true, encounterId: 70 }
+        });
+    });
+
+    it('surfaces start consultation failures in the in-app dialog instead of alert', async () => {
+        mockDataService.invoke.mockImplementation((endpoint: string) => {
+            if (endpoint === 'getQueue') return Promise.resolve([]);
+            if (endpoint === 'addToQueue') return Promise.reject(new Error('Internal server error'));
+            return Promise.resolve(null);
+        });
+        const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => undefined);
+        vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        component.patientId = 123;
+        await component.startConsult();
+        expect(alertSpy).not.toHaveBeenCalled();
+        expect(mockDialogService.open).toHaveBeenCalledWith(expect.objectContaining({
+            type: 'error',
+            title: 'Error'
+        }));
+        expect(mockRouter.navigate).not.toHaveBeenCalled();
+    });
+
     it('should open and close modal', () => {
         const visit = { id: 1, date: '2025-01-01' };
         component.viewVisit(visit);

--- a/desktop/src/renderer/app/patients/patient-details/patient-details.component.ts
+++ b/desktop/src/renderer/app/patients/patient-details/patient-details.component.ts
@@ -583,7 +583,13 @@ export class PatientDetailsComponent implements OnInit {
             });
         } catch (e) {
             console.error('Failed to start consultation', e);
-            alert('Failed to start consultation');
+            await this.dialogService.open({
+                title: 'Error',
+                message: e instanceof Error && e.message
+                    ? `Failed to start consultation: ${e.message}`
+                    : 'Failed to start consultation',
+                type: 'error'
+            });
         } finally {
             this.startingConsult = false;
         }

--- a/desktop/src/renderer/app/queue/queue.component.spec.ts
+++ b/desktop/src/renderer/app/queue/queue.component.spec.ts
@@ -126,4 +126,20 @@ describe('QueueComponent', () => {
         }));
         expect(mockRouter.navigate).not.toHaveBeenCalled();
     });
+
+    it('surfaces remove-from-queue failures in the in-app dialog instead of alert', async () => {
+        vi.spyOn(window, 'confirm').mockReturnValue(true);
+        mockDataService.invoke.mockRejectedValue(new Error('Cannot remove a queue entry with an active encounter'));
+        const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => undefined);
+        vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        await component.remove(1);
+
+        expect(alertSpy).not.toHaveBeenCalled();
+        expect(mockDialogService.open).toHaveBeenCalledWith(expect.objectContaining({
+            type: 'error',
+            title: 'Error',
+            message: expect.stringContaining('Failed to remove from queue')
+        }));
+    });
 });

--- a/desktop/src/renderer/app/queue/queue.component.spec.ts
+++ b/desktop/src/renderer/app/queue/queue.component.spec.ts
@@ -22,6 +22,7 @@ describe('QueueComponent', () => {
     let component: QueueComponent;
     let mockDataService: any;
     let mockRouter: any;
+    let mockDialogService: any;
 
     beforeEach(() => {
         mockDataService = {
@@ -42,7 +43,11 @@ describe('QueueComponent', () => {
             navigate: vi.fn()
         };
 
-        component = new QueueComponent(mockRouter, mockDataService);
+        mockDialogService = {
+            open: vi.fn().mockResolvedValue(true)
+        };
+
+        component = new QueueComponent(mockRouter, mockDataService, mockDialogService);
     });
 
     it('should resume the exact linked encounter for a postponed queue item', async () => {
@@ -98,7 +103,6 @@ describe('QueueComponent', () => {
             return Promise.resolve(null);
         });
         vi.spyOn(console, 'error').mockImplementation(() => undefined);
-        vi.spyOn(window, 'alert').mockImplementation(() => undefined);
 
         await component.startConsult(item);
         await component.startConsult(item);
@@ -106,5 +110,20 @@ describe('QueueComponent', () => {
         expect(requestIds).toHaveLength(2);
         expect(requestIds[1]).toBe(requestIds[0]);
         expect(mockRouter.navigate).toHaveBeenCalledWith(['/visit', 11], expect.objectContaining({ state: expect.objectContaining({ encounterId: 101 }) }));
+    });
+
+    it('surfaces start-consultation failures in the in-app dialog instead of alert', async () => {
+        mockDataService.invoke.mockRejectedValue(new Error('Queue entry was not created'));
+        const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => undefined);
+        vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        await component.startConsult({ id: 1, patient_id: 11 });
+
+        expect(alertSpy).not.toHaveBeenCalled();
+        expect(mockDialogService.open).toHaveBeenCalledWith(expect.objectContaining({
+            type: 'error',
+            title: 'Error'
+        }));
+        expect(mockRouter.navigate).not.toHaveBeenCalled();
     });
 });

--- a/desktop/src/renderer/app/queue/queue.component.ts
+++ b/desktop/src/renderer/app/queue/queue.component.ts
@@ -1,10 +1,11 @@
 
-import { Component, OnInit, OnDestroy, signal, inject } from '@angular/core';
+import { Component, OnInit, OnDestroy, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { DataService } from '../services/api.service';
 import { VitalsFormComponent } from '../visits/vitals/vitals-form.component';
 import { newRequestId } from '../services/request-id';
+import { DialogService } from '../shared/services/dialog.service';
 
 @Component({
   // ... (omitted for brevity, keeping same template)
@@ -151,7 +152,8 @@ export class QueueComponent implements OnInit, OnDestroy {
 
   constructor(
     private router: Router,
-    private dataService: DataService
+    private dataService: DataService,
+    private dialogService: DialogService
   ) { }
 
   ngOnInit() {
@@ -198,7 +200,13 @@ export class QueueComponent implements OnInit, OnDestroy {
       });
     } catch (e) {
       console.error('Could not start consultation', e);
-      alert('Failed to start consultation');
+      await this.dialogService.open({
+        title: 'Error',
+        message: e instanceof Error && e.message
+          ? `Failed to start consultation: ${e.message}`
+          : 'Failed to start consultation',
+        type: 'error'
+      });
     }
   }
 
@@ -209,7 +217,13 @@ export class QueueComponent implements OnInit, OnDestroy {
         this.refreshQueue();
       } catch (e) {
         console.error('Remove failed', e);
-        alert('Failed to remove from queue');
+        await this.dialogService.open({
+          title: 'Error',
+          message: e instanceof Error && e.message
+            ? `Failed to remove from queue: ${e.message}`
+            : 'Failed to remove from queue',
+          type: 'error'
+        });
       }
     }
   }

--- a/desktop/src/renderer/app/services/api.service.spec.ts
+++ b/desktop/src/renderer/app/services/api.service.spec.ts
@@ -61,6 +61,20 @@ describe('DataService', () => {
             }));
         });
 
+        it('posts addToQueue with the same object payload Electron IPC receives', async () => {
+            const mockFetch = vi.fn().mockResolvedValue({
+                ok: true,
+                headers: { get: () => 'application/json' },
+                json: async () => ({ lastInsertRowid: 1 })
+            });
+            global.fetch = mockFetch;
+
+            await service.invoke('addToQueue', { patientId: 42, priority: 2 });
+            expect(mockFetch).toHaveBeenCalledWith('/api/ipc/addToQueue', expect.objectContaining({
+                body: JSON.stringify([{ patientId: 42, priority: 2 }])
+            }));
+        });
+
         it('should throw if not authenticated', async () => {
             mockAuthService.getToken.mockReturnValue(null);
             await expect(service.invoke('any')).rejects.toThrow('Not authenticated');

--- a/desktop/src/renderer/app/visits/prescription/prescription.component.spec.ts
+++ b/desktop/src/renderer/app/visits/prescription/prescription.component.spec.ts
@@ -65,7 +65,7 @@ describe('PrescriptionComponent', () => {
         component.add();
         component.remove(0);
         component.emitChange();
-        expect(component.items().length).toBe(1);
+        expect(component.items()).toHaveLength(1);
         expect(component.changed.emit).not.toHaveBeenCalled();
     });
 });

--- a/desktop/src/renderer/app/visits/prescription/prescription.component.spec.ts
+++ b/desktop/src/renderer/app/visits/prescription/prescription.component.spec.ts
@@ -58,4 +58,14 @@ describe('PrescriptionComponent', () => {
         component.initialData = data;
         expect(component.items()).toEqual(data);
     });
+
+    it('disables add, remove, and change emission in read-only mode', () => {
+        vi.spyOn(component.changed, 'emit');
+        component.disabled = true;
+        component.add();
+        component.remove(0);
+        component.emitChange();
+        expect(component.items().length).toBe(1);
+        expect(component.changed.emit).not.toHaveBeenCalled();
+    });
 });

--- a/desktop/src/renderer/app/visits/prescription/prescription.component.ts
+++ b/desktop/src/renderer/app/visits/prescription/prescription.component.ts
@@ -7,7 +7,7 @@ import { FormsModule } from '@angular/forms';
   standalone: true,
   imports: [CommonModule, FormsModule],
   template: `
-    <div class="card bg-base-100 border border-base-200">
+    <div class="card bg-base-100 border border-base-200" [class.opacity-70]="disabled">
       <div class="card-body p-3 md:p-4">
         <h3 class="card-title text-sm mb-2">Prescription</h3>
         
@@ -18,7 +18,7 @@ import { FormsModule } from '@angular/forms';
              *ngFor="let item of items(); let i = index">
           
           <!-- Mobile Delete (Absolute Top Right) -->
-          <button class="md:hidden absolute top-1 right-1 btn btn-xs btn-ghost text-error" (click)="remove(i)">
+          <button class="md:hidden absolute top-1 right-1 btn btn-xs btn-ghost text-error" (click)="remove(i)" [disabled]="disabled">
               ✕
           </button>
 
@@ -27,13 +27,14 @@ import { FormsModule } from '@angular/forms';
             <span class="text-xs text-gray-500 md:hidden font-bold">Medicine</span>
             <input type="text" placeholder="Medicine Name" 
                    [(ngModel)]="item.medicine" (ngModelChange)="emitChange()"
+                   [disabled]="disabled"
                    class="input input-bordered input-sm w-full font-medium" />
           </div>
 
           <!-- 2. Form (1/3 Mobile) -->
           <div class="col-span-4 md:col-span-1">
              <span class="text-xs text-gray-500 md:hidden">Form</span>
-             <select [(ngModel)]="item.form" (ngModelChange)="emitChange()" class="select select-bordered select-sm w-full px-1">
+             <select [(ngModel)]="item.form" (ngModelChange)="emitChange()" [disabled]="disabled" class="select select-bordered select-sm w-full px-1">
                <option value="Tab">Tab</option>
                <option value="Cap">Cap</option>
                <option value="Syr">Syr</option>
@@ -48,13 +49,14 @@ import { FormsModule } from '@angular/forms';
             <span class="text-xs text-gray-500 md:hidden">Dose</span>
             <input type="text" placeholder="500mg" 
                    [(ngModel)]="item.dosage" (ngModelChange)="emitChange()"
+                   [disabled]="disabled"
                    class="input input-bordered input-sm w-full px-1" />
           </div>
 
           <!-- 4. Route (1/3 Mobile) -->
           <div class="col-span-4 md:col-span-1">
              <span class="text-xs text-gray-500 md:hidden">Route</span>
-             <select [(ngModel)]="item.route" (ngModelChange)="emitChange()" class="select select-bordered select-sm w-full px-1">
+             <select [(ngModel)]="item.route" (ngModelChange)="emitChange()" [disabled]="disabled" class="select select-bordered select-sm w-full px-1">
                <option value="Oral">Oral</option>
                <option value="IV">IV</option>
                <option value="IM">IM</option>
@@ -66,7 +68,7 @@ import { FormsModule } from '@angular/forms';
           <!-- 5. Frequency (1/2 Mobile) -->
           <div class="col-span-6 md:col-span-2">
             <span class="text-xs text-gray-500 md:hidden">Frequency</span>
-            <select [(ngModel)]="item.frequency" (ngModelChange)="emitChange()" class="select select-bordered select-sm w-full">
+            <select [(ngModel)]="item.frequency" (ngModelChange)="emitChange()" [disabled]="disabled" class="select select-bordered select-sm w-full">
               <option value="1-0-1">1-0-1 (BID)</option>
               <option value="1-1-1">1-1-1 (TID)</option>
               <option value="1-0-0">1-0-0 (OD)</option>
@@ -82,6 +84,7 @@ import { FormsModule } from '@angular/forms';
             <span class="text-xs text-gray-500 md:hidden">Duration</span>
             <input type="text" placeholder="3 days" 
                    [(ngModel)]="item.duration" (ngModelChange)="emitChange()"
+                   [disabled]="disabled"
                    class="input input-bordered input-sm w-full" />
           </div>
 
@@ -89,7 +92,7 @@ import { FormsModule } from '@angular/forms';
           <div class="col-span-12 md:col-span-2 flex gap-1 items-end">
             <div class="w-full">
                 <span class="text-xs text-gray-500 md:hidden">Instruction</span>
-                <select [(ngModel)]="item.instruction" (ngModelChange)="emitChange()" class="select select-bordered select-sm w-full px-1">
+                <select [(ngModel)]="item.instruction" (ngModelChange)="emitChange()" [disabled]="disabled" class="select select-bordered select-sm w-full px-1">
                     <option value="After Food">After Food</option>
                     <option value="Before Food">Before Food</option>
                     <option value="With Food">With Food</option>
@@ -97,14 +100,14 @@ import { FormsModule } from '@angular/forms';
                 </select>
             </div>
             
-            <button class="hidden md:flex btn btn-sm btn-square btn-ghost text-error" (click)="remove(i)">
+            <button class="hidden md:flex btn btn-sm btn-square btn-ghost text-error" (click)="remove(i)" [disabled]="disabled">
               ✕
             </button>
           </div>
         </div>
         
         <div class="flex justify-between mt-2">
-           <button class="btn btn-sm btn-ghost gap-2 text-blue-600 hover:bg-blue-50" (click)="add()">
+           <button class="btn btn-sm btn-ghost gap-2 text-blue-600 hover:bg-blue-50" (click)="add()" [disabled]="disabled">
             + Add Medicine
           </button>
         </div>
@@ -116,6 +119,7 @@ export class PrescriptionComponent {
   @Input() set initialData(value: any[]) {
     if (value && value.length > 0) this.items.set(value);
   }
+  @Input() disabled = false;
   @Output() changed = new EventEmitter<any[]>();
 
   items = signal<any[]>([
@@ -123,16 +127,19 @@ export class PrescriptionComponent {
   ]);
 
   add() {
+    if (this.disabled) return;
     this.items.update(list => [...list, { medicine: '', form: 'Tab', dosage: '', route: 'Oral', frequency: '1-0-1', duration: '3 days', instruction: 'After Food' }]);
     this.emitChange();
   }
 
   remove(index: number) {
+    if (this.disabled) return;
     this.items.update(list => list.filter((_, i) => i !== index));
     this.emitChange();
   }
 
   emitChange() {
+    if (this.disabled) return;
     this.changed.emit(this.items());
   }
 }

--- a/desktop/src/renderer/app/visits/visit/visit.component.spec.ts
+++ b/desktop/src/renderer/app/visits/visit/visit.component.spec.ts
@@ -472,4 +472,28 @@ describe('VisitComponent', () => {
         expect(component.canEditChart).toBe(false);
         expect(component.visitForm.enable).not.toHaveBeenCalled();
     });
+
+    it('unlocks SOAP and Rx together when editing a past visit, then relocks on reset', () => {
+        component.editVisit({ id: 42, diagnosis: 'Prior', prescription: [{ medicine: 'Para' }] });
+        expect(component.editingVisitId).toBe(42);
+        expect(component.canEditChart).toBe(true);
+        expect(component.isLiveConsultation).toBe(false);
+
+        component.resetForm();
+        expect(component.editingVisitId).toBeNull();
+        expect(component.canEditChart).toBe(false);
+    });
+
+    it('ignores prescription edits and copy-last-visit while the chart is read-only', () => {
+        component.history = [{ diagnosis: 'Flu', diagnosis_type: 'Final', prescription: [] }] as any;
+        component.updatePrescription([{ medicine: 'x' }]);
+        component.copyLastVisit();
+        expect(component.visitForm.patchValue).not.toHaveBeenCalledWith({ prescription: [{ medicine: 'x' }] });
+
+        component.chartWritable = true;
+        component.isConsulting = true;
+        component.encounterId = 7;
+        component.copyLastVisit();
+        expect(component.visitForm.patchValue).toHaveBeenCalledWith(expect.objectContaining({ diagnosis: 'Flu' }));
+    });
 });

--- a/desktop/src/renderer/app/visits/visit/visit.component.spec.ts
+++ b/desktop/src/renderer/app/visits/visit/visit.component.spec.ts
@@ -420,4 +420,56 @@ describe('VisitComponent', () => {
         expect(calls).toHaveLength(1);
         expect(calls[0][1]).toEqual({ encounterId: 7, visit: undefined });
     });
+
+    it('does not present LIVE writable chart when opened without beginConsultation', async () => {
+        component.patientId = 1;
+        await component.loadData();
+
+        expect(component.isConsulting).toBe(false);
+        expect(component.encounterId).toBeNull();
+        expect(component.isLiveConsultation).toBe(false);
+        expect(component.canEditChart).toBe(false);
+        expect(component.visitForm.enable).not.toHaveBeenCalled();
+        expect(mockDataService.invoke.mock.calls.some((call: any[]) => call[0] === 'beginConsultation')).toBe(false);
+    });
+
+    it('shows a writable LIVE consultation after a started encounter is resumed', async () => {
+        component.patientId = 1;
+        const activeEncounter = { id: 7, patient_id: 1, status: 'in-progress', prescription: [] };
+        mockDataService.invoke.mockImplementation((method: string) => {
+            if (method === 'getActiveConsultation') return Promise.resolve(activeEncounter);
+            if (method === 'resumeConsultation') return Promise.resolve(activeEncounter);
+            if (method === 'getPatients') return Promise.resolve([{ id: 1, name: 'John' }]);
+            if (method === 'getVitals') return Promise.resolve({});
+            return Promise.resolve([]);
+        });
+
+        await component.loadData();
+
+        expect(component.isConsulting).toBe(true);
+        expect(component.encounterId).toBe(7);
+        expect(component.isLiveConsultation).toBe(true);
+        expect(component.canEditChart).toBe(true);
+        expect(component.visitForm.enable).toHaveBeenCalled();
+    });
+
+    it('keeps SOAP and Rx read-only together when another practitioner owns the encounter', async () => {
+        component.patientId = 1;
+        component.isConsulting = true;
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        mockDataService.invoke.mockImplementation((method: string) => {
+            if (method === 'getVisits') return Promise.resolve([]);
+            if (method === 'getPatients') return Promise.resolve([{ id: 1, name: 'John' }]);
+            if (method === 'getVitals') return Promise.resolve({});
+            if (method === 'getActiveConsultation') return Promise.reject(new Error('Only the responsible practitioner can access this encounter'));
+            return Promise.resolve(null);
+        });
+
+        await component.loadData();
+
+        expect(component.activeEncounterReadOnly).toBe(true);
+        expect(component.isLiveConsultation).toBe(false);
+        expect(component.canEditChart).toBe(false);
+        expect(component.visitForm.enable).not.toHaveBeenCalled();
+    });
 });

--- a/desktop/src/renderer/app/visits/visit/visit.component.ts
+++ b/desktop/src/renderer/app/visits/visit/visit.component.ts
@@ -83,7 +83,7 @@ interface Visit {
               </div>
 
               <!-- COPY ACTION -->
-              <button *ngIf="!activeEncounterReadOnly" (click)="copyLastVisit()" class="w-full py-1.5 bg-white border border-blue-300 text-blue-700 text-xs font-bold rounded hover:bg-blue-100 hover:text-blue-900 transition flex items-center justify-center gap-2 shadow-sm">
+              <button *ngIf="canEditChart" (click)="copyLastVisit()" class="w-full py-1.5 bg-white border border-blue-300 text-blue-700 text-xs font-bold rounded hover:bg-blue-100 hover:text-blue-900 transition flex items-center justify-center gap-2 shadow-sm">
                 <span>📋</span> Copy to Current
               </button>
            </div>
@@ -124,14 +124,14 @@ interface Visit {
                </button>
 
                <h1 class="text-lg md:text-xl font-bold text-gray-800 truncate">
-                 {{ editingVisitId ? 'Editing Past Visit' : 'Current Consultation' }}
+                 {{ editingVisitId ? 'Editing Past Visit' : (isLiveConsultation ? 'Current Consultation' : 'Visit') }}
                </h1>
            </div>
 
            <div class="flex flex-wrap gap-2 items-center justify-end">
               <button *ngIf="editingVisitId" (click)="deleteVisit()" class="border border-red-200 text-red-600 bg-white hover:bg-red-50 px-3 py-1 rounded text-sm font-medium transition">Delete</button>
               <button *ngIf="editingVisitId" (click)="resetForm()" class="border border-blue-200 text-blue-600 bg-white hover:bg-blue-50 px-3 py-1 rounded text-sm font-medium transition">New Visit</button>
-              <div class="text-right flex items-center gap-2" *ngIf="!editingVisitId">
+              <div class="text-right flex items-center gap-2" *ngIf="isLiveConsultation">
                   <div class="hidden md:block text-xs text-gray-500 uppercase tracking-wider font-bold">Status</div>
                   <div class="bg-green-100 text-green-800 px-2 py-1 rounded-full text-xs font-bold gap-1 flex items-center">
                     <span class="w-2 h-2 bg-green-500 rounded-full animate-pulse"></span> LIVE
@@ -206,7 +206,8 @@ interface Visit {
                     </div>
                     
                     <app-prescription 
-                        [initialData]="currentPrescription" 
+                        [initialData]="currentPrescription"
+                        [disabled]="!canEditChart"
                         (changed)="updatePrescription($event)">
                     </app-prescription>
 
@@ -228,25 +229,25 @@ interface Visit {
                <button type="button" (click)="printPrescription()" class="px-4 py-2 rounded text-gray-600 hover:bg-gray-100 font-medium transition flex-1 md:flex-none justify-center">
                  Print
                </button>
-               <button *ngIf="isConsulting" type="button" (click)="postponeConsult()" class="px-4 py-2 rounded text-blue-600 border border-transparent hover:border-blue-200 hover:bg-blue-50 font-medium transition flex-1 md:flex-none justify-center">
+               <button *ngIf="isLiveConsultation" type="button" (click)="postponeConsult()" class="px-4 py-2 rounded text-blue-600 border border-transparent hover:border-blue-200 hover:bg-blue-50 font-medium transition flex-1 md:flex-none justify-center">
                  ⏸ Postpone
                </button>
             </div>
 
             <div class="flex flex-col md:flex-row gap-3 items-center w-full md:w-auto">
-               <ng-container *ngIf="isConsulting || editingVisitId; else noConsult">
+               <ng-container *ngIf="canEditChart; else noConsult">
                   <!-- Classic Save -->
                    <button type="submit" (click)="saveVisit()" [disabled]="!visitForm.valid || actionInFlight" class="hidden md:block px-4 py-2 rounded border border-gray-300 text-gray-600 hover:bg-gray-50 hover:text-gray-800 transition disabled:opacity-50 font-medium">
                      Save Progress
                    </button>
                    
                    <!-- Finish & Exit -->
-                   <button *ngIf="isConsulting" type="button" (click)="endConsult()" [disabled]="!visitForm.valid || actionInFlight" class="hidden md:block px-4 py-2 rounded border border-blue-200 text-blue-700 hover:bg-blue-50 transition disabled:opacity-50 font-medium">
+                   <button *ngIf="isLiveConsultation" type="button" (click)="endConsult()" [disabled]="!visitForm.valid || actionInFlight" class="hidden md:block px-4 py-2 rounded border border-blue-200 text-blue-700 hover:bg-blue-50 transition disabled:opacity-50 font-medium">
                      Finish & Exit
                    </button>
 
                    <!-- HERO ACTION: FINISH & NEXT -->
-                   <button *ngIf="isConsulting" type="button" (click)="finishAndNext()" [disabled]="!visitForm.valid || actionInFlight" class="w-full md:w-auto px-6 py-2 rounded bg-blue-600 hover:bg-blue-700 text-white font-bold shadow-sm transition disabled:opacity-50 flex items-center justify-center gap-2">
+                   <button *ngIf="isLiveConsultation" type="button" (click)="finishAndNext()" [disabled]="!visitForm.valid || actionInFlight" class="w-full md:w-auto px-6 py-2 rounded bg-blue-600 hover:bg-blue-700 text-white font-bold shadow-sm transition disabled:opacity-50 flex items-center justify-center gap-2">
                      <span>✓ Finish & Next</span> 
                    </button>
                    
@@ -277,6 +278,7 @@ export class VisitComponent implements OnInit {
   activeEncounterReadOnly = false;
   consultationLoadError: string | null = null;
   actionInFlight = false;
+  chartWritable = false;
   private consultationStartPending = false;
   private startRequestId: string | null = null;
   private nextStartRequestId: string | null = null;
@@ -322,6 +324,23 @@ export class VisitComponent implements OnInit {
     });
   }
 
+  get isLiveConsultation(): boolean {
+    return this.chartWritable && this.isConsulting && this.encounterId != null && !this.activeEncounterReadOnly;
+  }
+
+  get canEditChart(): boolean {
+    return this.chartWritable && !this.activeEncounterReadOnly && (this.isConsulting || this.editingVisitId != null);
+  }
+
+  private setChartWritable(writable: boolean) {
+    this.chartWritable = writable;
+    if (writable) {
+      this.visitForm.enable();
+    } else {
+      this.visitForm.disable();
+    }
+  }
+
   editVisit(visit: any) {
     // Historical editing and active completion are deliberately separate modes.
     if (this.isConsulting || this.encounterId || this.activeEncounterReadOnly) return;
@@ -341,7 +360,7 @@ export class VisitComponent implements OnInit {
       this.currentPrescription = [];
       this.visitForm.patchValue({ prescription: [] });
     }
-    this.visitForm.enable();
+    this.setChartWritable(true);
 
     // On mobile, close drawer after selection
     this.showMobileHistory = false;
@@ -351,12 +370,15 @@ export class VisitComponent implements OnInit {
     this.editingVisitId = null;
     this.visitForm.reset({ amount_paid: 0, prescription: [] });
     this.currentPrescription = [];
+    if (!this.isConsulting || this.activeEncounterReadOnly) {
+      this.setChartWritable(false);
+    }
   }
 
   async loadData() {
     this.consultationLoadError = null;
     try {
-      this.visitForm.disable();
+      this.setChartWritable(false);
       let activeEncounterReadDenied = false;
       const activeEncounterRequest = this.dataService.invoke<any>('getActiveConsultation', this.patientId)
         .catch(error => {
@@ -416,7 +438,7 @@ export class VisitComponent implements OnInit {
 
         // Enable only after the exact linked queue entry has been reclaimed.
         if (resumedEncounter) {
-          this.visitForm.enable();
+          this.setChartWritable(true);
 
           // Auto-Fill Vitals into Objective if empty
           if (this.patientVitals && !this.visitForm.get('examination_notes')?.value) {
@@ -441,10 +463,10 @@ export class VisitComponent implements OnInit {
         this.ngZone.run(() => {
           this.encounterId = encounter.id;
           this.patchEncounter(encounter);
-          this.visitForm.enable();
+          this.setChartWritable(true);
         });
       } else if (!resumedEncounter && !this.editingVisitId) {
-        this.visitForm.disable();
+        this.setChartWritable(false);
       }
     } catch (e) {
       console.error(e);
@@ -456,7 +478,7 @@ export class VisitComponent implements OnInit {
         } else {
           this.consultationLoadError = 'Could not load the consultation. Retry when the connection is available.';
         }
-        this.visitForm.disable();
+        this.setChartWritable(false);
       });
     }
   }
@@ -467,6 +489,7 @@ export class VisitComponent implements OnInit {
   }
 
   updatePrescription(items: any[]) {
+    if (!this.canEditChart) return;
     this.visitForm.patchValue({ prescription: items });
   }
 
@@ -613,16 +636,14 @@ export class VisitComponent implements OnInit {
   }
 
   copyLastVisit() {
-    if (this.history.length > 0) {
-      const last = this.history[0];
-      this.visitForm.patchValue({
-        diagnosis: last.diagnosis,
-        diagnosis_type: last.diagnosis_type,
-        prescription: last.prescription
-      });
-      this.currentPrescription = last.prescription || [];
-      // Optional: Notify user
-    }
+    if (!this.canEditChart || this.history.length === 0) return;
+    const last = this.history[0];
+    this.visitForm.patchValue({
+      diagnosis: last.diagnosis,
+      diagnosis_type: last.diagnosis_type,
+      prescription: last.prescription
+    });
+    this.currentPrescription = last.prescription || [];
   }
 
   async postponeConsult() {

--- a/desktop/src/server/app.spec.ts
+++ b/desktop/src/server/app.spec.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const JWT_SECRET = vi.hoisted(() => {
+    const secret = process.env['JWT_SECRET'] || 'ipc-queue-http-test-secret';
+    process.env['JWT_SECRET'] = secret;
+    return secret;
+});
+
+import * as jwt from 'jsonwebtoken';
+import * as os from 'node:os';
+import { ApiServer } from './app';
+
+function authHeader(user: { id: number; role: string; username?: string }) {
+    const token = jwt.sign(
+        { id: user.id, role: user.role, username: user.username || 'admin' },
+        JWT_SECRET,
+        { expiresIn: '1h' }
+    );
+    return `Bearer ${token}`;
+}
+
+describe('HTTP /api/ipc queue wrapper', () => {
+    let server: ApiServer;
+    let db: any;
+
+    beforeEach(() => {
+        db = {
+            beginWork: vi.fn(),
+            endWork: vi.fn(),
+            getPermissions: vi.fn().mockReturnValue(['addToQueue', 'updateQueueStatus', 'removeFromQueue']),
+            addToQueue: vi.fn().mockReturnValue({ lastInsertRowid: 11 }),
+            updateQueueStatus: vi.fn().mockReturnValue({ changes: 1 }),
+            updateQueueStatusByPatientId: vi.fn().mockReturnValue({ changes: 1 }),
+            removeFromQueue: vi.fn().mockReturnValue({ changes: 1 }),
+            getQueue: vi.fn().mockReturnValue([])
+        };
+        server = new ApiServer(db, os.tmpdir());
+    });
+
+    afterEach(async () => {
+        await server.close();
+    });
+
+    async function postIpc(method: string, args: unknown[], user = { id: 7, role: 'admin' }) {
+        return server.inject({
+            method: 'POST',
+            url: `/api/ipc/${method}`,
+            headers: {
+                authorization: authHeader(user),
+                'content-type': 'application/json'
+            },
+            payload: args
+        });
+    }
+
+    it('unpacks addToQueue [{ patientId, priority }] like Electron IPC and appends user.id', async () => {
+        const response = await postIpc('addToQueue', [{ patientId: 42, priority: 2 }]);
+
+        expect(response.statusCode).toBe(200);
+        expect(db.addToQueue).toHaveBeenCalledWith(42, 2, 7);
+        expect(db.addToQueue).not.toHaveBeenCalledWith({ patientId: 42, priority: 2 });
+    });
+
+    it('unpacks updateQueueStatus [{ id, status }] like Electron IPC and appends user.id', async () => {
+        const response = await postIpc('updateQueueStatus', [{ id: 9, status: 'waiting' }]);
+
+        expect(response.statusCode).toBe(200);
+        expect(db.updateQueueStatus).toHaveBeenCalledWith(9, 'waiting', 7);
+    });
+
+    it('unpacks updateQueueStatusByPatientId like Electron IPC', async () => {
+        const response = await postIpc('updateQueueStatusByPatientId', [{ patientId: 42, status: 'waiting' }]);
+
+        expect(response.statusCode).toBe(200);
+        expect(db.updateQueueStatusByPatientId).toHaveBeenCalledWith(42, 'waiting', 7);
+    });
+
+    it('appends authenticated user.id to removeFromQueue(id)', async () => {
+        const response = await postIpc('removeFromQueue', [9]);
+
+        expect(response.statusCode).toBe(200);
+        expect(db.removeFromQueue).toHaveBeenCalledWith(9, 7);
+    });
+
+    it('accepts the same renderer payload on Electron IPC and HTTP for a doctor', async () => {
+        const response = await postIpc('addToQueue', [{ patientId: 1, priority: 1 }], {
+            id: 15,
+            role: 'doctor',
+            username: 'doc'
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(db.addToQueue).toHaveBeenCalledWith(1, 1, 15);
+    });
+});

--- a/desktop/src/server/app.spec.ts
+++ b/desktop/src/server/app.spec.ts
@@ -27,12 +27,13 @@ describe('HTTP /api/ipc queue wrapper', () => {
         db = {
             beginWork: vi.fn(),
             endWork: vi.fn(),
-            getPermissions: vi.fn().mockReturnValue(['addToQueue', 'updateQueueStatus', 'removeFromQueue']),
+            getPermissions: vi.fn().mockReturnValue(['addToQueue', 'updateQueueStatus', 'removeFromQueue', 'beginConsultation']),
             addToQueue: vi.fn().mockReturnValue({ lastInsertRowid: 11 }),
             updateQueueStatus: vi.fn().mockReturnValue({ changes: 1 }),
             updateQueueStatusByPatientId: vi.fn().mockReturnValue({ changes: 1 }),
             removeFromQueue: vi.fn().mockReturnValue({ changes: 1 }),
-            getQueue: vi.fn().mockReturnValue([])
+            getQueue: vi.fn().mockReturnValue([]),
+            beginConsultation: vi.fn().mockReturnValue({ id: 70 })
         };
         server = new ApiServer(db, os.tmpdir());
     });
@@ -91,5 +92,17 @@ describe('HTTP /api/ipc queue wrapper', () => {
 
         expect(response.statusCode).toBe(200);
         expect(db.addToQueue).toHaveBeenCalledWith(1, 1, 15);
+    });
+
+    it('reuses setup across HTTP IPC calls and unpacks beginConsultation like Electron', async () => {
+        const first = await postIpc('addToQueue', [{ patientId: 1, priority: 1 }]);
+        const second = await postIpc('beginConsultation', [{ patientId: 1, queueEntryId: 9, startRequestId: 'req-1' }]);
+
+        expect(first.statusCode).toBe(200);
+        expect(second.statusCode).toBe(200);
+        expect(db.beginConsultation).toHaveBeenCalledWith(
+            { patientId: 1, queueEntryId: 9, startRequestId: 'req-1' },
+            7
+        );
     });
 });

--- a/desktop/src/server/app.ts
+++ b/desktop/src/server/app.ts
@@ -8,6 +8,7 @@ import * as crypto from 'crypto';
 import * as dotenv from 'dotenv';
 import * as http from 'node:http';
 import { loadDevelopmentEnv } from '../shared/load-env';
+import { invokeDbMethod } from '../shared/ipc-db-args';
 
 loadDevelopmentEnv();
 dotenv.config();
@@ -50,7 +51,7 @@ export class ApiServer {
         this.dbService = dbService;
         this.staticPath = staticPath;
         this.devUiProxyUrl = devUiProxyUrl;
-        this.fastify = Fastify({ logger: true });
+        this.fastify = Fastify({ logger: !process.env['VITEST'] });
     }
 
     private async setup() {
@@ -211,6 +212,16 @@ export class ApiServer {
         });
     }
 
+    private setupCompleted = false;
+
+    private async ensureSetup() {
+        if (this.setupCompleted) {
+            return;
+        }
+        await this.setup();
+        this.setupCompleted = true;
+    }
+
     async start(port: number = 3000, host: string = '0.0.0.0') {
         if (this._started) {
             console.warn('[API Server] Already started');
@@ -219,13 +230,29 @@ export class ApiServer {
         this._started = true;
 
         try {
-            await this.setup();
+            await this.ensureSetup();
             await this.fastify.listen({ port, host });
             console.log(`API Server running on http://${host}:${port}`);
         } catch (err) {
             this._started = false;
             console.error('[API Server] Failed to start:', err);
             throw err;
+        }
+    }
+
+    /** Register routes without binding a port (HTTP IPC tests). */
+    async inject(opts: Parameters<FastifyInstance['inject']>[0]) {
+        await this.ensureSetup();
+        await this.fastify.ready();
+        return this.fastify.inject(opts);
+    }
+
+    async close() {
+        try {
+            await this.fastify.close();
+        } finally {
+            this._started = false;
+            this.setupCompleted = false;
         }
     }
 
@@ -357,16 +384,10 @@ export class ApiServer {
 
             const dbAny = this.dbService as any;
 
-            // 3. Execution using Allowlist
+            // 3. Execution using Allowlist — same arg unpacking as Electron IPC
             if (typeof dbAny[method] === 'function') {
                 try {
-                    const encounterCommands = new Set([
-                        'beginConsultation', 'getActiveConsultation', 'saveConsultationProgress', 'completeConsultation',
-                        'postponeConsultation', 'resumeConsultation', 'beginNextConsultation'
-                    ]);
-                    const result = encounterCommands.has(method)
-                        ? await dbAny[method](...args, user.id)
-                        : await dbAny[method](...args);
+                    const result = await invokeDbMethod(dbAny, method, args, user.id);
                     return result;
                 } catch (e: any) {
                     console.error(`[IPC Error] method: ${method}`, e);

--- a/desktop/src/server/app.ts
+++ b/desktop/src/server/app.ts
@@ -1,4 +1,4 @@
-import Fastify, { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import Fastify, { FastifyInstance, FastifyRequest, FastifyReply, InjectOptions } from 'fastify';
 import fastifyStatic from '@fastify/static';
 import fastifyCors from '@fastify/cors';
 import * as jwt from 'jsonwebtoken';
@@ -241,7 +241,7 @@ export class ApiServer {
     }
 
     /** Register routes without binding a port (HTTP IPC tests). */
-    async inject(opts: Parameters<FastifyInstance['inject']>[0]) {
+    async inject(opts: InjectOptions | string) {
         await this.ensureSetup();
         await this.fastify.ready();
         return this.fastify.inject(opts);

--- a/desktop/src/server/app.ts
+++ b/desktop/src/server/app.ts
@@ -51,7 +51,7 @@ export class ApiServer {
         this.dbService = dbService;
         this.staticPath = staticPath;
         this.devUiProxyUrl = devUiProxyUrl;
-        this.fastify = Fastify({ logger: !process.env['VITEST'] });
+        this.fastify = Fastify({ logger: true });
     }
 
     private async setup() {

--- a/desktop/src/shared/ipc-db-args.ts
+++ b/desktop/src/shared/ipc-db-args.ts
@@ -1,0 +1,62 @@
+/**
+ * Maps renderer IPC payloads onto DatabaseService arguments.
+ * Electron handlers (`main.ts`) and the HTTP `/api/ipc` wrapper must stay in lockstep.
+ *
+ * Renderer `DataService.invoke(method, ...args)` sends `args` as an array. Queue
+ * commands pass a single object (or an id); DatabaseService expects unpacked
+ * scalars plus the authenticated user id.
+ */
+
+function payloadObject(value: unknown): Record<string, unknown> {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+        return value as Record<string, unknown>;
+    }
+    return {};
+}
+
+const ENCOUNTER_METHODS = new Set([
+    'beginConsultation',
+    'getActiveConsultation',
+    'saveConsultationProgress',
+    'completeConsultation',
+    'postponeConsultation',
+    'resumeConsultation',
+    'beginNextConsultation'
+]);
+
+export function resolveDbMethodArgs(method: string, args: unknown[], actingUserId: number): unknown[] {
+    switch (method) {
+        case 'addToQueue': {
+            const payload = payloadObject(args[0]);
+            return [payload['patientId'], payload['priority'], actingUserId];
+        }
+        case 'updateQueueStatus': {
+            const payload = payloadObject(args[0]);
+            return [payload['id'], payload['status'], actingUserId];
+        }
+        case 'updateQueueStatusByPatientId': {
+            const payload = payloadObject(args[0]);
+            return [payload['patientId'], payload['status'], actingUserId];
+        }
+        case 'removeFromQueue':
+            return [args[0], actingUserId];
+        default:
+            if (ENCOUNTER_METHODS.has(method)) {
+                return [...args, actingUserId];
+            }
+            return args;
+    }
+}
+
+export function invokeDbMethod(
+    db: object,
+    method: string,
+    args: unknown[],
+    actingUserId: number
+): unknown {
+    const fn = (db as Record<string, unknown>)[method];
+    if (typeof fn !== 'function') {
+        throw new Error(`Method not implemented: ${method}`);
+    }
+    return (fn as (...fnArgs: unknown[]) => unknown).apply(db, resolveDbMethodArgs(method, args, actingUserId));
+}

--- a/desktop/vitest.config.main.js
+++ b/desktop/vitest.config.main.js
@@ -8,10 +8,12 @@ module.exports = {
             provider: 'v8',
             reporter: ['text', 'json', 'html', 'lcov'],
             reportsDirectory: './coverage/main',
-            include: ['src/main/**/*.ts'],
+            include: ['src/main/**/*.ts', 'src/shared/**/*.ts', 'src/server/**/*.ts'],
             exclude: [
                 'src/main/**/*.spec.ts',
                 'src/main/**/*.test.ts',
+                'src/shared/**/*.spec.ts',
+                'src/server/**/*.spec.ts',
                 '**/node_modules/**',
                 '**/dist/**',
             ],

--- a/desktop/vitest.config.main.js
+++ b/desktop/vitest.config.main.js
@@ -2,7 +2,7 @@ module.exports = {
     test: {
         globals: true,
         environment: 'node',
-        include: ['src/main/**/*.spec.ts'],
+        include: ['src/main/**/*.spec.ts', 'src/shared/**/*.spec.ts', 'src/server/**/*.spec.ts'],
         reporters: ['default', 'json', 'html'],
         coverage: {
             provider: 'v8',

--- a/desktop/vitest.workspace.js
+++ b/desktop/vitest.workspace.js
@@ -11,7 +11,7 @@ module.exports = [
         extends: './vitest.config.js',
         test: {
             name: 'main',
-            include: ['src/main/**/*.spec.ts'],
+            include: ['src/main/**/*.spec.ts', 'src/shared/**/*.spec.ts', 'src/server/**/*.spec.ts'],
             environment: 'node',
         },
     },

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,6 +18,7 @@ sonar.inclusions=\
   desktop/src/main/**/*.ts,\
   desktop/src/renderer/**/*.ts,\
   desktop/src/server/**/*.ts,\
+  desktop/src/shared/**/*.ts,\
   desktop/src/**/*.html,\
   desktop/src/**/*.css
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Walk-in queue and Start Consultation were failing on the HTTP `/api/ipc` path used by the packaged app’s local API, and `#/visit/:id` showed STATUS LIVE with SOAP read-only while prescriptions stayed editable.

- **#31:** HTTP `/api/ipc` now unpacks renderer queue payloads the same way Electron IPC does (`patientId`/`id` + authenticated `user.id`) for `addToQueue`, `updateQueueStatus`, `updateQueueStatusByPatientId`, and `removeFromQueue`. Failed Start Consultation / queue writes use the in-app error dialog instead of `alert()`.
- **#32:** LIVE is shown only for a writable, started consultation. Read-only mode disables SOAP, Plan & Rx, and prescription edits together. Opening `#/visit/:id` without `beginConsultation` no longer presents a LIVE + writable-Rx hybrid.

Follow-up: Feature CI Ubuntu `Build Angular` failed because `Parameters<FastifyInstance['inject']>[0]` resolved to Fastify’s no-arg overload. `inject()` is now typed as `InjectOptions | string`. Unpack contract is unchanged.

## Test plan
- [ ] Login as admin, open a patient, Queue and Start Consultation succeed (no native `alert()`, no 500 on `POST /api/ipc/addToQueue`).
- [ ] Open `#/visit/:id` directly: no LIVE chip, SOAP + Rx + fee read-only, footer Read-only mode, no Complete/Save/End Visit.
- [ ] Start a consultation from the patient/queue path: LIVE shown, SOAP and Rx editable, Finish & Exit / Save Progress available.
- [ ] Unit tests: Electron IPC payload + HTTP wrapper with the same `{ patientId, priority }` shape; started vs not-started visit UI.
- [ ] Feature CI `Build Angular` (`tsc -p tsconfig.main.json`) is green.

Closes #31
Closes #32

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ce6d413-2292-4e33-9f71-4c6455cdaf5b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ce6d413-2292-4e33-9f71-4c6455cdaf5b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR aligns HTTP and Electron queue-command argument handling and makes visit editability follow the successfully resumed or started consultation state.
- Centralizes database argument unpacking for queue and encounter commands.
- Uses in-app dialogs for queue and consultation-start failures.
- Gates LIVE status, SOAP fields, prescriptions, fees, and consultation actions behind a shared writable-chart state.
- Expands main-process tests and analysis coverage to shared and server code.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| desktop/src/shared/ipc-db-args.ts | Introduces shared argument mapping that matches the current queue and encounter DatabaseService signatures. |
| desktop/src/server/app.ts | Routes HTTP IPC execution through the shared mapper and adds an injectable test lifecycle. |
| desktop/src/main/main.ts | Updates Electron queue handlers to use the same authenticated argument mapping as HTTP. |
| desktop/src/renderer/app/visits/visit/visit.component.ts | Couples LIVE status and all chart editing controls to successful consultation acquisition or explicit historical editing. |
| desktop/src/renderer/app/visits/prescription/prescription.component.ts | Adds read-only enforcement to prescription controls and mutation methods. |
| desktop/src/renderer/app/queue/queue.component.ts | Replaces native failure alerts with the application dialog service. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Renderer
    participant Transport as Electron IPC / HTTP API
    participant Mapper as invokeDbMethod
    participant DB as DatabaseService
    UI->>Transport: Queue command with object payload
    Transport->>Mapper: method, args[], authenticated user ID
    Mapper->>Mapper: Unpack queue fields and append user ID
    Mapper->>DB: Invoke scalar database signature
    DB-->>UI: Queue result
    UI->>Transport: Resume or begin consultation
    Transport->>Mapper: Encounter payload and user ID
    Mapper->>DB: Payload plus acting user ID
    DB-->>UI: Authorized encounter
    UI->>UI: Enable chart and show LIVE state
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(desktop): count HTTP IPC tests in So..."](https://github.com/sankara-sabapathy/nalamdesk/commit/83417233cd57d44c84b9b847aa16becb0087d15b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59888907)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added read-only controls for prescriptions and visit charts, preventing unintended edits.
  - Improved visit status and editing behavior across live, past, and other practitioners’ visits.
  - Replaced browser alerts with in-app error dialogs showing useful failure messages.

- **Bug Fixes**
  - Improved queue and consultation error handling to prevent navigation after failures.
  - Standardized queue and consultation requests across desktop and web modes.

- **Tests**
  - Expanded coverage for queue handling, visit editing, prescription read-only behavior, error dialogs, and request forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->