### PR TITLE
fix(desktop): dismissible error dialog, hash /settings, greeting, visits Amount, Settings restore

### DIFF
--- a/desktop/USER_GUIDE.md
+++ b/desktop/USER_GUIDE.md
@@ -62,9 +62,9 @@ Welcome to **NalamDesk**, your secure, offline-first Clinic Management System. T
 *   **Clinic Details:** Update your clinic's name and address (appears on prescriptions).
 
 ### Data Management
-*   **Backup:** Manually export your encrypted database.
-*   **Restore:** Restore from a previous backup file.
-*   **Google Drive:** Link your Google Account to enable **Automated Daily Backups** (runs every day at 10 PM if the app is open).
+*   **Backup:** Automated daily backups are saved locally (Settings → Data & Backup). Retention is 30 days.
+*   **Restore (after first run):** Settings → **Data & Backup** → **Restore from Backup File**. Choose a `.ndbackup`, enter the Recovery Code and the current administrator password. This is the same gated restore as the Welcome screen; the app restarts after a successful restore.
+*   **Google Drive:** Link your Google Account to enable **Automated Daily Backups** (runs every day at 10 PM if the app is open). Drive restore remains a separate cloud snapshot path.
 *   **Crash Reporting:** If the application closes unexpectedly, you will see a popup asking to "Save Crash Report". Please save this file and email it to support for analysis. Your data remains private; the report only contains error details, not patient records.
 
 ---

--- a/desktop/USER_GUIDE.md
+++ b/desktop/USER_GUIDE.md
@@ -64,7 +64,7 @@ Welcome to **NalamDesk**, your secure, offline-first Clinic Management System. T
 ### Data Management
 *   **Backup:** Automated daily backups are saved locally (Settings → Data & Backup). Retention is 30 days.
 *   **Restore (after first run):** Settings → **Data & Backup** → **Restore from Backup File**. Choose a `.ndbackup`, enter the Recovery Code and the current administrator password. This is the same gated restore as the Welcome screen; the app restarts after a successful restore.
-*   **Google Drive:** Link your Google Account to enable **Automated Daily Backups** (runs every day at 10 PM if the app is open). Drive restore remains a separate cloud snapshot path.
+*   **Google Drive:** Link your Google Account to enable **Automated Daily Backups** (runs every day at 10 PM if the app is open).
 *   **Crash Reporting:** If the application closes unexpectedly, you will see a popup asking to "Save Crash Report". Please save this file and email it to support for analysis. Your data remains private; the report only contains error details, not patient records.
 
 ---

--- a/desktop/src/renderer/app/dashboard/dashboard.component.spec.ts
+++ b/desktop/src/renderer/app/dashboard/dashboard.component.spec.ts
@@ -3,7 +3,7 @@
  */
 import '@angular/compiler';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { DashboardComponent } from './dashboard.component';
+import { DashboardComponent, greetingForLocalHour } from './dashboard.component';
 import { DataService } from '../services/api.service';
 import { AuthService } from '../services/auth.service';
 import { Router } from '@angular/router';
@@ -67,5 +67,21 @@ describe('DashboardComponent', () => {
         await component.loadData();
 
         expect(spy).toHaveBeenCalled();
+    });
+
+    it('greets Morning before noon, Afternoon before 17, Evening otherwise', () => {
+        expect(greetingForLocalHour(0)).toBe('Morning');
+        expect(greetingForLocalHour(11)).toBe('Morning');
+        expect(greetingForLocalHour(12)).toBe('Afternoon');
+        expect(greetingForLocalHour(16)).toBe('Afternoon');
+        expect(greetingForLocalHour(17)).toBe('Evening');
+        expect(greetingForLocalHour(18)).toBe('Evening');
+        expect(greetingForLocalHour(23)).toBe('Evening');
+    });
+
+    it('does not say Good Morning at 18:39 local time', () => {
+        component.currentTime = new Date(2026, 8, 3, 18, 39, 0);
+        expect(component.getTimeOfDay()).toBe('Evening');
+        expect(component.getTimeOfDay()).not.toBe('Morning');
     });
 });

--- a/desktop/src/renderer/app/dashboard/dashboard.component.ts
+++ b/desktop/src/renderer/app/dashboard/dashboard.component.ts
@@ -7,6 +7,13 @@ import { AuthService } from '../services/auth.service';
 import { CloudService } from '../services/cloud.service';
 import { PatientService } from '../services/patient.service';
 
+/** Local wall-clock greeting. Morning < 12, afternoon < 17, else evening. */
+export function greetingForLocalHour(hour: number): string {
+  if (hour < 12) return 'Morning';
+  if (hour < 17) return 'Afternoon';
+  return 'Evening';
+}
+
 @Component({
   // ... (template omitted, same as before) 
   selector: 'app-dashboard',
@@ -223,10 +230,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   getTimeOfDay(): string {
-    const hr = this.currentTime.getHours();
-    if (hr < 12) return 'Morning';
-    if (hr < 18) return 'Afternoon';
-    return 'Evening';
+    return greetingForLocalHour(this.currentTime.getHours());
   }
 
   async loadData() {

--- a/desktop/src/renderer/app/hash-location-rewrite.spec.ts
+++ b/desktop/src/renderer/app/hash-location-rewrite.spec.ts
@@ -17,4 +17,12 @@ describe('renderer hash rewrite', () => {
         expect(replace).toHaveBeenCalledWith('/#/settings');
         expect(localStorage.getItem('nalamdesk_user')).toContain('admin');
     });
+
+    it('preserves search on rewrite', () => {
+        const replace = vi.fn();
+        expect(rewriteNonHashAppPath({
+            pathname: '/settings', hash: '', search: '?tab=active', replace
+        })).toBe(true);
+        expect(replace).toHaveBeenCalledWith('/#/settings?tab=active');
+    });
 });

--- a/desktop/src/renderer/app/hash-location-rewrite.spec.ts
+++ b/desktop/src/renderer/app/hash-location-rewrite.spec.ts
@@ -1,0 +1,20 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { rewriteNonHashAppPath } from './hash-location-rewrite';
+
+describe('renderer hash rewrite', () => {
+    beforeEach(() => {
+        localStorage.setItem('nalamdesk_user', JSON.stringify({ id: 1, username: 'admin', role: 'admin' }));
+    });
+
+    it('rewrites /settings without dropping nalamdesk_user', () => {
+        const replace = vi.fn();
+        expect(rewriteNonHashAppPath({
+            pathname: '/settings', hash: '', search: '', replace
+        })).toBe(true);
+        expect(replace).toHaveBeenCalledWith('/#/settings');
+        expect(localStorage.getItem('nalamdesk_user')).toContain('admin');
+    });
+});

--- a/desktop/src/renderer/app/hash-location-rewrite.ts
+++ b/desktop/src/renderer/app/hash-location-rewrite.ts
@@ -1,0 +1,5 @@
+export {
+    hashUrlForPathname,
+    isHashSpaAppPath,
+    rewriteNonHashAppPath
+} from '../../shared/hash-app-path';

--- a/desktop/src/renderer/app/layout/main-layout/main-layout.component.spec.ts
+++ b/desktop/src/renderer/app/layout/main-layout/main-layout.component.spec.ts
@@ -1,5 +1,7 @@
 import { MainLayoutComponent } from './main-layout.component';
-import { vi, describe, xdescribe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { Subject } from 'rxjs';
+import { NavigationStart, NavigationEnd } from '@angular/router';
 
 describe('MainLayoutComponent', () => {
     let component: MainLayoutComponent;
@@ -17,7 +19,8 @@ describe('MainLayoutComponent', () => {
 
         mockRouter = {
             navigate: vi.fn(),
-            url: '/dashboard'
+            url: '/dashboard',
+            events: { subscribe: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }) }
         };
 
         mockDialogService = {
@@ -66,5 +69,24 @@ describe('MainLayoutComponent', () => {
         component.logout();
         expect(mockAuthService.logout).toHaveBeenCalled();
         expect(mockRouter.navigate).toHaveBeenCalledWith(['/login']);
+    });
+
+    it('clears the shell error when a child route starts', () => {
+        const events = new Subject();
+        mockRouter.events = events;
+        const layout = new MainLayoutComponent(
+            mockRouter,
+            mockDialogService,
+            mockAuthService,
+            mockNgZone,
+            mockRuntimeService
+        );
+        layout.ngOnInit();
+        events.next(new NavigationStart(1, '/visits'));
+        expect(mockDialogService.close).toHaveBeenCalled();
+        mockDialogService.close.mockClear();
+        events.next(new NavigationEnd(1, '/visits', '/visits'));
+        expect(mockDialogService.close).not.toHaveBeenCalled();
+        layout.ngOnDestroy();
     });
 });

--- a/desktop/src/renderer/app/layout/main-layout/main-layout.component.ts
+++ b/desktop/src/renderer/app/layout/main-layout/main-layout.component.ts
@@ -1,6 +1,7 @@
-import { Component, ViewChild, ElementRef, NgZone, OnInit } from '@angular/core';
+import { Component, ViewChild, ElementRef, NgZone, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterOutlet, RouterModule, Router } from '@angular/router';
+import { NavigationStart, RouterOutlet, RouterModule, Router } from '@angular/router';
+import { Subscription } from 'rxjs';
 import { UniversalDialogComponent } from '../../shared/components/universal-dialog/universal-dialog.component';
 import { DialogService } from '../../shared/services/dialog.service';
 import { AuthService } from '../../services/auth.service';
@@ -158,7 +159,7 @@ import { RuntimeService } from '../../services/runtime.service';
       (cancelDialog)="dialogService.close()"
       (isOpenChange)="!$event ? dialogService.close() : null">
       
-      <div actions class="flex gap-2 w-full justify-end">
+      <div actions #actions class="flex gap-2 w-full justify-end">
          <button *ngIf="dialogService.options().type === 'confirm'" 
                  class="px-4 py-2 rounded text-blue-600 border border-blue-200 hover:bg-blue-50 transition" (click)="dialogService.close()">
            {{ dialogService.options().cancelText }}
@@ -186,9 +187,10 @@ import { RuntimeService } from '../../services/runtime.service';
     }
   `]
 })
-export class MainLayoutComponent implements OnInit {
+export class MainLayoutComponent implements OnInit, OnDestroy {
   queueCount = 0; // TODO: Connect to service
   currentUser: any = null;
+  private routerSub?: Subscription;
 
   @ViewChild('drawerCheckbox') drawerCheckbox!: ElementRef<HTMLInputElement>;
 
@@ -206,6 +208,15 @@ export class MainLayoutComponent implements OnInit {
     if (!!(globalThis as any).electron) {
       this.runtime.init();
     }
+    this.routerSub = this.router.events.subscribe(event => {
+      if (event instanceof NavigationStart) {
+        this.dialogService.close();
+      }
+    });
+  }
+
+  ngOnDestroy() {
+    this.routerSub?.unsubscribe();
   }
 
   isCopied = false;

--- a/desktop/src/renderer/app/settings/settings.component.html
+++ b/desktop/src/renderer/app/settings/settings.component.html
@@ -262,8 +262,8 @@
                 </div>
             </div>
 
-            <!-- Local restore: same Welcome picker → restoreSystemBackup IPC -->
-            <div class="bg-white p-4 md:p-6 rounded-lg shadow-sm border border-gray-200 mb-6">
+            <!-- Local restore: same Welcome picker → restoreSystemBackup IPC. Electron only (#40). -->
+            <div *ngIf="isElectron" class="bg-white p-4 md:p-6 rounded-lg shadow-sm border border-gray-200 mb-6">
                 <h3 class="text-lg font-medium text-gray-800 mb-2">Restore from Backup File</h3>
                 <p class="text-sm text-gray-500 mb-4">
                     After first run, restore a local <span class="font-mono">.ndbackup</span> through the same

--- a/desktop/src/renderer/app/settings/settings.component.html
+++ b/desktop/src/renderer/app/settings/settings.component.html
@@ -262,6 +262,44 @@
                 </div>
             </div>
 
+            <!-- Local restore: same Welcome picker → restoreSystemBackup IPC -->
+            <div class="bg-white p-4 md:p-6 rounded-lg shadow-sm border border-gray-200 mb-6">
+                <h3 class="text-lg font-medium text-gray-800 mb-2">Restore from Backup File</h3>
+                <p class="text-sm text-gray-500 mb-4">
+                    After first run, restore a local <span class="font-mono">.ndbackup</span> through the same
+                    gated Welcome flow (picker, recovery code, and current administrator password).
+                </p>
+                <button (click)="selectRestoreBundle()" class="btn btn-outline btn-sm mb-4"
+                    [disabled]="isRestoring">
+                    Choose Backup File…
+                </button>
+                <div *ngIf="restoreBundle" class="space-y-3">
+                    <div class="text-sm font-mono bg-gray-50 border border-gray-200 rounded px-3 py-2 text-gray-800">
+                        {{ restoreBundle.name }}
+                    </div>
+                    <div>
+                        <label for="settings-restore-recovery-code" class="block text-xs font-bold text-gray-500 uppercase mb-1">Recovery Code</label>
+                        <input id="settings-restore-recovery-code" type="password"
+                            [(ngModel)]="restoreRecoveryCode" autocomplete="off"
+                            class="input input-bordered input-sm w-full font-mono"
+                            placeholder="Required to validate the encrypted vault">
+                    </div>
+                    <div>
+                        <label for="settings-restore-admin-password" class="block text-xs font-bold text-gray-500 uppercase mb-1">Current Administrator Password</label>
+                        <input id="settings-restore-admin-password" type="password"
+                            [(ngModel)]="restoreAdminPassword" autocomplete="off"
+                            class="input input-bordered input-sm w-full"
+                            placeholder="Required to authorize restore of a live vault">
+                    </div>
+                    <button (click)="restoreLocalBackup()"
+                        [disabled]="isRestoring || !restoreRecoveryCode || !restoreAdminPassword || !restoreBundle"
+                        class="btn btn-error btn-sm">
+                        {{ isRestoring ? 'Restoring…' : 'Restore Vault' }}
+                    </button>
+                </div>
+                <p *ngIf="restoreError" aria-live="polite" class="text-red-600 text-sm mt-3">{{ restoreError }}</p>
+            </div>
+
             <!-- Google Drive Backup Section -->
             <div class="bg-white rounded-lg shadow-sm border border-gray-200 mb-6 overflow-hidden">
                 <!-- Header -->

--- a/desktop/src/renderer/app/settings/settings.component.spec.ts
+++ b/desktop/src/renderer/app/settings/settings.component.spec.ts
@@ -115,4 +115,62 @@ describe('SettingsComponent Validation', () => {
         expect(component.newRecoveryCode).toBe('AAAA-BBBB-CCCC-DDDD');
         expect(component.showRecoveryModal).toBe(true);
     });
+
+    it('selects a Welcome-style restore bundle through the existing picker IPC', async () => {
+        component.isElectron = true;
+        (window as any).electron = {
+            backup: { selectRestoreBundle: vi.fn(async () => ({
+                path: '/external/clinic.ndbackup', name: 'clinic.ndbackup'
+            })) }
+        };
+        await component.selectRestoreBundle();
+        expect(component.restoreBundle).toMatchObject({ name: 'clinic.ndbackup', path: '/external/clinic.ndbackup' });
+        expect(component.restoreError).toBe('');
+    });
+
+    it('restores through restoreSystemBackup with recovery code and live-vault admin auth', async () => {
+        component.isElectron = true;
+        component.restoreBundle = { path: '/external/clinic.ndbackup', name: 'clinic.ndbackup' };
+        component.restoreRecoveryCode = 'AAAA-BBBB-CCCC-DDDD';
+        component.restoreAdminPassword = 'admin-secret';
+        vi.spyOn(window, 'confirm').mockReturnValue(true);
+        const restoreSystemBackup = vi.fn(async () => ({ success: true, restartRequired: true }));
+        (window as any).electron = { restoreSystemBackup };
+        await component.restoreLocalBackup();
+        expect(restoreSystemBackup).toHaveBeenCalledWith({
+            path: '/external/clinic.ndbackup',
+            recoveryCode: 'AAAA-BBBB-CCCC-DDDD',
+            currentAdminPassword: 'admin-secret'
+        });
+        expect(component.restoreRecoveryCode).toBe('');
+        expect(component.restoreAdminPassword).toBe('');
+    });
+
+    it('does not invent a second restore pipeline for a live vault', async () => {
+        component.isElectron = true;
+        component.restoreBundle = { path: '/external/clinic.ndbackup', name: 'clinic.ndbackup' };
+        component.restoreRecoveryCode = 'CODE';
+        component.restoreAdminPassword = 'secret';
+        vi.spyOn(window, 'confirm').mockReturnValue(true);
+        const restoreSystemBackup = vi.fn(async () => ({ success: false, error: 'INVALID_ADMIN_CREDENTIAL' }));
+        (window as any).electron = {
+            restoreSystemBackup,
+            drive: { restore: vi.fn() }
+        };
+        await component.restoreLocalBackup();
+        expect(restoreSystemBackup).toHaveBeenCalled();
+        expect((window as any).electron.drive.restore).not.toHaveBeenCalled();
+        expect(component.restoreError).toContain('administrator password');
+        expect(component.isRestoring).toBe(false);
+    });
+
+    it('requires a recovery code before calling restore IPC', async () => {
+        component.isElectron = true;
+        component.restoreBundle = { path: '/external/clinic.ndbackup', name: 'clinic.ndbackup' };
+        component.restoreAdminPassword = 'secret';
+        (window as any).electron = { restoreSystemBackup: vi.fn() };
+        await component.restoreLocalBackup();
+        expect((window as any).electron.restoreSystemBackup).not.toHaveBeenCalled();
+        expect(component.restoreError).toContain('Recovery Code');
+    });
 });

--- a/desktop/src/renderer/app/settings/settings.component.spec.ts
+++ b/desktop/src/renderer/app/settings/settings.component.spec.ts
@@ -173,4 +173,16 @@ describe('SettingsComponent Validation', () => {
         expect((window as any).electron.restoreSystemBackup).not.toHaveBeenCalled();
         expect(component.restoreError).toContain('Recovery Code');
     });
+
+    it('does not expose Welcome restore on non-Electron web sessions', async () => {
+        component.isElectron = false;
+        (window as any).electron = {
+            backup: { selectRestoreBundle: vi.fn() },
+            restoreSystemBackup: vi.fn()
+        };
+        await component.selectRestoreBundle();
+        await component.restoreLocalBackup();
+        expect((window as any).electron.backup.selectRestoreBundle).not.toHaveBeenCalled();
+        expect((window as any).electron.restoreSystemBackup).not.toHaveBeenCalled();
+    });
 });

--- a/desktop/src/renderer/app/settings/settings.component.ts
+++ b/desktop/src/renderer/app/settings/settings.component.ts
@@ -79,6 +79,11 @@ export class SettingsComponent implements OnInit {
   message = '';
   success = false;
   backups: any[] = [];
+  restoreBundle: { path: string; name: string } | null = null;
+  restoreRecoveryCode = '';
+  restoreAdminPassword = '';
+  restoreError = '';
+  isRestoring = false;
 
 
   // Audit Log Column Definitions
@@ -647,6 +652,65 @@ export class SettingsComponent implements OnInit {
         this.isBackupLoading = false;
         alert('Restore Error: ' + e.message);
       });
+    }
+  }
+
+  async selectRestoreBundle() {
+    if (!this.isElectron) return;
+    try {
+      const selected = await window.electron.backup.selectRestoreBundle();
+      if (!selected) return;
+      const legacy = selected.name.toLowerCase().endsWith('.db');
+      this.ngZone.run(() => {
+        this.restoreBundle = selected;
+        this.restoreError = legacy
+          ? 'This legacy backup can be identified, but cannot recover a live vault.'
+          : '';
+      });
+    } catch (e: any) {
+      this.ngZone.run(() => {
+        this.restoreError = e?.message || 'Unable to select the backup file.';
+      });
+    }
+  }
+
+  async restoreLocalBackup() {
+    if (!this.isElectron || !this.restoreBundle) return;
+    if (this.restoreBundle.name.toLowerCase().endsWith('.db')) {
+      this.restoreError = 'This legacy database-only backup is missing recovery metadata and cannot be restored on a live vault.';
+      return;
+    }
+    if (!this.restoreRecoveryCode) {
+      this.restoreError = 'Enter the Recovery Code for this backup.';
+      return;
+    }
+    if (!this.restoreAdminPassword) {
+      this.restoreError = 'Enter the current administrator password.';
+      return;
+    }
+    if (!confirm('The backup will be validated first. Your current vault will be snapshotted before replacement. Continue?')) return;
+
+    this.isRestoring = true;
+    this.restoreError = '';
+    try {
+      const result = await window.electron.restoreSystemBackup({
+        path: this.restoreBundle.path,
+        recoveryCode: this.restoreRecoveryCode,
+        currentAdminPassword: this.restoreAdminPassword
+      });
+      this.restoreRecoveryCode = '';
+      this.restoreAdminPassword = '';
+      if (!result.success) throw new Error(result.error || 'Restore failed');
+    } catch (e: any) {
+      this.isRestoring = false;
+      const code = e?.message || 'Restore failed';
+      this.restoreError = code === 'LEGACY_DATABASE_ONLY_BACKUP'
+        ? 'This legacy database-only backup is missing recovery metadata and cannot be restored on a live vault.'
+        : code === 'INVALID_RECOVERY_CODE'
+          ? 'The Recovery Code is incorrect for this backup.'
+          : code === 'INVALID_ADMIN_CREDENTIAL'
+            ? 'The administrator password is incorrect.'
+            : `Restore failed: ${code}`;
     }
   }
 

--- a/desktop/src/renderer/app/shared/components/table/table.component.spec.ts
+++ b/desktop/src/renderer/app/shared/components/table/table.component.spec.ts
@@ -66,4 +66,9 @@ describe('SharedTableComponent', () => {
         component.multiSelect = true;
         expect(component.multiSelect).toBe(true);
     });
+
+    it('exposes a visible horizontal overflow cue so trailing columns are not clipped', () => {
+        const gridWrap = fixture.nativeElement.querySelector('.flex-1.w-full');
+        expect(gridWrap.className).toContain('overflow-x-auto');
+    });
 });

--- a/desktop/src/renderer/app/shared/components/table/table.component.ts
+++ b/desktop/src/renderer/app/shared/components/table/table.component.ts
@@ -62,7 +62,7 @@ import { ColDef, GridOptions } from 'ag-grid-community';
           </div>
       </div>
 
-      <div class="flex-1 w-full overflow-hidden relative">
+      <div class="flex-1 w-full overflow-x-auto overflow-y-hidden relative">
         <ag-grid-angular
             class="h-full w-full ag-theme-quartz"
             [rowData]="rowData"

--- a/desktop/src/renderer/app/shared/components/universal-dialog/universal-dialog.component.spec.ts
+++ b/desktop/src/renderer/app/shared/components/universal-dialog/universal-dialog.component.spec.ts
@@ -143,14 +143,11 @@ describe('UniversalDialogComponent', () => {
             expect(component.animateIn).toBe(false);
         });
 
-        it('should emit isOpenChange and cancelDialog after animation delay', () => {
+        it('should emit isOpenChange and cancelDialog immediately so OK and ✕ dismiss', () => {
             const isOpenChangeSpy = vi.spyOn(component.isOpenChange, 'emit');
             const cancelDialogSpy = vi.spyOn(component.cancelDialog, 'emit');
 
             component.close();
-            expect(isOpenChangeSpy).not.toHaveBeenCalled();
-
-            vi.advanceTimersByTime(200);
             expect(isOpenChangeSpy).toHaveBeenCalledWith(false);
             expect(cancelDialogSpy).toHaveBeenCalled();
         });
@@ -178,3 +175,54 @@ describe('UniversalDialogComponent', () => {
         });
     });
 });
+
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+@Component({
+    standalone: true,
+    imports: [UniversalDialogComponent],
+    template: `
+        <app-universal-dialog [isOpen]="true" title="Error" message="Failed to add to queue: Internal server error">
+            <div actions #actions>
+                <button type="button" class="projected-ok">OK</button>
+            </div>
+        </app-universal-dialog>
+    `
+})
+class DialogWithProjectedOkComponent { }
+
+@Component({
+    standalone: true,
+    imports: [UniversalDialogComponent],
+    template: `<app-universal-dialog [isOpen]="true" title="Error" message="Broken"></app-universal-dialog>`
+})
+class DialogWithoutActionsComponent { }
+
+describe('UniversalDialog projected actions', () => {
+    it('does not duplicate OK when actions are projected via a real ContentChild query', async () => {
+        await TestBed.configureTestingModule({
+            imports: [DialogWithProjectedOkComponent]
+        }).compileComponents();
+        const fixture: ComponentFixture<DialogWithProjectedOkComponent> = TestBed.createComponent(DialogWithProjectedOkComponent);
+        fixture.detectChanges();
+        const okButtons = fixture.nativeElement.querySelectorAll('button');
+        const okLabels = [...okButtons].filter((b: HTMLButtonElement) => b.textContent?.trim() === 'OK');
+        expect(okLabels.length).toBe(1);
+        expect(fixture.nativeElement.querySelector('[data-testid="default-ok"]')).toBeNull();
+        expect(fixture.nativeElement.querySelector('.projected-ok')).toBeTruthy();
+    });
+
+    it('shows a single default OK when no actions are projected', async () => {
+        await TestBed.configureTestingModule({
+            imports: [DialogWithoutActionsComponent]
+        }).compileComponents();
+        const fixture = TestBed.createComponent(DialogWithoutActionsComponent);
+        fixture.detectChanges();
+        const okLabels = [...fixture.nativeElement.querySelectorAll('button')]
+            .filter((b: HTMLButtonElement) => b.textContent?.trim() === 'OK');
+        expect(okLabels.length).toBe(1);
+        expect(fixture.nativeElement.querySelector('[data-testid="default-ok"]')).toBeTruthy();
+    });
+});
+

--- a/desktop/src/renderer/app/shared/components/universal-dialog/universal-dialog.component.ts
+++ b/desktop/src/renderer/app/shared/components/universal-dialog/universal-dialog.component.ts
@@ -60,6 +60,7 @@ import { CommonModule } from '@angular/common';
            <!-- Default Close Action if enabled -->
            <button *ngIf="showDefaultActions && !hasActionsContent" type="button" 
                    class="bg-blue-600 text-white px-4 py-2 rounded font-medium hover:bg-blue-700 w-full sm:w-auto shadow-sm"
+                   data-testid="default-ok"
                    (click)="close()">
              OK
            </button>
@@ -85,9 +86,9 @@ export class UniversalDialogComponent implements OnChanges, OnDestroy {
 
   animateIn = false;
 
-  // Check for projected content presence using attribute selectors
-  @ContentChild('[icon]', { read: ElementRef }) iconContent: ElementRef | undefined;
-  @ContentChild('[actions]', { read: ElementRef }) actionsContent: ElementRef | undefined;
+  // Template refs (#icon / #actions). CSS `[actions]` is not a ContentChild query.
+  @ContentChild('icon', { read: ElementRef }) iconContent: ElementRef | undefined;
+  @ContentChild('actions', { read: ElementRef }) actionsContent: ElementRef | undefined;
 
   private animateInTimerId: ReturnType<typeof setTimeout> | null = null;
 
@@ -126,11 +127,8 @@ export class UniversalDialogComponent implements OnChanges, OnDestroy {
 
   close() {
     this.animateIn = false;
-    setTimeout(() => {
-      // Do NOT mutate @Input directly
-      this.isOpenChange.emit(false);
-      this.cancelDialog.emit();
-    }, 200); // Wait for transition
+    this.isOpenChange.emit(false);
+    this.cancelDialog.emit();
   }
 
   onBackdropClick() {

--- a/desktop/src/renderer/app/visits/visit-list/visit-list.component.spec.ts
+++ b/desktop/src/renderer/app/visits/visit-list/visit-list.component.spec.ts
@@ -1,0 +1,23 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { VisitListComponent } from './visit-list.component';
+
+vi.mock('../../services/api.service');
+vi.mock('@angular/core', async () => {
+    const actual = await vi.importActual('@angular/core');
+    return { ...actual as any, inject: vi.fn() };
+});
+
+describe('VisitListComponent layout', () => {
+    it('keeps Amount visible at 1024px clinic-laptop width', () => {
+        const component = new VisitListComponent({ run: (fn: () => void) => fn() } as any, { navigate: vi.fn() } as any);
+        const amount = component.colDefs.find(c => c.field === 'amount_paid');
+        expect(amount?.headerName).toBe('Amount');
+        expect(amount?.minWidth).toBeGreaterThanOrEqual(110);
+        const minSum = component.colDefs.reduce((sum, col) => sum + (col.minWidth || 0), 0);
+        // 1024px minus lg sidebar (288) minus page padding (48) minus checkbox (~50)
+        expect(minSum).toBeLessThanOrEqual(688);
+    });
+});

--- a/desktop/src/renderer/app/visits/visit-list/visit-list.component.spec.ts
+++ b/desktop/src/renderer/app/visits/visit-list/visit-list.component.spec.ts
@@ -17,7 +17,12 @@ describe('VisitListComponent layout', () => {
         expect(amount?.headerName).toBe('Amount');
         expect(amount?.minWidth).toBeGreaterThanOrEqual(110);
         const minSum = component.colDefs.reduce((sum, col) => sum + (col.minWidth || 0), 0);
-        // 1024px minus lg sidebar (288) minus page padding (48) minus checkbox (~50)
-        expect(minSum).toBeLessThanOrEqual(688);
+        // 1024px − lg sidebar (288) − md:p-6 padding (48) = 688. Visit list sets
+        // [multiSelect]="true", which SharedTable maps to string rowSelection
+        // 'multiple'. AG Grid 32 only injects the controls column (library
+        // maxWidth 50) for object rowSelection / selectionColumnDef — neither
+        // is configured — so extra selection width is 0.
+        const selectionColumnWidth = 0;
+        expect(minSum).toBeLessThanOrEqual(1024 - 288 - 48 - selectionColumnWidth);
     });
 });

--- a/desktop/src/renderer/app/visits/visit-list/visit-list.component.ts
+++ b/desktop/src/renderer/app/visits/visit-list/visit-list.component.ts
@@ -10,7 +10,7 @@ import { ColDef } from 'ag-grid-community';
   standalone: true,
   imports: [CommonModule, RouterModule, SharedTableComponent],
   template: `
-    <div class="h-full bg-gray-100 p-4 md:p-6 flex flex-col overflow-hidden">
+    <div class="h-full bg-gray-100 p-4 md:p-6 flex flex-col overflow-x-auto overflow-y-hidden">
       <div class="w-full">
         <div class="flex justify-between items-center mb-6">
             <h1 class="text-3xl font-bold text-gray-800">Recent Visits</h1>
@@ -51,7 +51,7 @@ export class VisitListComponent implements OnInit {
       field: 'date',
       headerName: 'Date',
       flex: 1,
-      minWidth: 160,
+      minWidth: 120,
       valueFormatter: (params) => {
         if (!params.value) return '';
         return new Date(params.value).toLocaleString();
@@ -61,16 +61,16 @@ export class VisitListComponent implements OnInit {
       field: 'patient_name',
       headerName: 'Patient',
       flex: 1.5,
-      minWidth: 180,
+      minWidth: 140,
       cellClass: 'font-medium text-blue-600'
     },
-    { field: 'diagnosis', headerName: 'Diagnosis', flex: 2, minWidth: 250, wrapText: true, autoHeight: true },
-    { field: 'doctor_name', headerName: 'Doctor', flex: 1, minWidth: 150 },
+    { field: 'diagnosis', headerName: 'Diagnosis', flex: 2, minWidth: 150, wrapText: true, autoHeight: true },
+    { field: 'doctor_name', headerName: 'Doctor', flex: 1, minWidth: 110 },
     {
       field: 'amount_paid',
       headerName: 'Amount',
       flex: 0.8,
-      minWidth: 120,
+      minWidth: 110,
       type: 'rightAligned',
       valueFormatter: (params) => params.value ? '₹' + params.value : '₹0'
     }

--- a/desktop/src/renderer/main.ts
+++ b/desktop/src/renderer/main.ts
@@ -3,9 +3,7 @@ import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
 import { rewriteNonHashAppPath } from './app/hash-location-rewrite';
 
-if (rewriteNonHashAppPath(window.location)) {
-  return;
+if (!rewriteNonHashAppPath(window.location)) {
+  bootstrapApplication(AppComponent, appConfig)
+    .catch((err) => console.error(err));
 }
-
-bootstrapApplication(AppComponent, appConfig)
-  .catch((err) => console.error(err));

--- a/desktop/src/renderer/main.ts
+++ b/desktop/src/renderer/main.ts
@@ -1,7 +1,9 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
+import { rewriteNonHashAppPath } from './app/hash-location-rewrite';
 
+rewriteNonHashAppPath(window.location);
 
 bootstrapApplication(AppComponent, appConfig)
   .catch((err) => console.error(err));

--- a/desktop/src/renderer/main.ts
+++ b/desktop/src/renderer/main.ts
@@ -3,7 +3,9 @@ import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
 import { rewriteNonHashAppPath } from './app/hash-location-rewrite';
 
-rewriteNonHashAppPath(window.location);
+if (rewriteNonHashAppPath(window.location)) {
+  return;
+}
 
 bootstrapApplication(AppComponent, appConfig)
   .catch((err) => console.error(err));

--- a/desktop/src/server/app.spec.ts
+++ b/desktop/src/server/app.spec.ts
@@ -136,4 +136,10 @@ describe('hash SPA fallback', () => {
         expect(response.statusCode).toBe(404);
         expect(response.headers.location).toBeUndefined();
     });
+
+    it('preserves query string on rewrite', async () => {
+        const response = await server.inject({ method: 'GET', url: '/patients?editId=5' });
+        expect(response.statusCode).toBe(302);
+        expect(response.headers.location).toBe('/#/patients?editId=5');
+    });
 });

--- a/desktop/src/server/app.spec.ts
+++ b/desktop/src/server/app.spec.ts
@@ -106,3 +106,34 @@ describe('HTTP /api/ipc queue wrapper', () => {
         );
     });
 });
+
+describe('hash SPA fallback', () => {
+    let server: ApiServer;
+
+    beforeEach(() => {
+        server = new ApiServer({} as any, os.tmpdir());
+    });
+
+    afterEach(async () => {
+        await server.close();
+    });
+
+    it('rewrites /settings to /#/settings before the empty-hash login map', async () => {
+        const response = await server.inject({ method: 'GET', url: '/settings' });
+        expect(response.statusCode).toBe(302);
+        expect(response.headers.location).toBe('/#/settings');
+    });
+
+    it('rewrites other app paths the same way', async () => {
+        const queue = await server.inject({ method: 'GET', url: '/queue' });
+        const visits = await server.inject({ method: 'GET', url: '/visits' });
+        expect(queue.headers.location).toBe('/#/queue');
+        expect(visits.headers.location).toBe('/#/visits');
+    });
+
+    it('does not rewrite API routes', async () => {
+        const response = await server.inject({ method: 'GET', url: '/api/missing' });
+        expect(response.statusCode).toBe(404);
+        expect(response.headers.location).toBeUndefined();
+    });
+});

--- a/desktop/src/server/app.ts
+++ b/desktop/src/server/app.ts
@@ -135,8 +135,11 @@ export class ApiServer {
         // SPA Fallback (prod: index.html; dev: proxy to ng serve for LAN access)
         this.fastify.setNotFoundHandler(async (req, reply) => {
             if (req.method === 'GET' && !req.url.startsWith('/api') && !req.url.startsWith('/oauth2callback')) {
-                const pathOnly = (req.url || '/').split('?')[0];
-                const hashed = hashUrlForPathname(pathOnly);
+                const raw = req.url || '/';
+                const queryIndex = raw.indexOf('?');
+                const pathOnly = queryIndex === -1 ? raw : raw.slice(0, queryIndex);
+                const search = queryIndex === -1 ? '' : raw.slice(queryIndex);
+                const hashed = hashUrlForPathname(pathOnly, search);
                 if (hashed) {
                     return reply.redirect(hashed);
                 }

--- a/desktop/src/server/app.ts
+++ b/desktop/src/server/app.ts
@@ -9,6 +9,7 @@ import * as dotenv from 'dotenv';
 import * as http from 'node:http';
 import { loadDevelopmentEnv } from '../shared/load-env';
 import { invokeDbMethod } from '../shared/ipc-db-args';
+import { hashUrlForPathname } from '../shared/hash-app-path';
 
 loadDevelopmentEnv();
 dotenv.config();
@@ -134,6 +135,11 @@ export class ApiServer {
         // SPA Fallback (prod: index.html; dev: proxy to ng serve for LAN access)
         this.fastify.setNotFoundHandler(async (req, reply) => {
             if (req.method === 'GET' && !req.url.startsWith('/api') && !req.url.startsWith('/oauth2callback')) {
+                const pathOnly = (req.url || '/').split('?')[0];
+                const hashed = hashUrlForPathname(pathOnly);
+                if (hashed) {
+                    return reply.redirect(hashed);
+                }
                 if (this.devUiProxyUrl) {
                     return this.proxyToDevUi(req, reply);
                 }

--- a/desktop/src/shared/hash-app-path.spec.ts
+++ b/desktop/src/shared/hash-app-path.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+import { hashUrlForPathname, isHashSpaAppPath, rewriteNonHashAppPath } from './hash-app-path';
+
+describe('hash SPA path rewrite', () => {
+    it('rewrites /settings to /#/settings', () => {
+        expect(hashUrlForPathname('/settings')).toBe('/#/settings');
+    });
+
+    it('rewrites nested app paths and preserves the query string', () => {
+        expect(hashUrlForPathname('/patients/12', '?q=1')).toBe('/#/patients/12?q=1');
+        expect(hashUrlForPathname('/visit/3')).toBe('/#/visit/3');
+        expect(hashUrlForPathname('/online-booking')).toBe('/#/online-booking');
+        expect(hashUrlForPathname('/queue')).toBe('/#/queue');
+        expect(hashUrlForPathname('/dashboard')).toBe('/#/dashboard');
+    });
+
+    it('does not rewrite empty, hashed, asset, or API paths', () => {
+        expect(hashUrlForPathname('/')).toBeNull();
+        expect(hashUrlForPathname('/index.html')).toBeNull();
+        expect(hashUrlForPathname('/assets/logo.png')).toBeNull();
+        expect(hashUrlForPathname('/api/auth/login')).toBeNull();
+        expect(isHashSpaAppPath('/settings')).toBe(true);
+        expect(isHashSpaAppPath('/oauth2callback')).toBe(false);
+    });
+
+    it('rewrites a location before Angular maps an empty hash to login', () => {
+        const replace = vi.fn();
+        expect(rewriteNonHashAppPath({
+            pathname: '/settings', hash: '', search: '', replace
+        })).toBe(true);
+        expect(replace).toHaveBeenCalledWith('/#/settings');
+    });
+
+    it('leaves an existing hash session untouched', () => {
+        const replace = vi.fn();
+        expect(rewriteNonHashAppPath({
+            pathname: '/', hash: '#/settings', search: '', replace
+        })).toBe(false);
+        expect(replace).not.toHaveBeenCalled();
+    });
+});

--- a/desktop/src/shared/hash-app-path.spec.ts
+++ b/desktop/src/shared/hash-app-path.spec.ts
@@ -23,6 +23,14 @@ describe('hash SPA path rewrite', () => {
         expect(isHashSpaAppPath('/oauth2callback')).toBe(false);
     });
 
+    it('does not hang on a long unmatched GET', () => {
+        const junk = `/${'a'.repeat(20_000)}${'/x'.repeat(2_000)}`;
+        const started = Date.now();
+        expect(hashUrlForPathname(junk)).toBeNull();
+        expect(isHashSpaAppPath(junk)).toBe(false);
+        expect(Date.now() - started).toBeLessThan(50);
+    });
+
     it('rewrites a location before Angular maps an empty hash to login', () => {
         const replace = vi.fn();
         expect(rewriteNonHashAppPath({

--- a/desktop/src/shared/hash-app-path.ts
+++ b/desktop/src/shared/hash-app-path.ts
@@ -1,0 +1,33 @@
+/** Hash-SPA paths that must rewrite before Angular maps an empty hash to login. */
+const APP_PATH = /^\/(login|setup|recover|change-password|dashboard|patients|visits|visit|online-booking|settings|queue)(\/[^/]+)*$/;
+
+export function normalizeAppPathname(pathname: string): string {
+    if (!pathname) return '/';
+    const decoded = pathname.split('?')[0] || '/';
+    if (decoded.length > 1 && decoded.endsWith('/')) return decoded.slice(0, -1);
+    return decoded;
+}
+
+export function isHashSpaAppPath(pathname: string): boolean {
+    return APP_PATH.test(normalizeAppPathname(pathname));
+}
+
+/** `/settings` → `/#/settings`. Leaves hashed URLs, `/`, assets, and APIs alone. */
+export function hashUrlForPathname(pathname: string, search = ''): string | null {
+    const path = normalizeAppPathname(pathname);
+    if (!isHashSpaAppPath(path)) return null;
+    return `/#${path}${search || ''}`;
+}
+
+export function rewriteNonHashAppPath(loc: {
+    pathname: string;
+    hash: string;
+    search: string;
+    replace: (url: string) => void;
+}): boolean {
+    if (loc.hash && loc.hash.length > 1) return false;
+    const target = hashUrlForPathname(loc.pathname, loc.search);
+    if (!target) return false;
+    loc.replace(target);
+    return true;
+}

--- a/desktop/src/shared/hash-app-path.ts
+++ b/desktop/src/shared/hash-app-path.ts
@@ -1,5 +1,11 @@
-/** Hash-SPA paths that must rewrite before Angular maps an empty hash to login. */
-const APP_PATH = /^\/(login|setup|recover|change-password|dashboard|patients|visits|visit|online-booking|settings|queue)(\/[^/]+)*$/;
+/** Hash-SPA roots that must rewrite before Angular maps an empty hash to login. */
+const APP_ROOTS = new Set([
+    'login', 'setup', 'recover', 'change-password', 'dashboard',
+    'patients', 'visits', 'visit', 'online-booking', 'settings', 'queue'
+]);
+
+/** Clinic app paths are short (`/patients/:id`). Reject pathological GETs linearly. */
+const MAX_APP_PATH_LENGTH = 256;
 
 export function normalizeAppPathname(pathname: string): string {
     if (!pathname) return '/';
@@ -8,8 +14,23 @@ export function normalizeAppPathname(pathname: string): string {
     return decoded;
 }
 
+/** Linear scan: `/settings`, `/patients/12`, `/visit/3`. No nested regex quantifiers. */
 export function isHashSpaAppPath(pathname: string): boolean {
-    return APP_PATH.test(normalizeAppPathname(pathname));
+    const path = normalizeAppPathname(pathname);
+    if (path.length < 2 || path.length > MAX_APP_PATH_LENGTH || path.charCodeAt(0) !== 47) return false;
+    const rest = path.slice(1);
+    const slash = rest.indexOf('/');
+    const root = slash === -1 ? rest : rest.slice(0, slash);
+    if (!APP_ROOTS.has(root)) return false;
+    if (slash === -1) return true;
+    for (let i = slash; i < rest.length; ) {
+        if (rest.charCodeAt(i) !== 47) return false;
+        i += 1;
+        const start = i;
+        while (i < rest.length && rest.charCodeAt(i) !== 47) i += 1;
+        if (i === start) return false;
+    }
+    return true;
 }
 
 /** `/settings` → `/#/settings`. Leaves hashed URLs, `/`, assets, and APIs alone. */

--- a/desktop/tsconfig.app.json
+++ b/desktop/tsconfig.app.json
@@ -9,6 +9,7 @@
     "src/renderer/main.ts"
   ],
   "include": [
-    "src/renderer/**/*.d.ts"
+    "src/renderer/**/*.d.ts",
+    "src/shared/hash-app-path.ts"
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #33 #39 #34 #38 #37.

Desktop-only follow-up on master after PR 41 (`8f79225`). Architect lock held: hash routing, existing shell dialog, Welcome restore IPC. No new types, toast bus, PathLocationStrategy, timezone service, Drive/cloud restore rewrite, web backup UI (#40), or Linux packaging (#35/#36). Out: invoices, booking.

## #33 Error dialog
`@ContentChild('[actions]')` is not a real query, so the shell projected OK and the default OK both rendered. Projected actions now use `@ContentChild('actions')` with `#actions`. OK and ✕ emit close immediately. Child-route `NavigationStart` clears the shell error so it cannot survive Queue → Visits → Dashboard. No toast bus.

## #39 `/settings` without hash
Keep `withHashLocation()`. Non-hash app paths (`/settings`, `/queue`, `/visits`, …) rewrite to `/#/settings` (same pattern) in Fastify before SPA fallback and in the renderer before bootstrap, so empty-hash does not map to login. Query strings are preserved (`/patients?editId=5` → `/#/patients?editId=5`). Path matching is a linear scan with a length cap (no nested regex quantifiers). If the renderer rewrite runs `Location.replace`, bootstrap does not continue on the non-hash URL. `nalamdesk_user` is untouched. Not PathLocationStrategy.

## #34 Greeting
Local `getHours()`: morning `< 12`, afternoon `< 17`, else evening. 18:39 local is Evening, not Morning. No timezone service.

## #38 Visits Amount
Column min-widths fit a 1024px clinic laptop with the sidebar open. Shared table wrapper uses `overflow-x-auto` as a visible overflow cue. Layout only. Width assertion subtracts the real selection-column config (none with string `rowSelection`).

## #37 Settings restore
Settings → Data & Backup calls the same Welcome restore: picker → authorized path → `restoreSystemBackup` → `restoreOperationGate.run` → `fence()` → `closeDb()` with `.ndbackup` + recovery code + live-vault admin password. Electron IPC only (`isElectron` gate). No `handleDb`/`runWork` parallel pipeline. No web backup UI.

Tests cover the AC. Feature CI must compile. Leave unmerged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c73216b7-9382-44d6-b0dd-630a46c32a16?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c73216b7-9382-44d6-b0dd-630a46c32a16&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Electron-only local backup restoration using a backup file, Recovery Code, and administrator password.
  - Added automatic handling for application routes, preserving query parameters when navigating directly to pages.
  - Tables now support horizontal scrolling on smaller screens.

- **Bug Fixes**
  - Corrected dashboard greetings after 5:00 PM.
  - Shell error dialogs now close when navigation begins.
  - Dialog actions respond immediately and prevent duplicate default buttons.
  - Improved visit-list layout so the Amount column remains visible.

- **Documentation**
  - Updated backup documentation with daily backups, 30-day retention, and restore requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR completes the desktop fixes for hash-route rewriting, dialog dismissal, local-time greetings, visit-table layout, and authenticated local backup restoration.
- Preserves query parameters when non-hash application paths redirect to hash routes.
- Replaces the vulnerable route regex with a length-capped linear path matcher.
- Adds Electron-only restore controls backed by the existing restore IPC.
- Updates dialog behavior, visit-table overflow, documentation, and focused tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| desktop/src/server/app.ts | The SPA fallback now separates and preserves the complete query suffix when redirecting recognized application paths. |
| desktop/src/shared/hash-app-path.ts | Centralizes same-origin hash URL construction and replaces regex matching with a bounded linear segment scan. |
| desktop/src/renderer/main.ts | Rewrites recognized non-hash routes before Angular bootstrap so the hash router receives the intended path. |
| desktop/src/renderer/app/settings/settings.component.ts | Adds an Electron-gated local restore flow using the existing picker and authenticated restore IPC. |
| desktop/src/renderer/app/shared/components/universal-dialog/universal-dialog.component.ts | Uses real template-reference content queries and emits dialog closure immediately. |
| desktop/src/renderer/app/visits/visit-list/visit-list.component.ts | Reduces visit-column minimum widths and enables horizontal overflow to keep trailing data accessible. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(desktop): bootstrap only when hash r..."](https://github.com/sankara-sabapathy/nalamdesk/commit/a1c7eb526fcef4666d980e342a04ac39ef666811) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59922775)</sub>

<!-- /greptile_comment -->