### PR TITLE
fix(desktop): completed visit view + PDF download

### DIFF
--- a/desktop/src/renderer/app/visits/visit-list/visit-list.component.spec.ts
+++ b/desktop/src/renderer/app/visits/visit-list/visit-list.component.spec.ts
@@ -25,4 +25,14 @@ describe('VisitListComponent layout', () => {
         const selectionColumnWidth = 0;
         expect(minSum).toBeLessThanOrEqual(1024 - 288 - 48 - selectionColumnWidth);
     });
+
+    it('opens a finished visit in view mode with visitId', () => {
+        const navigate = vi.fn();
+        const component = new VisitListComponent({ run: (fn: () => void) => fn() } as any, { navigate } as any);
+        component.goToVisit({ id: 42, patient_id: 7, diagnosis: 'Headache' });
+        expect(navigate).toHaveBeenCalledWith(['/visit', 7], {
+            queryParams: { visitId: 42, mode: 'view' },
+            state: { visitId: 42, mode: 'view' }
+        });
+    });
 });

--- a/desktop/src/renderer/app/visits/visit-list/visit-list.component.ts
+++ b/desktop/src/renderer/app/visits/visit-list/visit-list.component.ts
@@ -124,6 +124,9 @@ export class VisitListComponent implements OnInit {
   }
 
   goToVisit(visit: any) {
-    this.router.navigate(['/visit', visit.patient_id]);
+    this.router.navigate(['/visit', visit.patient_id], {
+      queryParams: { visitId: visit.id, mode: 'view' },
+      state: { visitId: visit.id, mode: 'view' }
+    });
   }
 }

--- a/desktop/src/renderer/app/visits/visit/visit.component.spec.ts
+++ b/desktop/src/renderer/app/visits/visit/visit.component.spec.ts
@@ -35,7 +35,7 @@ describe('VisitComponent', () => {
     let mockAuthService: any;
 
     beforeEach(() => {
-        mockRoute = { params: of({ id: 1 }) };
+        mockRoute = { params: of({ id: 1 }), snapshot: { queryParams: {} } };
         mockRouter = {
             navigate: vi.fn(),
             getCurrentNavigation: vi.fn().mockReturnValue({ extras: { state: {} } })
@@ -482,6 +482,114 @@ describe('VisitComponent', () => {
         component.resetForm();
         expect(component.editingVisitId).toBeNull();
         expect(component.canEditChart).toBe(false);
+    });
+
+    it('loads a finished visit in view mode without starting a consult', async () => {
+        component.patientId = 1;
+        component.viewMode = true;
+        component.viewVisitId = 42;
+        const finished = {
+            id: 42,
+            status: 'finished',
+            symptoms: 'Headache for 2 days',
+            examination_notes: 'BP 120/80',
+            diagnosis: 'Tension headache',
+            diagnosis_type: 'Final',
+            prescription: [{ medicine: 'Paracetamol', frequency: 'SOS' }],
+            amount_paid: 300
+        };
+        mockDataService.invoke.mockImplementation((method: string) => {
+            if (method === 'getVisits') return Promise.resolve([finished]);
+            if (method === 'getPatients') return Promise.resolve([{ id: 1, name: 'Clinical Tester Sep2' }]);
+            if (method === 'getVitals') return Promise.resolve({ pulse: 72 });
+            return Promise.resolve(null);
+        });
+
+        await component.loadData();
+
+        expect(component.patient).toEqual({ id: 1, name: 'Clinical Tester Sep2' });
+        expect(component.viewedVisit).toEqual(finished);
+        expect(component.visitForm.patchValue).toHaveBeenCalledWith(expect.objectContaining({
+            symptoms: 'Headache for 2 days',
+            examination_notes: 'BP 120/80',
+            diagnosis: 'Tension headache',
+            diagnosis_type: 'Final',
+            prescription: [{ medicine: 'Paracetamol', frequency: 'SOS' }],
+            amount_paid: 300
+        }));
+        expect(component.currentPrescription).toEqual([{ medicine: 'Paracetamol', frequency: 'SOS' }]);
+        expect(component.isViewMode).toBe(true);
+        expect(component.isLiveConsultation).toBe(false);
+        expect(component.canEditChart).toBe(false);
+        expect(component.isConsulting).toBe(false);
+        expect(component.encounterId).toBeNull();
+        expect(component.editingVisitId).toBeNull();
+        expect(component.visitForm.enable).not.toHaveBeenCalled();
+        expect(mockDataService.invoke.mock.calls.some((call: any[]) => call[0] === 'beginConsultation')).toBe(false);
+        expect(mockDataService.invoke.mock.calls.some((call: any[]) => call[0] === 'getActiveConsultation')).toBe(false);
+        expect(mockDataService.invoke.mock.calls.some((call: any[]) => call[0] === 'resumeConsultation')).toBe(false);
+    });
+
+    it('reads view intent from router state and query params', () => {
+        mockRouter.getCurrentNavigation.mockReturnValue({
+            extras: { state: { visitId: 42, mode: 'view' } }
+        });
+        const fromState = new VisitComponent(mockRoute, mockRouter, mockFb, mockNgZone, mockPdfService, mockDataService, mockAuthService);
+        expect(fromState.viewMode).toBe(true);
+        expect(fromState.viewVisitId).toBe(42);
+
+        mockRoute.snapshot = { queryParams: { visitId: '88', mode: 'view' } };
+        component.ngOnInit();
+        expect(component.viewMode).toBe(true);
+        expect(component.viewVisitId).toBe(88);
+    });
+
+    it('downloads a PDF from the loaded visit snapshot, not the empty form', async () => {
+        component.patient = { id: 1, name: 'Clinical Tester Sep2', age: 40, gender: 'Female' };
+        component.viewedVisit = {
+            id: 42,
+            date: '2026-09-02T10:00:00Z',
+            diagnosis: 'Tension headache',
+            prescription: [{ medicine: 'Paracetamol', frequency: 'SOS' }],
+            amount_paid: 300
+        } as any;
+        component.visitForm = { value: {}, invalid: false } as any;
+        mockDataService.invoke.mockImplementation((method: string) => {
+            if (method === 'getPublicSettings') return Promise.resolve({ doctor_name: 'Dr. Clinic' });
+            return Promise.resolve(null);
+        });
+        mockAuthService.getUser.mockReturnValue({ name: 'Dr. Clinic', specialty: 'General', license_number: 'LIC-1' });
+
+        await component.downloadVisitPdf();
+
+        expect(mockPdfService.generatePrescription).toHaveBeenCalledWith(
+            expect.objectContaining({
+                diagnosis: 'Tension headache',
+                prescription: [{ medicine: 'Paracetamol', frequency: 'SOS' }],
+                amount_paid: 300
+            }),
+            component.patient,
+            expect.objectContaining({ name: 'Dr. Clinic' })
+        );
+        expect(mockPdfService.generatePrescription.mock.calls[0][0]).not.toEqual(expect.objectContaining({
+            diagnosis: undefined
+        }));
+    });
+
+    it('keeps sidebar history clicks read-only in view mode', () => {
+        component.viewMode = true;
+        component.viewVisitId = 42;
+        component.editVisit({
+            id: 9,
+            diagnosis: 'Older flu',
+            prescription: [{ medicine: 'Azithro' }],
+            amount_paid: 200
+        });
+        expect(component.viewVisitId).toBe(9);
+        expect(component.editingVisitId).toBeNull();
+        expect(component.canEditChart).toBe(false);
+        expect(component.visitForm.enable).not.toHaveBeenCalled();
+        expect(component.visitForm.patchValue).toHaveBeenCalledWith(expect.objectContaining({ diagnosis: 'Older flu' }));
     });
 
     it('ignores prescription edits and copy-last-visit while the chart is read-only', () => {

--- a/desktop/src/renderer/app/visits/visit/visit.component.spec.ts
+++ b/desktop/src/renderer/app/visits/visit/visit.component.spec.ts
@@ -547,6 +547,16 @@ describe('VisitComponent', () => {
         fromQuery.ngOnInit();
         expect(fromQuery.viewMode).toBe(true);
         expect(fromQuery.viewVisitId).toBe(88);
+
+        mockRoute = {
+            params: of({ id: 1 }),
+            queryParams: of({ mode: 'view' }),
+            snapshot: { queryParams: { mode: 'view' } }
+        };
+        const viewWithoutId = new VisitComponent(mockRoute, mockRouter, mockFb, mockNgZone, mockPdfService, mockDataService, mockAuthService);
+        viewWithoutId.ngOnInit();
+        expect(viewWithoutId.viewMode).toBe(true);
+        expect(viewWithoutId.viewVisitId).toBeNull();
     });
 
     it('clears view mode when the same visit route is reused without view query params', async () => {
@@ -599,6 +609,39 @@ describe('VisitComponent', () => {
         expect(reused.viewVisitId).toBe(88);
         expect(reused.viewedVisit).toEqual(expect.objectContaining({ diagnosis: 'Flu' }));
         expect(reused.canEditChart).toBe(false);
+    });
+
+    it('prints via PdfService and skips download when no visit snapshot is loaded', async () => {
+        component.patient = { id: 1, name: 'John', age: 30, gender: 'Male' };
+        mockDataService.invoke.mockImplementation((method: string) => {
+            if (method === 'getPublicSettings') return Promise.resolve({ doctor_name: 'Dr. Clinic', license_key: 'LIC-9' });
+            return Promise.resolve(null);
+        });
+        mockAuthService.getUser.mockReturnValue({});
+
+        await component.printPrescription();
+        expect(mockPdfService.generatePrescription).toHaveBeenCalled();
+
+        mockPdfService.generatePrescription.mockClear();
+        component.viewedVisit = null;
+        await component.downloadVisitPdf();
+        expect(mockPdfService.generatePrescription).not.toHaveBeenCalled();
+    });
+
+    it('surfaces an error when the viewed visit id is missing from history', async () => {
+        component.patientId = 1;
+        component.viewMode = true;
+        component.viewVisitId = 99;
+        mockDataService.invoke.mockImplementation((method: string) => {
+            if (method === 'getVisits') return Promise.resolve([{ id: 42, status: 'finished', diagnosis: 'Other' }]);
+            if (method === 'getPatients') return Promise.resolve([{ id: 1, name: 'John' }]);
+            if (method === 'getVitals') return Promise.resolve({});
+            return Promise.resolve(null);
+        });
+        await component.loadData();
+        expect(component.viewedVisit).toBeNull();
+        expect(component.consultationLoadError).toContain('Could not load this visit');
+        expect(component.canEditChart).toBe(false);
     });
 
     it('downloads a PDF from the loaded visit snapshot, not the empty form', async () => {

--- a/desktop/src/renderer/app/visits/visit/visit.component.spec.ts
+++ b/desktop/src/renderer/app/visits/visit/visit.component.spec.ts
@@ -6,7 +6,7 @@ import { describe, xdescribe, it, expect, vi, beforeEach } from 'vitest';
 import { VisitComponent } from './visit.component';
 import { DataService } from '../../services/api.service';
 import { AuthService } from '../../services/auth.service';
-import { of } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 
 // Mock services
 vi.mock('../../services/api.service');
@@ -35,7 +35,7 @@ describe('VisitComponent', () => {
     let mockAuthService: any;
 
     beforeEach(() => {
-        mockRoute = { params: of({ id: 1 }), snapshot: { queryParams: {} } };
+        mockRoute = { params: of({ id: 1 }), queryParams: of({}), snapshot: { queryParams: {} } };
         mockRouter = {
             navigate: vi.fn(),
             getCurrentNavigation: vi.fn().mockReturnValue({ extras: { state: {} } })
@@ -538,10 +538,64 @@ describe('VisitComponent', () => {
         expect(fromState.viewMode).toBe(true);
         expect(fromState.viewVisitId).toBe(42);
 
-        mockRoute.snapshot = { queryParams: { visitId: '88', mode: 'view' } };
-        component.ngOnInit();
-        expect(component.viewMode).toBe(true);
-        expect(component.viewVisitId).toBe(88);
+        mockRoute = {
+            params: of({ id: 1 }),
+            queryParams: of({ visitId: '88', mode: 'view' }),
+            snapshot: { queryParams: { visitId: '88', mode: 'view' } }
+        };
+        const fromQuery = new VisitComponent(mockRoute, mockRouter, mockFb, mockNgZone, mockPdfService, mockDataService, mockAuthService);
+        fromQuery.ngOnInit();
+        expect(fromQuery.viewMode).toBe(true);
+        expect(fromQuery.viewVisitId).toBe(88);
+    });
+
+    it('clears view mode when the same visit route is reused without view query params', async () => {
+        const params$ = new BehaviorSubject({ id: 1 });
+        const query$ = new BehaviorSubject<Record<string, any>>({ visitId: '42', mode: 'view' });
+        mockRoute = { params: params$, queryParams: query$, snapshot: { queryParams: query$.value } };
+        const reused = new VisitComponent(mockRoute, mockRouter, mockFb, mockNgZone, mockPdfService, mockDataService, mockAuthService);
+        reused.ngOnInit();
+        await Promise.resolve();
+        expect(reused.viewMode).toBe(true);
+        expect(reused.viewVisitId).toBe(42);
+
+        query$.next({});
+        await Promise.resolve();
+        expect(reused.viewMode).toBe(false);
+        expect(reused.viewVisitId).toBeNull();
+        expect(reused.viewedVisit).toBeNull();
+        expect(reused.isViewMode).toBe(false);
+        expect(mockDataService.invoke.mock.calls.some((call: any[]) => call[0] === 'beginConsultation')).toBe(false);
+    });
+
+    it('updates the viewed visit when query visitId changes on the reused route', async () => {
+        const params$ = new BehaviorSubject({ id: 1 });
+        const query$ = new BehaviorSubject<Record<string, any>>({ visitId: '42', mode: 'view' });
+        mockRoute = { params: params$, queryParams: query$, snapshot: { queryParams: query$.value } };
+        const visits = [
+            { id: 42, status: 'finished', diagnosis: 'Headache', prescription: [], amount_paid: 100 },
+            { id: 88, status: 'finished', diagnosis: 'Flu', prescription: [{ medicine: 'Azithro' }], amount_paid: 200 }
+        ];
+        mockDataService.invoke.mockImplementation((method: string) => {
+            if (method === 'getVisits') return Promise.resolve(visits);
+            if (method === 'getPatients') return Promise.resolve([{ id: 1, name: 'John' }]);
+            if (method === 'getVitals') return Promise.resolve({});
+            return Promise.resolve(null);
+        });
+        const reused = new VisitComponent(mockRoute, mockRouter, mockFb, mockNgZone, mockPdfService, mockDataService, mockAuthService);
+        reused.ngOnInit();
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(reused.viewVisitId).toBe(42);
+        expect(reused.viewedVisit).toEqual(expect.objectContaining({ diagnosis: 'Headache' }));
+
+        query$.next({ visitId: '88', mode: 'view' });
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(reused.viewMode).toBe(true);
+        expect(reused.viewVisitId).toBe(88);
+        expect(reused.viewedVisit).toEqual(expect.objectContaining({ diagnosis: 'Flu' }));
+        expect(reused.canEditChart).toBe(false);
     });
 
     it('downloads a PDF from the loaded visit snapshot, not the empty form', async () => {

--- a/desktop/src/renderer/app/visits/visit/visit.component.spec.ts
+++ b/desktop/src/renderer/app/visits/visit/visit.component.spec.ts
@@ -558,6 +558,7 @@ describe('VisitComponent', () => {
         await Promise.resolve();
         expect(reused.viewMode).toBe(true);
         expect(reused.viewVisitId).toBe(42);
+        reused.viewedVisit = { id: 42, diagnosis: 'Headache' } as any;
 
         query$.next({});
         await Promise.resolve();
@@ -565,6 +566,8 @@ describe('VisitComponent', () => {
         expect(reused.viewVisitId).toBeNull();
         expect(reused.viewedVisit).toBeNull();
         expect(reused.isViewMode).toBe(false);
+        expect(reused.canEditChart).toBe(false);
+        expect(mockDataService.invoke.mock.calls.some((call: any[]) => call[0] === 'getActiveConsultation')).toBe(true);
         expect(mockDataService.invoke.mock.calls.some((call: any[]) => call[0] === 'beginConsultation')).toBe(false);
     });
 

--- a/desktop/src/renderer/app/visits/visit/visit.component.ts
+++ b/desktop/src/renderer/app/visits/visit/visit.component.ts
@@ -124,13 +124,16 @@ interface Visit {
                </button>
 
                <h1 class="text-lg md:text-xl font-bold text-gray-800 truncate">
-                 {{ editingVisitId ? 'Editing Past Visit' : (isLiveConsultation ? 'Current Consultation' : 'Visit') }}
+                 {{ isViewMode ? 'View Visit' : (editingVisitId ? 'Editing Past Visit' : (isLiveConsultation ? 'Current Consultation' : 'Visit')) }}
                </h1>
            </div>
 
            <div class="flex flex-wrap gap-2 items-center justify-end">
-              <button *ngIf="editingVisitId" (click)="deleteVisit()" class="border border-red-200 text-red-600 bg-white hover:bg-red-50 px-3 py-1 rounded text-sm font-medium transition">Delete</button>
-              <button *ngIf="editingVisitId" (click)="resetForm()" class="border border-blue-200 text-blue-600 bg-white hover:bg-blue-50 px-3 py-1 rounded text-sm font-medium transition">New Visit</button>
+              <button *ngIf="editingVisitId && !isViewMode" (click)="deleteVisit()" class="border border-red-200 text-red-600 bg-white hover:bg-red-50 px-3 py-1 rounded text-sm font-medium transition">Delete</button>
+              <button *ngIf="editingVisitId && !isViewMode" (click)="resetForm()" class="border border-blue-200 text-blue-600 bg-white hover:bg-blue-50 px-3 py-1 rounded text-sm font-medium transition">New Visit</button>
+              <div class="text-right flex items-center gap-2" *ngIf="isViewMode">
+                  <div class="bg-gray-100 text-gray-700 px-2 py-1 rounded-full text-xs font-bold">VIEW</div>
+              </div>
               <div class="text-right flex items-center gap-2" *ngIf="isLiveConsultation">
                   <div class="hidden md:block text-xs text-gray-500 uppercase tracking-wider font-bold">Status</div>
                   <div class="bg-green-100 text-green-800 px-2 py-1 rounded-full text-xs font-bold gap-1 flex items-center">
@@ -226,7 +229,10 @@ interface Visit {
         <!-- STICKY FOOTER ACTION BAR -->
         <div class="min-h-20 bg-white border-t px-4 md:px-8 flex flex-col md:flex-row items-center justify-between z-30 py-3 gap-3">
             <div class="flex gap-3 w-full md:w-auto justify-center md:justify-start">
-               <button type="button" (click)="printPrescription()" class="px-4 py-2 rounded text-gray-600 hover:bg-gray-100 font-medium transition flex-1 md:flex-none justify-center">
+               <button *ngIf="isViewMode" type="button" (click)="downloadVisitPdf()" [disabled]="!viewedVisit" class="px-4 py-2 rounded bg-gray-800 text-white hover:bg-gray-900 font-medium transition flex-1 md:flex-none justify-center disabled:opacity-50">
+                 Download PDF
+               </button>
+               <button *ngIf="!isViewMode" type="button" (click)="printPrescription()" class="px-4 py-2 rounded text-gray-600 hover:bg-gray-100 font-medium transition flex-1 md:flex-none justify-center">
                  Print
                </button>
                <button *ngIf="isLiveConsultation" type="button" (click)="postponeConsult()" class="px-4 py-2 rounded text-blue-600 border border-transparent hover:border-blue-200 hover:bg-blue-50 font-medium transition flex-1 md:flex-none justify-center">
@@ -287,7 +293,9 @@ export class VisitComponent implements OnInit {
   showMobileHistory = false;
 
   currentPrescription: any[] = [];
-  // ...
+  viewMode = false;
+  viewVisitId: number | null = null;
+  viewedVisit: Visit | null = null;
 
   constructor(
     private route: ActivatedRoute,
@@ -299,12 +307,14 @@ export class VisitComponent implements OnInit {
     private authService: AuthService
   ) {
     const nav = this.router.getCurrentNavigation();
-    if (nav?.extras?.state?.['isConsulting']) {
+    const state = nav?.extras?.state || {};
+    if (state['isConsulting']) {
       this.isConsulting = true;
     }
-    if (nav?.extras?.state?.['encounterId']) {
-      this.encounterId = Number(nav.extras.state['encounterId']);
+    if (state['encounterId']) {
+      this.encounterId = Number(state['encounterId']);
     }
+    this.applyViewIntent(state);
 
     this.visitForm = this.fb.group({
       symptoms: [''],
@@ -320,8 +330,13 @@ export class VisitComponent implements OnInit {
     this.currentUser = this.authService.getUser();
     this.route.params.subscribe(params => {
       this.patientId = +params['id'];
+      this.applyViewIntent(this.route.snapshot.queryParams);
       this.loadData();
     });
+  }
+
+  get isViewMode(): boolean {
+    return this.viewMode && !this.isLiveConsultation;
   }
 
   get isLiveConsultation(): boolean {
@@ -343,6 +358,13 @@ export class VisitComponent implements OnInit {
 
   editVisit(visit: any) {
     // Historical editing and active completion are deliberately separate modes.
+    if (this.isViewMode) {
+      this.viewVisitId = visit.id;
+      this.patchVisitSnapshot(visit);
+      this.setChartWritable(false);
+      this.showMobileHistory = false;
+      return;
+    }
     if (this.isConsulting || this.encounterId || this.activeEncounterReadOnly) return;
     this.editingVisitId = visit.id;
     this.visitForm.patchValue({
@@ -379,6 +401,10 @@ export class VisitComponent implements OnInit {
     this.consultationLoadError = null;
     try {
       this.setChartWritable(false);
+      if (this.viewMode) {
+        await this.loadFinishedVisitView();
+        return;
+      }
       let activeEncounterReadDenied = false;
       const activeEncounterRequest = this.dataService.invoke<any>('getActiveConsultation', this.patientId)
         .catch(error => {
@@ -546,21 +572,18 @@ export class VisitComponent implements OnInit {
 
   async printPrescription() {
     try {
-      const settings = await this.dataService.invoke<any>('getPublicSettings');
-      const currentUser = this.authService.getUser();
-      const doctor = {
-        name: currentUser?.name || settings?.doctor_name || 'Doctor',
-        specialty: currentUser?.specialty || 'General',
-        license_number: currentUser?.license_number || settings?.license_key || ''
-      };
-
-      await this.pdfService.generatePrescription(
-        { ...this.visitForm.value, date: new Date() },
-        this.patient,
-        doctor
-      );
+      await this.generateVisitPdf({ ...this.visitForm.value, date: new Date() });
     } catch (e) {
       console.error('Print failed', e);
+    }
+  }
+
+  async downloadVisitPdf() {
+    if (!this.viewedVisit) return;
+    try {
+      await this.generateVisitPdf(this.viewedVisit);
+    } catch (e) {
+      console.error('PDF download failed', e);
     }
   }
 
@@ -665,6 +688,71 @@ export class VisitComponent implements OnInit {
 
   private currentVisitData() {
     return { ...this.visitForm.value };
+  }
+
+  private applyViewIntent(source: Record<string, any> | null | undefined) {
+    if (!source) return;
+    if (source['mode'] === 'view') this.viewMode = true;
+    const visitId = source['visitId'];
+    if (visitId != null && visitId !== '') this.viewVisitId = Number(visitId);
+  }
+
+  private async loadFinishedVisitView() {
+    const [visits, allPatients, vitals] = await Promise.all([
+      this.dataService.invoke<any[]>('getVisits', this.patientId),
+      this.dataService.invoke<any[]>('getPatients', ''),
+      this.dataService.invoke<any>('getVitals', this.patientId)
+    ]);
+    const patient = allPatients.find((item: any) => item.id === this.patientId);
+    const finished = (visits || []).filter((visit: any) => visit.status !== 'in-progress');
+    const target = this.viewVisitId != null
+      ? finished.find((visit: any) => Number(visit.id) === Number(this.viewVisitId))
+      : undefined;
+
+    this.ngZone.run(() => {
+      this.patient = patient;
+      this.history = finished;
+      this.patientVitals = vitals;
+      this.activeEncounterReadOnly = false;
+      this.encounterId = null;
+      this.isConsulting = false;
+      this.editingVisitId = null;
+      this.viewedVisit = target || null;
+      if (target) {
+        this.patchVisitSnapshot(target);
+      } else if (this.viewVisitId != null) {
+        this.consultationLoadError = 'Could not load this visit.';
+      }
+      this.setChartWritable(false);
+    });
+  }
+
+  private async generateVisitPdf(visit: any) {
+    const settings = await this.dataService.invoke<any>('getPublicSettings');
+    const currentUser = this.authService.getUser();
+    const doctor = {
+      name: currentUser?.name || settings?.doctor_name || 'Doctor',
+      specialty: currentUser?.specialty || 'General',
+      license_number: currentUser?.license_number || settings?.license_key || ''
+    };
+    await this.pdfService.generatePrescription(
+      { ...visit, date: visit.date || new Date() },
+      this.patient,
+      doctor
+    );
+  }
+
+  private patchVisitSnapshot(visit: any) {
+    this.viewedVisit = visit;
+    this.visitForm.patchValue({
+      symptoms: visit.symptoms || '',
+      examination_notes: visit.examination_notes || '',
+      diagnosis: visit.diagnosis || '',
+      diagnosis_type: visit.diagnosis_type || '',
+      prescription: visit.prescription || [],
+      amount_paid: visit.amount_paid || 0
+    });
+    this.currentPrescription = visit.prescription || [];
   }
 
   private patchEncounter(encounter: any) {

--- a/desktop/src/renderer/app/visits/visit/visit.component.ts
+++ b/desktop/src/renderer/app/visits/visit/visit.component.ts
@@ -297,7 +297,6 @@ export class VisitComponent implements OnInit {
   viewMode = false;
   viewVisitId: number | null = null;
   viewedVisit: Visit | null = null;
-  private pendingNavState: Record<string, any> | null = null;
 
   constructor(
     private route: ActivatedRoute,
@@ -310,7 +309,6 @@ export class VisitComponent implements OnInit {
   ) {
     const nav = this.router.getCurrentNavigation();
     const state = nav?.extras?.state || {};
-    this.pendingNavState = state;
     if (state['isConsulting']) {
       this.isConsulting = true;
     }
@@ -333,7 +331,7 @@ export class VisitComponent implements OnInit {
     this.currentUser = this.authService.getUser();
     combineLatest([this.route.params, this.route.queryParams]).subscribe(([params, queryParams]) => {
       this.patientId = +params['id'];
-      this.applyViewIntent(queryParams, true);
+      this.applyViewIntent(queryParams);
       this.loadData();
     });
   }
@@ -693,36 +691,14 @@ export class VisitComponent implements OnInit {
     return { ...this.visitForm.value };
   }
 
-  private applyViewIntent(source: Record<string, any> | null | undefined, replace = false) {
-    if (replace) {
-      const query = source || {};
-      const hasQueryIntent = query['mode'] != null || (query['visitId'] != null && query['visitId'] !== '');
-      if (hasQueryIntent) {
-        this.viewMode = query['mode'] === 'view';
-        this.viewVisitId = this.viewMode && query['visitId'] != null && query['visitId'] !== ''
-          ? Number(query['visitId'])
-          : null;
-        this.pendingNavState = null;
-      } else if (this.pendingNavState && (this.pendingNavState['mode'] === 'view' || this.pendingNavState['visitId'] != null)) {
-        const state = this.pendingNavState;
-        this.pendingNavState = null;
-        this.viewMode = state['mode'] === 'view';
-        const stateVisitId = state['visitId'];
-        this.viewVisitId = this.viewMode && stateVisitId != null && stateVisitId !== ''
-          ? Number(stateVisitId)
-          : null;
-      } else {
-        this.viewMode = false;
-        this.viewVisitId = null;
-        this.pendingNavState = null;
-      }
-      if (!this.viewMode) this.viewedVisit = null;
-      return;
-    }
-    if (!source) return;
-    if (source['mode'] === 'view') this.viewMode = true;
-    const visitId = source['visitId'];
-    if (visitId != null && visitId !== '') this.viewVisitId = Number(visitId);
+  private applyViewIntent(source: Record<string, any> | null | undefined) {
+    const isViewMode = source?.['mode'] === 'view';
+    const visitId = source?.['visitId'];
+    this.viewMode = isViewMode;
+    this.viewVisitId = isViewMode && visitId != null && visitId !== ''
+      ? Number(visitId)
+      : null;
+    if (!isViewMode) this.viewedVisit = null;
   }
 
   private async loadFinishedVisitView() {

--- a/desktop/src/renderer/app/visits/visit/visit.component.ts
+++ b/desktop/src/renderer/app/visits/visit/visit.component.ts
@@ -8,6 +8,7 @@ import { PrescriptionComponent } from '../../visits/prescription/prescription.co
 import { AuthService } from '../../services/auth.service';
 import { DataService } from '../../services/api.service';
 import { newRequestId } from '../../services/request-id';
+import { combineLatest } from 'rxjs';
 
 interface PrescriptionItem {
   medicine: string;
@@ -296,6 +297,7 @@ export class VisitComponent implements OnInit {
   viewMode = false;
   viewVisitId: number | null = null;
   viewedVisit: Visit | null = null;
+  private pendingNavState: Record<string, any> | null = null;
 
   constructor(
     private route: ActivatedRoute,
@@ -308,6 +310,7 @@ export class VisitComponent implements OnInit {
   ) {
     const nav = this.router.getCurrentNavigation();
     const state = nav?.extras?.state || {};
+    this.pendingNavState = state;
     if (state['isConsulting']) {
       this.isConsulting = true;
     }
@@ -328,9 +331,9 @@ export class VisitComponent implements OnInit {
 
   ngOnInit() {
     this.currentUser = this.authService.getUser();
-    this.route.params.subscribe(params => {
+    combineLatest([this.route.params, this.route.queryParams]).subscribe(([params, queryParams]) => {
       this.patientId = +params['id'];
-      this.applyViewIntent(this.route.snapshot.queryParams);
+      this.applyViewIntent(queryParams, true);
       this.loadData();
     });
   }
@@ -690,7 +693,32 @@ export class VisitComponent implements OnInit {
     return { ...this.visitForm.value };
   }
 
-  private applyViewIntent(source: Record<string, any> | null | undefined) {
+  private applyViewIntent(source: Record<string, any> | null | undefined, replace = false) {
+    if (replace) {
+      const query = source || {};
+      const hasQueryIntent = query['mode'] != null || (query['visitId'] != null && query['visitId'] !== '');
+      if (hasQueryIntent) {
+        this.viewMode = query['mode'] === 'view';
+        this.viewVisitId = this.viewMode && query['visitId'] != null && query['visitId'] !== ''
+          ? Number(query['visitId'])
+          : null;
+        this.pendingNavState = null;
+      } else if (this.pendingNavState && (this.pendingNavState['mode'] === 'view' || this.pendingNavState['visitId'] != null)) {
+        const state = this.pendingNavState;
+        this.pendingNavState = null;
+        this.viewMode = state['mode'] === 'view';
+        const stateVisitId = state['visitId'];
+        this.viewVisitId = this.viewMode && stateVisitId != null && stateVisitId !== ''
+          ? Number(stateVisitId)
+          : null;
+      } else {
+        this.viewMode = false;
+        this.viewVisitId = null;
+        this.pendingNavState = null;
+      }
+      if (!this.viewMode) this.viewedVisit = null;
+      return;
+    }
     if (!source) return;
     if (source['mode'] === 'view') this.viewMode = true;
     const visitId = source['visitId'];

--- a/desktop/src/shared/hash-app-path.spec.ts
+++ b/desktop/src/shared/hash-app-path.spec.ts
@@ -9,6 +9,7 @@ describe('hash SPA path rewrite', () => {
     it('rewrites nested app paths and preserves the query string', () => {
         expect(hashUrlForPathname('/patients/12', '?q=1')).toBe('/#/patients/12?q=1');
         expect(hashUrlForPathname('/visit/3')).toBe('/#/visit/3');
+        expect(hashUrlForPathname('/visit/3', '?visitId=42&mode=view')).toBe('/#/visit/3?visitId=42&mode=view');
         expect(hashUrlForPathname('/online-booking')).toBe('/#/online-booking');
         expect(hashUrlForPathname('/queue')).toBe('/#/queue');
         expect(hashUrlForPathname('/dashboard')).toBe('/#/dashboard');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #45.

Opening a finished visit from **Visits** now loads that visit in read-only view and can download a real PDF of its data.

## What
- From Visits history, a finished visit opens with that visit’s SOAP, diagnosis, Rx, and fee (not an empty chart).
- Mode is **VIEW** (not LIVE, not a new consult). Save / End / Finish & Next stay hidden.
- **Download PDF** calls existing `PdfService.generatePrescription` (jsPDF) with the loaded visit snapshot.

## How
- Keep hash route `visit/:patientId`. Pass `visitId` + `mode=view` via router state and query.
- View mode loads that visit, patches the form, `setChartWritable(false)`, leaves `isLiveConsultation` false, and does not call `beginConsultation`.
- Reused `visit/:id` route: query-param changes replace view intent (leave view when `mode`/`visitId` are gone).
- Live consult path and Patients → Medical Record `window.print()` are unchanged.

## Out of scope
Drive/cloud, LIVE redesign, invoices (#21), #46 inventory, FHIR/#15/#11, PathLocationStrategy, new PDF stack.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-536f8106-856e-4d04-98e8-c15d8347c5b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-536f8106-856e-4d04-98e8-c15d8347c5b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only view mode for reviewing completed visits.
  * Added visit navigation that preserves the visit ID and view mode.
  * Added PDF downloads for visits in view mode.
  * Hidden editing and destructive actions while viewing completed visits.

* **Bug Fixes**
  * Preserved visit query parameters when navigating to nested visit pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->