### PR TITLE
feat(desktop): in-app upgrades and visit Rx catalogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Follow these steps to set up the development environment from a clean repository
 - **Native Module Errors (`better-sqlite3`)**:
     - Ensure you have the Windows Build Tools installed.
     - Re-run `npm run postinstall` to rebuild modules against the Electron header files.
-- **Linux install**: Use the `.deb` from Feature CI (`sudo apt install ./nalamdesk-desktop_*_amd64.deb`). The AppImage needs FUSE 2; if it does not start, install the `.deb` instead of extracting the squashfs.
+- **Linux install**: Use the `.deb` from Feature CI (`sudo apt install ./nalamdesk-desktop_*_amd64.deb`). The AppImage needs FUSE 2; if it does not start, install the `.deb` instead of extracting the squashfs. In-app upgrades apply via AppImage; `.deb` installs fall back to the download page (no apt repo).
 - **Linux `ENCRYPTION_UNAVAILABLE`**: The packaged app selects `gnome-libsecret` at process start. Install `libsecret-1-0` and `gnome-keyring`. Do not use `--password-store=basic`.
 - **Database**:
     - A local SQLite database `nalamdesk.db` is automatically created in the `desktop` directory (dev) or `%APPDATA%` (prod) on first run.

--- a/cloud/documentation/docs/developer-guide/architecture.md
+++ b/cloud/documentation/docs/developer-guide/architecture.md
@@ -23,7 +23,7 @@ NalamDesk uses a secure, local-first hybrid desktop architecture designed for re
 - **Responsibilities**:
     - App Window Management.
     - Native System Integrations (File System, Dialogs).
-    - Auto-updates (`electron-updater`) against a generic clinic feed (`NALAMDESK_UPDATE_FEED_URL`) in packaged builds; GitHub provider is a later-PR seam (`NALAMDESK_UPDATE_PROVIDER=github`).
+    - Auto-updates (`electron-updater`) against a generic HTTPS clinic feed (`NALAMDESK_UPDATE_FEED_URL`) in packaged builds; GitHub provider is a later-PR seam (`NALAMDESK_UPDATE_PROVIDER=github`).
     - Linux `gnome-libsecret` password-store switch at process start.
     - Authenticated desktop session (`SessionService`); `auth:logout` clears the principal.
 

--- a/cloud/documentation/docs/developer-guide/architecture.md
+++ b/cloud/documentation/docs/developer-guide/architecture.md
@@ -23,8 +23,7 @@ NalamDesk uses a secure, local-first hybrid desktop architecture designed for re
 - **Responsibilities**:
     - App Window Management.
     - Native System Integrations (File System, Dialogs).
-    - Auto-updates (electron-updater).
-    - Spawning the background component calls.
+    - Auto-updates (`electron-updater`) against a generic clinic feed (`NALAMDESK_UPDATE_FEED_URL`) in packaged builds; GitHub provider is a later-PR seam (`NALAMDESK_UPDATE_PROVIDER=github`).
     - Linux `gnome-libsecret` password-store switch at process start.
     - Authenticated desktop session (`SessionService`); `auth:logout` clears the principal.
 

--- a/cloud/documentation/docs/developer-guide/database-schema.md
+++ b/cloud/documentation/docs/developer-guide/database-schema.md
@@ -44,6 +44,17 @@ Records clinical encounters.
 | `date` | DATETIME | Timestamp of the visit. |
 | `diagnosis` | TEXT | Medical diagnosis notes. |
 | `prescription_json` | TEXT | JSON string array of medicines. |
+
+## Condition catalog
+Clinic-local diagnoses for Plan & Rx typeahead. Unique `name` among **active** rows. Soft-retire sets `active = 0` and does not rewrite historical visit text.
+
+## Medicine catalog
+Clinic-local medicines with optional default Rx fields (`form`, `dosage`, `route`, `frequency`, `duration`, `instruction`) matching the visit prescription snapshot.
+
+## Condition medicine presets
+Ordered default Rx lines for a condition (`condition_id`, `sort_order`, optional `medicine_id`, plus snapshot columns matching `PrescriptionItem`). Applied into the editable Rx list on diagnosis pick.
+
+## Patient Queue Table
 | `amount_paid` | NUMERIC(12,2) | Consultation fee collected. |
 
 ## Patient Queue Table

--- a/cloud/documentation/docs/developer-guide/database-schema.md
+++ b/cloud/documentation/docs/developer-guide/database-schema.md
@@ -44,6 +44,7 @@ Records clinical encounters.
 | `date` | DATETIME | Timestamp of the visit. |
 | `diagnosis` | TEXT | Medical diagnosis notes. |
 | `prescription_json` | TEXT | JSON string array of medicines. |
+| `amount_paid` | NUMERIC(12,2) | Consultation fee collected. |
 
 ## Condition catalog
 Clinic-local diagnoses for Plan & Rx typeahead. Unique `name` among **active** rows. Soft-retire sets `active = 0` and does not rewrite historical visit text.
@@ -53,9 +54,6 @@ Clinic-local medicines with optional default Rx fields (`form`, `dosage`, `route
 
 ## Condition medicine presets
 Ordered default Rx lines for a condition (`condition_id`, `sort_order`, optional `medicine_id`, plus snapshot columns matching `PrescriptionItem`). Applied into the editable Rx list on diagnosis pick.
-
-## Patient Queue Table
-| `amount_paid` | NUMERIC(12,2) | Consultation fee collected. |
 
 ## Patient Queue Table
 Manages the daily patient flow.

--- a/desktop/DEVELOPER_GUIDE.md
+++ b/desktop/DEVELOPER_GUIDE.md
@@ -59,7 +59,7 @@ Set `NALAMDESK_UPDATE_PROVIDER=github` (optional `NALAMDESK_UPDATE_GITHUB_OWNER`
 | Linux | AppImage | `electron-updater` `quitAndInstall` |
 | Linux | `.deb` (clinic first-install) | **Open download page** if the running process is not an AppImage, or if the feed has no AppImage. No apt repo. |
 
-Unsigned / checksum-only feeds must not claim full code-signature verification in the UI. Set `NALAMDESK_UPDATE_RELEASE_SIGNED=1` only when a later signed channel is actually in use.
+Unsigned / checksum-only feeds must not claim full code-signature verification in the UI. `NALAMDESK_UPDATE_RELEASE_SIGNED=1` is a later-PR seam only; this build always reports checksum-only integrity until the updater returns a real verification result.
 
 The updater never wipes, moves, or re-encrypts `userData` / the vault.
 

--- a/desktop/DEVELOPER_GUIDE.md
+++ b/desktop/DEVELOPER_GUIDE.md
@@ -40,6 +40,32 @@ This will:
 - Development builds append `(development)` to the displayed version.
 - `npm run build` stamps `desktop/build-identity.json`. Feature CI asserts artifact names, electron-builder `latest*.yml`, identity, and displayed version agree (`npm run assert:packaged-version`).
 
+## In-app updates (#43)
+Packaged Electron only (`app.isPackaged`). Unpackaged `npm start` skips the updater.
+
+### Interim feed (this PR)
+- Provider: **generic** via `NALAMDESK_UPDATE_FEED_URL` (directory that serves `latest.yml` / `latest-mac.yml` / `latest-linux.yml` plus the OS packages those files name).
+- Ops copies **approved** builds onto that feed. Feature CI PR zips and random Actions artifacts are not an update channel. Automated Release / public GitHub Releases are not required here.
+- Optional: `NALAMDESK_UPDATE_DOWNLOAD_PAGE` (Linux `.deb` fallback opens this URL).
+
+### GitHub provider seam (later PR)
+Set `NALAMDESK_UPDATE_PROVIDER=github` (optional `NALAMDESK_UPDATE_GITHUB_OWNER` / `NALAMDESK_UPDATE_GITHUB_REPO`). IPC (`updates:check|download|install|cancel|status` + `updates:event`) and Settings/launch UX stay the same.
+
+### OS apply paths
+| OS | Packaged form | In-app apply |
+| --- | --- | --- |
+| Windows | NSIS | `electron-updater` `quitAndInstall` |
+| macOS | DMG | `electron-updater` `quitAndInstall` |
+| Linux | AppImage | `electron-updater` `quitAndInstall` |
+| Linux | `.deb` (clinic first-install) | **Open download page** if the running process is not an AppImage, or if the feed has no AppImage. No apt repo. |
+
+Unsigned / checksum-only feeds must not claim full code-signature verification in the UI. Set `NALAMDESK_UPDATE_RELEASE_SIGNED=1` only when a later signed channel is actually in use.
+
+The updater never wipes, moves, or re-encrypts `userData` / the vault.
+
+## Visit catalogs (#46)
+One SQLite migration (`condition_catalog`, `medicine_catalog`, `condition_med_presets`). Visit writes stay denormalized `diagnosis` TEXT + `prescription_json`. IPC extends existing `db:*` / `invokeDbMethod` (Electron and HTTP `/api/ipc`). Doctor/admin can search and Add new during a visit; Settings catalog maintenance is admin-only.
+
 ## Build & Distribution
 Output is `desktop/release/`.
 

--- a/desktop/DEVELOPER_GUIDE.md
+++ b/desktop/DEVELOPER_GUIDE.md
@@ -44,7 +44,7 @@ This will:
 Packaged Electron only (`app.isPackaged`). Unpackaged `npm start` skips the updater.
 
 ### Interim feed (this PR)
-- Provider: **generic** via `NALAMDESK_UPDATE_FEED_URL` (directory that serves `latest.yml` / `latest-mac.yml` / `latest-linux.yml` plus the OS packages those files name).
+- Provider: **generic** via `NALAMDESK_UPDATE_FEED_URL` (HTTPS directory that serves `latest.yml` / `latest-mac.yml` / `latest-linux.yml` plus the OS packages those files name). Plain HTTP is rejected except `localhost` / `127.0.0.1`.
 - Ops copies **approved** builds onto that feed. Feature CI PR zips and random Actions artifacts are not an update channel. Automated Release / public GitHub Releases are not required here.
 - Optional: `NALAMDESK_UPDATE_DOWNLOAD_PAGE` (Linux `.deb` fallback opens this URL).
 

--- a/desktop/USER_GUIDE.md
+++ b/desktop/USER_GUIDE.md
@@ -45,8 +45,9 @@ Welcome to **NalamDesk**, your secure, offline-first Clinic Management System. T
 ### 3. Doctor's Workbench
 *   **Timeline:** View a patient's entire medical history (previous visits, prescriptions) in a chronological timeline.
 *   **Prescription Pad:**
-    *   **Diagnosis:** Enter clinical notes and diagnosis.
-    *   **Medicines:** Search and add medicines with dosage instructions (e.g., "1-0-1", "After Food").
+    *   **Diagnosis:** Typeahead against the clinic condition catalog. Use **Add new** if the term is missing — the visit is never blocked.
+    *   **Presets:** Choosing a condition can fill a clinic-configured medicine set. Edit or remove lines before save.
+    *   **Medicines:** Typeahead against the medicine catalog, with **Add new** on the go.
     *   **Print:** Click "Print" to generate a professional PDF prescription instantly.
 
 ### 4. Online Booking (Cloud Sync) ☁️
@@ -72,6 +73,8 @@ Welcome to **NalamDesk**, your secure, offline-first Clinic Management System. T
 *   **Theme:** Switch between Light, Dark, and High-Contrast modes.
 *   **Clinic Details:** Update your clinic's name and address (appears on prescriptions).
 *   **Application version:** The Settings footer shows the packaged application version from Electron (`app.getVersion()`), plus a short commit when the build embeds one. Development builds are labeled `(development)`.
+*   **Updates:** Packaged desktops check for a newer approved build on launch and from **Settings → Check for updates**. If one is available you see the current and new version, optional notes, and **Update now** / **Later**. Later keeps the running app. A failed check or download shows a plain error and does not touch the vault. Unsigned or checksum-only feeds do **not** claim full signature verification.
+*   **Catalogs:** Administrators maintain diagnosis and medicine inventories (and condition→medicine presets) under **Settings → Catalogs**. Soft-retire hides a term from typeahead; past visit text is unchanged.
 
 ### Data Management
 *   **Backup:** Automated daily backups are saved locally (Settings → Data & Backup). Retention is 30 days.

--- a/desktop/e2e/full-flow.spec.ts
+++ b/desktop/e2e/full-flow.spec.ts
@@ -106,11 +106,11 @@ test('NalamDesk Full Clinical Flow', async () => {
         await expect(window.locator(`h3:has-text("${patientName}")`)).toBeVisible();
 
         // Fill Diagnosis
-        await window.locator('textarea[formControlName="diagnosis"]').fill('Flu symptoms. Fever and cold.');
+        await window.locator('[data-testid="diagnosis-input"]').fill('Flu symptoms. Fever and cold.');
 
         // Prescribe Medicine (First row is auto-added)
         const firstRowMock = window.locator('app-prescription .grid').first();
-        await firstRowMock.locator('input[placeholder="Medicine Name"]').fill('Paracetamol');
+        await firstRowMock.locator('[data-testid="rx-medicine-0"]').fill('Paracetamol');
         await firstRowMock.locator('input[placeholder="Duration (e.g. 5 days)"]').fill('3 days');
 
         // Save Progress

--- a/desktop/src/main/catalog/catalogStore.spec.ts
+++ b/desktop/src/main/catalog/catalogStore.spec.ts
@@ -151,4 +151,15 @@ describe('condition and medicine catalogs', () => {
         const presets = service.getConditionMedPresets(condition.id);
         expect(presets.map((line: any) => line.medicine)).toEqual(['Paracetamol', 'ORS']);
     });
+
+    it('keeps existing Rx defaults when a medicine is renamed', () => {
+        const medicine = service.createMedicine({
+            name: 'Paracetamol', dosage: '500mg', frequency: '1-1-1', duration: '5 days'
+        });
+        const updated = service.updateMedicine({ id: medicine.id, name: 'Acetaminophen' });
+        expect(updated.name).toBe('Acetaminophen');
+        expect(updated.dosage).toBe('500mg');
+        expect(updated.frequency).toBe('1-1-1');
+        expect(updated.duration).toBe('5 days');
+    });
 });

--- a/desktop/src/main/catalog/catalogStore.spec.ts
+++ b/desktop/src/main/catalog/catalogStore.spec.ts
@@ -133,4 +133,22 @@ describe('condition and medicine catalogs', () => {
         expect(service.searchMedicines('Oseltamivir')).toHaveLength(0);
         expect(service.listConditions(true).some((row: any) => row.id === condition.id && row.active === 0)).toBe(true);
     });
+
+    it('omits retired medicines when loading condition presets', () => {
+        const condition = service.createCondition({ name: 'URI' });
+        const active = service.createMedicine({ name: 'Paracetamol' });
+        const retired = service.createMedicine({ name: 'Old syrup' });
+        service.replaceConditionMedPresets({
+            conditionId: condition.id,
+            lines: [
+                { medicine_id: active.id },
+                { medicine_id: retired.id },
+                { medicine: 'ORS' }
+            ]
+        });
+        service.retireMedicine(retired.id);
+
+        const presets = service.getConditionMedPresets(condition.id);
+        expect(presets.map((line: any) => line.medicine)).toEqual(['Paracetamol', 'ORS']);
+    });
 });

--- a/desktop/src/main/catalog/catalogStore.spec.ts
+++ b/desktop/src/main/catalog/catalogStore.spec.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { DatabaseService } from '../services/DatabaseService';
+
+const { DatabaseSync } = require('node:sqlite');
+
+class TestDatabase {
+    private readonly sqlite = new DatabaseSync(':memory:');
+    readonly name = ':memory:';
+
+    exec(sql: string) { return this.sqlite.exec(sql); }
+    prepare(sql: string) { return this.sqlite.prepare(sql); }
+    close() { return this.sqlite.close(); }
+    pragma(sql: string, options?: { simple?: boolean }) {
+        const assignment = sql.match(/^user_version\s*=\s*(\d+)$/);
+        if (assignment) {
+            this.sqlite.exec(`PRAGMA user_version = ${assignment[1]}`);
+            return;
+        }
+        const row = this.sqlite.prepare(`PRAGMA ${sql}`).get() as any;
+        return options?.simple ? row?.user_version : row;
+    }
+    transaction<T extends (...args: any[]) => any>(operation: T): T & { immediate: T } {
+        const run = ((...args: any[]) => {
+            this.sqlite.exec('BEGIN IMMEDIATE');
+            try {
+                const value = operation(...args);
+                this.sqlite.exec('COMMIT');
+                return value;
+            } catch (error) {
+                this.sqlite.exec('ROLLBACK');
+                throw error;
+            }
+        }) as T & { immediate: T };
+        run.immediate = run;
+        return run;
+    }
+}
+
+describe('condition and medicine catalogs', () => {
+    let db: any;
+    let service: DatabaseService;
+
+    beforeEach(async () => {
+        db = new TestDatabase();
+        db.exec('PRAGMA foreign_keys = ON');
+        service = new DatabaseService();
+        service.setDb(db);
+        await service.migrate({ skipBackup: true });
+        db.prepare("INSERT INTO users (id, username, role, name, active) VALUES (10, 'doctor', 'doctor', 'Dr Test', 1)").run();
+        db.prepare("INSERT INTO patients (id, uuid, name) VALUES (1, 'p-1', 'Patient One')").run();
+    });
+
+    afterEach(() => db.close());
+
+    it('searches active catalog rows only and caps the result length', () => {
+        service.createCondition({ name: 'Influenza' });
+        service.createCondition({ name: 'Infected wound' });
+        const retired = service.createCondition({ name: 'Old flu' });
+        service.retireCondition(retired.id);
+        for (let i = 0; i < 25; i++) {
+            service.createCondition({ name: `Inflammation ${i}` });
+        }
+
+        const hits = service.searchConditions('infl');
+        expect(hits.every((row: any) => row.active === 1)).toBe(true);
+        expect(hits.some((row: any) => row.name === 'Old flu')).toBe(false);
+        expect(hits.length).toBeLessThanOrEqual(20);
+        expect(hits[0].name).toMatch(/^Infl/i);
+    });
+
+    it('adds a new condition and medicine, then rejects empty or duplicate active names', () => {
+        const condition = service.createCondition({ name: '  Viral fever ' });
+        expect(condition.name).toBe('Viral fever');
+        expect(service.searchConditions('viral')[0].id).toBe(condition.id);
+
+        const medicine = service.createMedicine({ name: 'Paracetamol', dosage: '500mg' });
+        expect(medicine.dosage).toBe('500mg');
+        expect(service.searchMedicines('para')[0].name).toBe('Paracetamol');
+
+        expect(() => service.createCondition({ name: '   ' })).toThrow('NAME_REQUIRED');
+        expect(() => service.createMedicine({ name: '' })).toThrow('NAME_REQUIRED');
+        expect(() => service.createCondition({ name: 'viral fever' })).toThrow('DUPLICATE_ACTIVE_NAME');
+        expect(() => service.createMedicine({ name: 'paracetamol' })).toThrow('DUPLICATE_ACTIVE_NAME');
+    });
+
+    it('applies ordered presets as editable Rx lines', () => {
+        const condition = service.createCondition({ name: 'URI' });
+        const para = service.createMedicine({ name: 'Paracetamol', dosage: '500mg', frequency: '1-1-1' });
+        const cet = service.createMedicine({ name: 'Cetirizine', dosage: '10mg' });
+        const presets = service.replaceConditionMedPresets({
+            conditionId: condition.id,
+            lines: [
+                { medicine_id: para.id },
+                { medicine_id: cet.id, duration: '5 days' }
+            ]
+        });
+        expect(presets).toHaveLength(2);
+        expect(presets[0].medicine).toBe('Paracetamol');
+        expect(presets[0].dosage).toBe('500mg');
+        expect(presets[1].duration).toBe('5 days');
+        presets[0].duration = '7 days';
+        expect(service.getConditionMedPresets(condition.id)[0].duration).toBe('3 days');
+    });
+
+    it('soft-retires catalog rows without changing a saved visit snapshot', () => {
+        const condition = service.createCondition({ name: 'Influenza' });
+        const medicine = service.createMedicine({ name: 'Oseltamivir', dosage: '75mg' });
+        service.replaceConditionMedPresets({
+            conditionId: condition.id,
+            lines: [{ medicine_id: medicine.id }]
+        });
+
+        const queueEntryId = Number(db.prepare('INSERT INTO patient_queue (patient_id, priority) VALUES (1, 1)').run().lastInsertRowid);
+        const encounter = service.beginConsultation({
+            patientId: 1, queueEntryId, startRequestId: 'start-catalog'
+        }, 10);
+        const prescription = service.getConditionMedPresets(condition.id);
+        prescription[0].duration = '5 days';
+        service.saveConsultationProgress({
+            encounterId: encounter.id,
+            visit: { diagnosis: 'Influenza', prescription, amount_paid: 200 }
+        }, 10);
+
+        service.retireCondition(condition.id);
+        service.retireMedicine(medicine.id);
+
+        const stored = db.prepare('SELECT diagnosis, prescription_json FROM visits WHERE id = ?').get(encounter.id);
+        expect(stored.diagnosis).toBe('Influenza');
+        const snapshot = JSON.parse(stored.prescription_json);
+        expect(snapshot[0].medicine).toBe('Oseltamivir');
+        expect(snapshot[0].duration).toBe('5 days');
+        expect(service.searchConditions('Influenza')).toHaveLength(0);
+        expect(service.searchMedicines('Oseltamivir')).toHaveLength(0);
+        expect(service.listConditions(true).some((row: any) => row.id === condition.id && row.active === 0)).toBe(true);
+    });
+});

--- a/desktop/src/main/catalog/catalogStore.spec.ts
+++ b/desktop/src/main/catalog/catalogStore.spec.ts
@@ -162,4 +162,15 @@ describe('condition and medicine catalogs', () => {
         expect(updated.frequency).toBe('1-1-1');
         expect(updated.duration).toBe('5 days');
     });
+
+    it('updates conditions, lists medicines, and ignores invalid preset ids', () => {
+        const condition = service.createCondition({ name: 'URI' });
+        const renamed = service.updateCondition({ id: condition.id, name: 'Upper URI' });
+        expect(renamed.name).toBe('Upper URI');
+        const medicine = service.createMedicine({ name: 'Paracetamol_500' });
+        expect(service.searchMedicines('Paracetamol_').some((row: any) => row.id === medicine.id)).toBe(true);
+        expect(service.listMedicines().some((row: any) => row.id === medicine.id)).toBe(true);
+        expect(service.getConditionMedPresets(0)).toEqual([]);
+        expect(() => service.replaceConditionMedPresets({ conditionId: 999, lines: [] })).toThrow('CONDITION_NOT_FOUND');
+    });
 });

--- a/desktop/src/main/catalog/catalogStore.ts
+++ b/desktop/src/main/catalog/catalogStore.ts
@@ -77,10 +77,12 @@ export function getConditionMedPresets(db: SqliteDb, conditionId: number): Presc
     const id = Number(conditionId);
     if (!Number.isInteger(id) || id <= 0) return [];
     const rows = db.prepare(`
-        SELECT medicine_id, medicine, form, dosage, route, frequency, duration, instruction
-        FROM condition_med_presets
-        WHERE condition_id = ?
-        ORDER BY sort_order ASC, id ASC
+        SELECT p.medicine_id, p.medicine, p.form, p.dosage, p.route, p.frequency, p.duration, p.instruction
+        FROM condition_med_presets p
+        LEFT JOIN medicine_catalog m ON m.id = p.medicine_id
+        WHERE p.condition_id = ?
+          AND (p.medicine_id IS NULL OR m.active = 1)
+        ORDER BY p.sort_order ASC, p.id ASC
     `).all(id);
     return rows.map((row) => toRxLine(row));
 }

--- a/desktop/src/main/catalog/catalogStore.ts
+++ b/desktop/src/main/catalog/catalogStore.ts
@@ -103,8 +103,10 @@ export function updateCondition(db: SqliteDb, input: { id?: number; name?: strin
 
 export function updateMedicine(db: SqliteDb, input: Partial<MedicineCatalogRow> & { id?: number; name?: string }): MedicineCatalogRow {
     const id = requireId(input?.id);
-    const name = normalizeName(input?.name);
-    const defaults = defaultRxFields(input);
+    const existing = db.prepare('SELECT * FROM medicine_catalog WHERE id = ?').get(id) as MedicineCatalogRow | undefined;
+    if (!existing) throw new Error('CATALOG_NOT_FOUND');
+    const name = normalizeName(input?.name != null ? input.name : existing.name);
+    const defaults = defaultRxFields(mergeMedicineFields(existing, input));
     return updateNamed(db, 'medicine_catalog', id, { name, ...defaults }) as MedicineCatalogRow;
 }
 
@@ -257,6 +259,20 @@ function toRxLine(row: any): PrescriptionLine {
         frequency: row.frequency || defaults.frequency,
         duration: row.duration || defaults.duration,
         instruction: row.instruction || defaults.instruction
+    };
+}
+
+function mergeMedicineFields(
+    existing: MedicineCatalogRow,
+    input: Partial<MedicineCatalogRow>
+): Partial<MedicineCatalogRow> {
+    return {
+        form: input.form !== undefined ? input.form : existing.form,
+        dosage: input.dosage !== undefined ? input.dosage : existing.dosage,
+        route: input.route !== undefined ? input.route : existing.route,
+        frequency: input.frequency !== undefined ? input.frequency : existing.frequency,
+        duration: input.duration !== undefined ? input.duration : existing.duration,
+        instruction: input.instruction !== undefined ? input.instruction : existing.instruction
     };
 }
 

--- a/desktop/src/main/catalog/catalogStore.ts
+++ b/desktop/src/main/catalog/catalogStore.ts
@@ -295,7 +295,8 @@ function normalizeName(value: unknown): string {
 }
 
 function normalizeOptionalName(value: unknown): string {
-    return String(value || '').trim().replace(/\s+/g, ' ').slice(0, CATALOG_QUERY_MAX);
+    if (typeof value !== 'string' && typeof value !== 'number') return '';
+    return String(value).trim().replace(/\s+/g, ' ').slice(0, CATALOG_QUERY_MAX);
 }
 
 function requireId(value: unknown): number {
@@ -319,11 +320,11 @@ function likePrefix(term: string): string {
 }
 
 function escapeLike(term: string): string {
-    return term.replace(/([%_\\])/g, '\\$1');
+    return term.replaceAll('\\', '\\\\').replaceAll('%', '\\%').replaceAll('_', '\\_');
 }
 
 function mapConstraint(error: unknown): Error {
-    const message = String((error as Error)?.message || error || '');
+    const message = error instanceof Error ? error.message : (typeof error === 'string' ? error : '');
     if (/UNIQUE|constraint/i.test(message)) return new Error('DUPLICATE_ACTIVE_NAME');
     if (error instanceof Error) return error;
     return new Error(message || 'CATALOG_WRITE_FAILED');

--- a/desktop/src/main/catalog/catalogStore.ts
+++ b/desktop/src/main/catalog/catalogStore.ts
@@ -1,0 +1,312 @@
+export const CATALOG_SEARCH_LIMIT = 20;
+export const CATALOG_SEARCH_LIMIT_MAX = 50;
+export const CATALOG_QUERY_MAX = 80;
+
+export interface CatalogRow {
+    id: number;
+    name: string;
+    active: number;
+    created_at?: string;
+    updated_at?: string;
+}
+
+export interface MedicineCatalogRow extends CatalogRow {
+    form: string | null;
+    dosage: string | null;
+    route: string | null;
+    frequency: string | null;
+    duration: string | null;
+    instruction: string | null;
+}
+
+export interface PrescriptionLine {
+    medicine: string;
+    form: string;
+    dosage: string;
+    route: string;
+    frequency: string;
+    duration: string;
+    instruction: string;
+    medicine_id?: number | null;
+}
+
+type SqliteDb = {
+    prepare: (sql: string) => {
+        get: (...args: any[]) => any;
+        all: (...args: any[]) => any[];
+        run: (...args: any[]) => { lastInsertRowid: number | bigint; changes: number };
+    };
+    exec: (sql: string) => unknown;
+    transaction: <T extends (...args: any[]) => any>(fn: T) => T & { immediate: T };
+};
+
+interface CatalogWriteFields {
+    name: string;
+    form?: string;
+    dosage?: string;
+    route?: string;
+    frequency?: string;
+    duration?: string;
+    instruction?: string;
+}
+
+export function searchConditions(db: SqliteDb, query?: string, limit?: number): CatalogRow[] {
+    return searchActive(db, 'condition_catalog', query, limit);
+}
+
+export function searchMedicines(db: SqliteDb, query?: string, limit?: number): MedicineCatalogRow[] {
+    return searchActive(db, 'medicine_catalog', query, limit) as MedicineCatalogRow[];
+}
+
+export function createCondition(db: SqliteDb, input: { name?: string } | string): CatalogRow {
+    const name = normalizeName(typeof input === 'string' ? input : input?.name);
+    return insertNamed(db, 'condition_catalog', { name });
+}
+
+export function createMedicine(db: SqliteDb, input: Partial<MedicineCatalogRow> & { name?: string }): MedicineCatalogRow {
+    const name = normalizeName(input?.name);
+    const defaults = defaultRxFields(input);
+    const row = insertNamed(db, 'medicine_catalog', {
+        name,
+        ...defaults
+    });
+    return { ...row, ...defaults };
+}
+
+export function getConditionMedPresets(db: SqliteDb, conditionId: number): PrescriptionLine[] {
+    const id = Number(conditionId);
+    if (!Number.isInteger(id) || id <= 0) return [];
+    const rows = db.prepare(`
+        SELECT medicine_id, medicine, form, dosage, route, frequency, duration, instruction
+        FROM condition_med_presets
+        WHERE condition_id = ?
+        ORDER BY sort_order ASC, id ASC
+    `).all(id);
+    return rows.map((row) => toRxLine(row));
+}
+
+export function listConditions(db: SqliteDb, includeRetired = false): CatalogRow[] {
+    return listCatalog(db, 'condition_catalog', includeRetired);
+}
+
+export function listMedicines(db: SqliteDb, includeRetired = false): MedicineCatalogRow[] {
+    return listCatalog(db, 'medicine_catalog', includeRetired) as MedicineCatalogRow[];
+}
+
+export function updateCondition(db: SqliteDb, input: { id?: number; name?: string }): CatalogRow {
+    const id = requireId(input?.id);
+    const name = normalizeName(input?.name);
+    return updateNamed(db, 'condition_catalog', id, { name });
+}
+
+export function updateMedicine(db: SqliteDb, input: Partial<MedicineCatalogRow> & { id?: number; name?: string }): MedicineCatalogRow {
+    const id = requireId(input?.id);
+    const name = normalizeName(input?.name);
+    const defaults = defaultRxFields(input);
+    return updateNamed(db, 'medicine_catalog', id, { name, ...defaults }) as MedicineCatalogRow;
+}
+
+export function retireCondition(db: SqliteDb, id: number): { id: number; active: number } {
+    return retireRow(db, 'condition_catalog', id);
+}
+
+export function retireMedicine(db: SqliteDb, id: number): { id: number; active: number } {
+    return retireRow(db, 'medicine_catalog', id);
+}
+
+export function replaceConditionMedPresets(
+    db: SqliteDb,
+    input: { conditionId?: number; lines?: Array<Partial<PrescriptionLine>> }
+): PrescriptionLine[] {
+    const conditionId = requireId(input?.conditionId);
+    const condition = db.prepare('SELECT id FROM condition_catalog WHERE id = ?').get(conditionId);
+    if (!condition) throw new Error('CONDITION_NOT_FOUND');
+
+    const lines = Array.isArray(input?.lines) ? input.lines : [];
+    const run = db.transaction(() => {
+        db.prepare('DELETE FROM condition_med_presets WHERE condition_id = ?').run(conditionId);
+        const insert = db.prepare(`
+            INSERT INTO condition_med_presets (
+                condition_id, sort_order, medicine_id, medicine, form, dosage, route, frequency, duration, instruction
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `);
+        lines.forEach((line, index) => {
+            const rx = resolvePresetLine(db, line);
+            insert.run(
+                conditionId,
+                index,
+                rx.medicine_id || null,
+                rx.medicine,
+                rx.form,
+                rx.dosage,
+                rx.route,
+                rx.frequency,
+                rx.duration,
+                rx.instruction
+            );
+        });
+        return getConditionMedPresets(db, conditionId);
+    });
+    return typeof (run as any).immediate === 'function' ? (run as any).immediate() : run();
+}
+
+function searchActive(db: SqliteDb, table: 'condition_catalog' | 'medicine_catalog', query?: string, limit?: number) {
+    const capped = capLimit(limit);
+    const term = String(query || '').trim().slice(0, CATALOG_QUERY_MAX);
+    if (!term) {
+        return db.prepare(`SELECT * FROM ${table} WHERE active = 1 ORDER BY name COLLATE NOCASE LIMIT ?`).all(capped);
+    }
+    const contains = likeContains(term);
+    const prefix = likePrefix(term);
+    return db.prepare(`
+        SELECT * FROM ${table}
+        WHERE active = 1 AND name LIKE ? ESCAPE '\\'
+        ORDER BY CASE WHEN name LIKE ? ESCAPE '\\' THEN 0 ELSE 1 END, name COLLATE NOCASE
+        LIMIT ?
+    `).all(contains, prefix, capped);
+}
+
+function listCatalog(db: SqliteDb, table: 'condition_catalog' | 'medicine_catalog', includeRetired: boolean) {
+    if (includeRetired) {
+        return db.prepare(`SELECT * FROM ${table} ORDER BY active DESC, name COLLATE NOCASE`).all();
+    }
+    return db.prepare(`SELECT * FROM ${table} WHERE active = 1 ORDER BY name COLLATE NOCASE`).all();
+}
+
+function insertNamed(db: SqliteDb, table: 'condition_catalog' | 'medicine_catalog', fields: CatalogWriteFields) {
+    try {
+        if (table === 'condition_catalog') {
+            const result = db.prepare(`
+                INSERT INTO condition_catalog (name, active, created_at, updated_at)
+                VALUES (?, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+            `).run(fields.name);
+            return db.prepare('SELECT * FROM condition_catalog WHERE id = ?').get(Number(result.lastInsertRowid));
+        }
+        const result = db.prepare(`
+            INSERT INTO medicine_catalog (
+                name, form, dosage, route, frequency, duration, instruction, active, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+        `).run(fields.name, fields.form, fields.dosage, fields.route, fields.frequency, fields.duration, fields.instruction);
+        return db.prepare('SELECT * FROM medicine_catalog WHERE id = ?').get(Number(result.lastInsertRowid));
+    } catch (error) {
+        throw mapConstraint(error);
+    }
+}
+
+function updateNamed(db: SqliteDb, table: 'condition_catalog' | 'medicine_catalog', id: number, fields: CatalogWriteFields) {
+    const existing = db.prepare(`SELECT * FROM ${table} WHERE id = ?`).get(id);
+    if (!existing) throw new Error('CATALOG_NOT_FOUND');
+    try {
+        if (table === 'condition_catalog') {
+            db.prepare(`
+                UPDATE condition_catalog SET name = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?
+            `).run(fields.name, id);
+        } else {
+            db.prepare(`
+                UPDATE medicine_catalog
+                SET name = ?, form = ?, dosage = ?, route = ?, frequency = ?, duration = ?, instruction = ?,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+            `).run(fields.name, fields.form, fields.dosage, fields.route, fields.frequency, fields.duration, fields.instruction, id);
+        }
+        return db.prepare(`SELECT * FROM ${table} WHERE id = ?`).get(id);
+    } catch (error) {
+        throw mapConstraint(error);
+    }
+}
+
+function retireRow(db: SqliteDb, table: 'condition_catalog' | 'medicine_catalog', id: number) {
+    const numericId = requireId(id);
+    const existing = db.prepare(`SELECT id FROM ${table} WHERE id = ?`).get(numericId);
+    if (!existing) throw new Error('CATALOG_NOT_FOUND');
+    db.prepare(`UPDATE ${table} SET active = 0, updated_at = CURRENT_TIMESTAMP WHERE id = ?`).run(numericId);
+    return { id: numericId, active: 0 };
+}
+
+function resolvePresetLine(db: SqliteDb, line: Partial<PrescriptionLine>): PrescriptionLine {
+    let medicineId = line.medicine_id != null ? Number(line.medicine_id) : null;
+    let catalog: MedicineCatalogRow | undefined;
+    if (medicineId && Number.isInteger(medicineId)) {
+        catalog = db.prepare('SELECT * FROM medicine_catalog WHERE id = ?').get(medicineId);
+    }
+    const medicine = normalizeOptionalName(line.medicine) || catalog?.name || '';
+    if (!medicine) throw new Error('NAME_REQUIRED');
+    const defaults = catalog ? defaultRxFields(catalog) : defaultRxFields(line);
+    return {
+        medicine_id: catalog?.id || medicineId || null,
+        medicine,
+        form: line.form || defaults.form,
+        dosage: line.dosage ?? defaults.dosage,
+        route: line.route || defaults.route,
+        frequency: line.frequency || defaults.frequency,
+        duration: line.duration || defaults.duration,
+        instruction: line.instruction || defaults.instruction
+    };
+}
+
+function toRxLine(row: any): PrescriptionLine {
+    const defaults = defaultRxFields(row);
+    return {
+        medicine_id: row.medicine_id || null,
+        medicine: row.medicine,
+        form: row.form || defaults.form,
+        dosage: row.dosage ?? defaults.dosage,
+        route: row.route || defaults.route,
+        frequency: row.frequency || defaults.frequency,
+        duration: row.duration || defaults.duration,
+        instruction: row.instruction || defaults.instruction
+    };
+}
+
+function defaultRxFields(input: Partial<MedicineCatalogRow> | Partial<PrescriptionLine> = {}): Omit<PrescriptionLine, 'medicine' | 'medicine_id'> {
+    const instruction = (input as any).instruction || (input as any).instructions || 'After Food';
+    return {
+        form: (input as any).form || 'Tab',
+        dosage: (input as any).dosage || '',
+        route: (input as any).route || 'Oral',
+        frequency: (input as any).frequency || '1-0-1',
+        duration: (input as any).duration || '3 days',
+        instruction
+    };
+}
+
+function normalizeName(value: unknown): string {
+    const name = normalizeOptionalName(value);
+    if (!name) throw new Error('NAME_REQUIRED');
+    return name;
+}
+
+function normalizeOptionalName(value: unknown): string {
+    return String(value || '').trim().replace(/\s+/g, ' ').slice(0, CATALOG_QUERY_MAX);
+}
+
+function requireId(value: unknown): number {
+    const id = Number(value);
+    if (!Number.isInteger(id) || id <= 0) throw new Error('CATALOG_NOT_FOUND');
+    return id;
+}
+
+function capLimit(limit?: number): number {
+    const parsed = Number(limit);
+    if (!Number.isInteger(parsed) || parsed <= 0) return CATALOG_SEARCH_LIMIT;
+    return Math.min(parsed, CATALOG_SEARCH_LIMIT_MAX);
+}
+
+function likeContains(term: string): string {
+    return `%${escapeLike(term)}%`;
+}
+
+function likePrefix(term: string): string {
+    return `${escapeLike(term)}%`;
+}
+
+function escapeLike(term: string): string {
+    return term.replace(/([%_\\])/g, '\\$1');
+}
+
+function mapConstraint(error: unknown): Error {
+    const message = String((error as Error)?.message || error || '');
+    if (/UNIQUE|constraint/i.test(message)) return new Error('DUPLICATE_ACTIVE_NAME');
+    if (error instanceof Error) return error;
+    return new Error(message || 'CATALOG_WRITE_FAILED');
+}

--- a/desktop/src/main/ipc-db-args.spec.ts
+++ b/desktop/src/main/ipc-db-args.spec.ts
@@ -50,6 +50,10 @@ describe('IPC DatabaseService argument unpacking', () => {
     it('leaves read methods unchanged', () => {
         expect(resolveDbMethodArgs('getQueue', [], 7)).toEqual([]);
         expect(resolveDbMethodArgs('getPatients', [''], 7)).toEqual(['']);
+        expect(resolveDbMethodArgs('searchConditions', ['flu'], 7)).toEqual(['flu']);
+        expect(resolveDbMethodArgs('createCondition', [{ name: 'URI' }], 7)).toEqual([{ name: 'URI' }]);
+        expect(resolveDbMethodArgs('replaceConditionMedPresets', [{ conditionId: 1, lines: [] }], 7))
+            .toEqual([{ conditionId: 1, lines: [] }]);
     });
 
     it('does not bind a non-object payload as patient_id', () => {

--- a/desktop/src/main/linuxFuseGuard.spec.ts
+++ b/desktop/src/main/linuxFuseGuard.spec.ts
@@ -15,6 +15,7 @@ describe('Linux FUSE / .deb clinic path', () => {
         expect(message).toContain('sudo apt install ./nalamdesk-desktop_0.0.8_amd64.deb');
         expect(message).toMatch(/Do not extract the AppImage squashfs/i);
         expect(linuxClinicInstallInstructions('0.0.8')).toContain('Primary package: nalamdesk-desktop_0.0.8_amd64.deb');
+        expect(linuxClinicInstallInstructions('0.0.8')).toContain('In-app upgrades use the AppImage');
         expect(linuxClinicInstallInstructions('0.0.8')).not.toMatch(/unsquashfs|--appimage-extract-and-run/i);
     });
 

--- a/desktop/src/main/linuxFuseGuard.ts
+++ b/desktop/src/main/linuxFuseGuard.ts
@@ -50,6 +50,9 @@ export function linuxClinicInstallInstructions(version: string): string {
         '',
         'The AppImage is a secondary artifact and requires FUSE 2 (libfuse.so.2).',
         'If the AppImage does not start, install the .deb — do not extract the squashfs.',
+        '',
+        'In-app upgrades use the AppImage (electron-updater). Clinic first-install stays the .deb.',
+        'If the update feed has no AppImage, open the download page for a new package — there is no apt repo.',
         ''
     ].join('\n');
 }

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow, ipcMain, clipboard, shell, dialog } from 'electron'
 import * as path from 'path';
 import { autoUpdater } from 'electron-updater';
 import log from 'electron-log';
-import { bindUpdateIpc, createUpdateService } from './updates/updateService';
+import { bindUpdateIpc, createUpdateService, type UpdaterPort } from './updates/updateService';
 
 import { preferLinuxGnomeLibsecret } from './linuxKeyring';
 import { loadAppVersionInfo } from './appVersionInfo';
@@ -116,7 +116,7 @@ ipcMain.handle('utils:getRuntimeInfo', () => ({
 ipcMain.handle('app:getVersion', () => loadAppVersionInfo(app, isDev));
 
 const updateService = createUpdateService({
-        updater: autoUpdater as any,
+        updater: autoUpdater as unknown as UpdaterPort,
     isPackaged: app.isPackaged,
     env: process.env,
     platform: process.platform,

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow, ipcMain, clipboard, shell, dialog } from 'electron'
 import * as path from 'path';
 import { autoUpdater } from 'electron-updater';
 import log from 'electron-log';
+import { bindUpdateIpc, createUpdateService } from './updates/updateService';
 
 import { preferLinuxGnomeLibsecret } from './linuxKeyring';
 import { loadAppVersionInfo } from './appVersionInfo';
@@ -113,6 +114,23 @@ ipcMain.handle('utils:getRuntimeInfo', () => ({
 }));
 
 ipcMain.handle('app:getVersion', () => loadAppVersionInfo(app, isDev));
+
+const updateService = createUpdateService({
+        updater: autoUpdater as any,
+    isPackaged: app.isPackaged,
+    env: process.env,
+    platform: process.platform,
+    isAppImage: Boolean(process.env['APPIMAGE']),
+    getVersion: () => app.getVersion(),
+    send: (_channel, payload) => {
+        if (mainWindow && !mainWindow.isDestroyed()) {
+            mainWindow.webContents.send('updates:event', payload);
+        }
+    },
+    openExternal: (url) => shell.openExternal(url)
+});
+bindUpdateIpc(ipcMain, updateService);
+autoUpdater.logger = log;
 
 // Services
 const securityService = new SecurityService(new ElectronSafeStorageDeviceKeyStore());
@@ -821,6 +839,62 @@ handleDb('db:saveAppointment', (_, appt) => {
     const user = sessionService.getUser();
     if (!user) throw new Error('Unauthorized');
     return databaseService.saveAppointment(appt);
+});
+
+function requireCatalogSession(roles: string[]) {
+    const user = sessionService.getUser();
+    if (!user) throw new Error('Unauthorized');
+    if (!roles.includes(user.role)) throw new Error('Forbidden');
+    return user;
+}
+
+handleDb('db:searchConditions', (_, query, limit) => {
+    requireCatalogSession(['doctor', 'admin']);
+    return databaseService.searchConditions(query, limit);
+});
+handleDb('db:searchMedicines', (_, query, limit) => {
+    requireCatalogSession(['doctor', 'admin']);
+    return databaseService.searchMedicines(query, limit);
+});
+handleDb('db:createCondition', (_, input) => {
+    requireCatalogSession(['doctor', 'admin']);
+    return databaseService.createCondition(input);
+});
+handleDb('db:createMedicine', (_, input) => {
+    requireCatalogSession(['doctor', 'admin']);
+    return databaseService.createMedicine(input);
+});
+handleDb('db:getConditionMedPresets', (_, conditionId) => {
+    requireCatalogSession(['doctor', 'admin']);
+    return databaseService.getConditionMedPresets(conditionId);
+});
+handleDb('db:listConditions', (_, includeRetired) => {
+    requireCatalogSession(['admin']);
+    return databaseService.listConditions(includeRetired);
+});
+handleDb('db:listMedicines', (_, includeRetired) => {
+    requireCatalogSession(['admin']);
+    return databaseService.listMedicines(includeRetired);
+});
+handleDb('db:updateCondition', (_, input) => {
+    requireCatalogSession(['admin']);
+    return databaseService.updateCondition(input);
+});
+handleDb('db:updateMedicine', (_, input) => {
+    requireCatalogSession(['admin']);
+    return databaseService.updateMedicine(input);
+});
+handleDb('db:retireCondition', (_, id) => {
+    requireCatalogSession(['admin']);
+    return databaseService.retireCondition(id);
+});
+handleDb('db:retireMedicine', (_, id) => {
+    requireCatalogSession(['admin']);
+    return databaseService.retireMedicine(id);
+});
+handleDb('db:replaceConditionMedPresets', (_, input) => {
+    requireCatalogSession(['admin']);
+    return databaseService.replaceConditionMedPresets(input);
 });
 
 // Drive IPC Handlers

--- a/desktop/src/main/preload.spec.ts
+++ b/desktop/src/main/preload.spec.ts
@@ -49,11 +49,28 @@ describe('preload bridge surface', () => {
 
     it('exposes catalog search/create and updates IPC', async () => {
         await api.db.searchConditions('flu');
+        await api.db.searchMedicines('para');
+        await api.db.createCondition({ name: 'URI' });
         await api.db.createMedicine({ name: 'Paracetamol' });
+        await api.db.getConditionMedPresets(4);
+        await api.db.listConditions(true);
+        await api.db.listMedicines(false);
+        await api.db.updateCondition({ id: 1, name: 'URI' });
+        await api.db.updateMedicine({ id: 2, name: 'Paracetamol' });
+        await api.db.retireCondition(1);
+        await api.db.retireMedicine(2);
+        await api.db.replaceConditionMedPresets({ conditionId: 1, lines: [] });
         await api.updates.check({ source: 'manual' });
+        await api.updates.download();
+        await api.updates.install();
+        await api.updates.cancel();
+        await api.updates.getStatus();
+        const off = api.updates.onEvent(() => undefined);
+        off();
         expect(electron.invoke).toHaveBeenCalledWith('db:searchConditions', 'flu', undefined);
         expect(electron.invoke).toHaveBeenCalledWith('db:createMedicine', { name: 'Paracetamol' });
         expect(electron.invoke).toHaveBeenCalledWith('updates:check', { source: 'manual' });
-        expect(api.updates.onEvent).toEqual(expect.any(Function));
+        expect(electron.invoke).toHaveBeenCalledWith('updates:download');
+        expect(electron.on).toHaveBeenCalledWith('updates:event', expect.any(Function));
     });
 });

--- a/desktop/src/main/preload.spec.ts
+++ b/desktop/src/main/preload.spec.ts
@@ -3,13 +3,15 @@ import { beforeAll, describe, expect, it, vi } from 'vitest';
 const electron = vi.hoisted(() => ({
     exposeInMainWorld: vi.fn(),
     invoke: vi.fn(),
-    on: vi.fn()
+    on: vi.fn(),
+    removeListener: vi.fn()
 }));
 
 vi.mock('electron', () => ({
     contextBridge: { exposeInMainWorld: electron.exposeInMainWorld },
-    ipcRenderer: { invoke: electron.invoke, on: electron.on }
+    ipcRenderer: { invoke: electron.invoke, on: electron.on, removeListener: electron.removeListener }
 }));
+
 
 describe('preload bridge surface', () => {
     let api: any;
@@ -43,5 +45,15 @@ describe('preload bridge surface', () => {
         expect(electron.invoke).toHaveBeenCalledWith('db:addToQueue', { patientId: 42, priority: 2 });
         expect(electron.invoke).toHaveBeenCalledWith('db:updateQueueStatus', { id: 9, status: 'waiting' });
         expect(electron.invoke).toHaveBeenCalledWith('db:removeFromQueue', 9);
+    });
+
+    it('exposes catalog search/create and updates IPC', async () => {
+        await api.db.searchConditions('flu');
+        await api.db.createMedicine({ name: 'Paracetamol' });
+        await api.updates.check({ source: 'manual' });
+        expect(electron.invoke).toHaveBeenCalledWith('db:searchConditions', 'flu', undefined);
+        expect(electron.invoke).toHaveBeenCalledWith('db:createMedicine', { name: 'Paracetamol' });
+        expect(electron.invoke).toHaveBeenCalledWith('updates:check', { source: 'manual' });
+        expect(api.updates.onEvent).toEqual(expect.any(Function));
     });
 });

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -63,7 +63,19 @@ contextBridge.exposeInMainWorld('electron', {
         updateAppointmentRequestStatus: (data: { id: string, status: string }) => ipcRenderer.invoke('db:updateAppointmentRequestStatus', data),
         // Appointments
         getAppointments: (date: string) => ipcRenderer.invoke('db:getAppointments', date),
-        saveAppointment: (appt: any) => ipcRenderer.invoke('db:saveAppointment', appt)
+        saveAppointment: (appt: any) => ipcRenderer.invoke('db:saveAppointment', appt),
+        searchConditions: (query: string, limit?: number) => ipcRenderer.invoke('db:searchConditions', query, limit),
+        searchMedicines: (query: string, limit?: number) => ipcRenderer.invoke('db:searchMedicines', query, limit),
+        createCondition: (input: any) => ipcRenderer.invoke('db:createCondition', input),
+        createMedicine: (input: any) => ipcRenderer.invoke('db:createMedicine', input),
+        getConditionMedPresets: (conditionId: number) => ipcRenderer.invoke('db:getConditionMedPresets', conditionId),
+        listConditions: (includeRetired?: boolean) => ipcRenderer.invoke('db:listConditions', includeRetired),
+        listMedicines: (includeRetired?: boolean) => ipcRenderer.invoke('db:listMedicines', includeRetired),
+        updateCondition: (input: any) => ipcRenderer.invoke('db:updateCondition', input),
+        updateMedicine: (input: any) => ipcRenderer.invoke('db:updateMedicine', input),
+        retireCondition: (id: number) => ipcRenderer.invoke('db:retireCondition', id),
+        retireMedicine: (id: number) => ipcRenderer.invoke('db:retireMedicine', id),
+        replaceConditionMedPresets: (input: any) => ipcRenderer.invoke('db:replaceConditionMedPresets', input)
     },
     drive: {
         isAuthenticated: () => ipcRenderer.invoke('drive:isAuthenticated'),
@@ -73,20 +85,16 @@ contextBridge.exposeInMainWorld('electron', {
         restore: (fileId: string) => ipcRenderer.invoke('drive:restore', fileId),
         listBackups: () => ipcRenderer.invoke('drive:listBackups')
     },
-    updater: {
-        checkForUpdates: () => ipcRenderer.invoke('updater:check'),
-        quitAndInstall: () => ipcRenderer.invoke('updater:quitAndInstall'),
-        onUpdateAvailable: (callback: (info: any) => void) => {
-            ipcRenderer.on('update-available', (_, info) => callback(info));
-        },
-        onUpdateDownloaded: (callback: (info: any) => void) => {
-            ipcRenderer.on('update-downloaded', (_, info) => callback(info));
-        },
-        onDownloadProgress: (callback: (progress: any) => void) => {
-            ipcRenderer.on('download-progress', (_, progress) => callback(progress));
-        },
-        onUpdateError: (callback: (err: any) => void) => {
-            ipcRenderer.on('update-error', (_, err) => callback(err));
+    updates: {
+        check: (opts?: { source?: 'startup' | 'manual' }) => ipcRenderer.invoke('updates:check', opts),
+        download: () => ipcRenderer.invoke('updates:download'),
+        install: () => ipcRenderer.invoke('updates:install'),
+        cancel: () => ipcRenderer.invoke('updates:cancel'),
+        getStatus: () => ipcRenderer.invoke('updates:status'),
+        onEvent: (callback: (status: any) => void) => {
+            const listener = (_event: unknown, status: any) => callback(status);
+            ipcRenderer.on('updates:event', listener);
+            return () => ipcRenderer.removeListener('updates:event', listener);
         }
     },
     cloud: {

--- a/desktop/src/main/schema/migrations.spec.ts
+++ b/desktop/src/main/schema/migrations.spec.ts
@@ -33,8 +33,8 @@ describe('Database Migrations', () => {
             });
         });
 
-        it('should have 8 migrations total', () => {
-            expect(MIGRATIONS).toHaveLength(8);
+        it('should have 9 migrations total', () => {
+            expect(MIGRATIONS).toHaveLength(9);
         });
     });
 
@@ -251,6 +251,37 @@ describe('Database Migrations', () => {
             expect(permissions).toContain('saveVisit');
             expect(permissions).toContain('beginConsultation');
             expect(permissions).toContain('beginNextConsultation');
+        });
+    });
+
+    describe('Migration v9 (Condition and medicine catalogs)', () => {
+        it('creates catalog tables, active-name uniqueness, and ordered presets', () => {
+            MIGRATIONS[8].up(mockDb);
+            const sql = executedSql.join('\n');
+            expect(sql).toContain('CREATE TABLE IF NOT EXISTS condition_catalog');
+            expect(sql).toContain('CREATE TABLE IF NOT EXISTS medicine_catalog');
+            expect(sql).toContain('CREATE TABLE IF NOT EXISTS condition_med_presets');
+            expect(sql).toContain('idx_condition_catalog_active_name');
+            expect(sql).toContain('idx_medicine_catalog_active_name');
+            expect(sql).toContain('WHERE active = 1');
+            expect(sql).toContain('instruction TEXT');
+        });
+
+        it('adds visit catalog permissions for doctors without dropping existing ones', () => {
+            const run = vi.fn();
+            mockDb.prepare = vi.fn().mockReturnValue({
+                run,
+                get: vi.fn().mockReturnValue({ permissions: JSON.stringify(['saveVisit']) }),
+                all: vi.fn()
+            });
+            MIGRATIONS[8].up(mockDb);
+            const [serializedPermissions, role] = run.mock.calls[0];
+            const permissions = JSON.parse(serializedPermissions);
+            expect(role).toBe('doctor');
+            expect(permissions).toContain('saveVisit');
+            expect(permissions).toContain('searchConditions');
+            expect(permissions).toContain('createMedicine');
+            expect(permissions).toContain('getConditionMedPresets');
         });
     });
 

--- a/desktop/src/main/schema/migrations.ts
+++ b/desktop/src/main/schema/migrations.ts
@@ -405,5 +405,65 @@ export const MIGRATIONS = [
                 );
             `);
         }
+    },
+    {
+        version: 9,
+        up: (db: any) => {
+            console.log('Running Migration v9 (Condition and medicine catalogs)...');
+            db.exec(`
+                CREATE TABLE IF NOT EXISTS condition_catalog (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL,
+                    active INTEGER NOT NULL DEFAULT 1,
+                    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+                );
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_condition_catalog_active_name
+                    ON condition_catalog(name COLLATE NOCASE) WHERE active = 1;
+
+                CREATE TABLE IF NOT EXISTS medicine_catalog (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL,
+                    form TEXT,
+                    dosage TEXT,
+                    route TEXT,
+                    frequency TEXT,
+                    duration TEXT,
+                    instruction TEXT,
+                    active INTEGER NOT NULL DEFAULT 1,
+                    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+                );
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_medicine_catalog_active_name
+                    ON medicine_catalog(name COLLATE NOCASE) WHERE active = 1;
+
+                CREATE TABLE IF NOT EXISTS condition_med_presets (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    condition_id INTEGER NOT NULL,
+                    sort_order INTEGER NOT NULL DEFAULT 0,
+                    medicine_id INTEGER,
+                    medicine TEXT NOT NULL,
+                    form TEXT,
+                    dosage TEXT,
+                    route TEXT,
+                    frequency TEXT,
+                    duration TEXT,
+                    instruction TEXT,
+                    FOREIGN KEY(condition_id) REFERENCES condition_catalog(id) ON DELETE CASCADE,
+                    FOREIGN KEY(medicine_id) REFERENCES medicine_catalog(id)
+                );
+                CREATE INDEX IF NOT EXISTS idx_condition_med_presets_condition
+                    ON condition_med_presets(condition_id, sort_order);
+            `);
+
+            const doctor = db.prepare('SELECT permissions FROM roles WHERE name = ?').get('doctor');
+            if (doctor?.permissions) {
+                const permissions = new Set<string>(JSON.parse(doctor.permissions));
+                ['searchConditions', 'searchMedicines', 'createCondition', 'createMedicine', 'getConditionMedPresets']
+                    .forEach(permission => permissions.add(permission));
+                db.prepare('UPDATE roles SET permissions = ? WHERE name = ?')
+                    .run(JSON.stringify([...permissions]), 'doctor');
+            }
+        }
     }
 ];

--- a/desktop/src/main/services/CredentialRotationService.integration.spec.ts
+++ b/desktop/src/main/services/CredentialRotationService.integration.spec.ts
@@ -90,7 +90,7 @@ describe.skipIf(!process.versions.electron)('CredentialRotationService SQLCipher
         expect(security.getDb().prepare('SELECT value FROM preserved_clinic_data').get())
             .toEqual({ value: 'preserved' });
         expect(await database.validateUser('admin', 'admin-current')).toMatchObject({ success: true });
-        expect(security.getDb().pragma('user_version', { simple: true })).toBe(8);
+        expect(security.getDb().pragma('user_version', { simple: true })).toBe(9);
     });
 
     it.each(['after-prepare', 'after-apply'] as CredentialRotationStep[])(

--- a/desktop/src/main/services/DatabaseService.ts
+++ b/desktop/src/main/services/DatabaseService.ts
@@ -1,4 +1,5 @@
 import { MIGRATIONS } from '../schema/migrations';
+import * as catalog from '../catalog/catalogStore';
 
 export class DatabaseService {
     private db: any;
@@ -1011,6 +1012,54 @@ export class DatabaseService {
                 VALUES (?, ?, ?, ?, 'CONFIRMED')
             `).run(appt.patient_id, appt.date, appt.time, appt.reason);
         }
+    }
+
+    searchConditions(query?: string, limit?: number) {
+        return catalog.searchConditions(this.db, query, limit);
+    }
+
+    searchMedicines(query?: string, limit?: number) {
+        return catalog.searchMedicines(this.db, query, limit);
+    }
+
+    createCondition(input: any) {
+        return catalog.createCondition(this.db, input);
+    }
+
+    createMedicine(input: any) {
+        return catalog.createMedicine(this.db, input);
+    }
+
+    getConditionMedPresets(conditionId: number) {
+        return catalog.getConditionMedPresets(this.db, conditionId);
+    }
+
+    listConditions(includeRetired = false) {
+        return catalog.listConditions(this.db, includeRetired);
+    }
+
+    listMedicines(includeRetired = false) {
+        return catalog.listMedicines(this.db, includeRetired);
+    }
+
+    updateCondition(input: any) {
+        return catalog.updateCondition(this.db, input);
+    }
+
+    updateMedicine(input: any) {
+        return catalog.updateMedicine(this.db, input);
+    }
+
+    retireCondition(id: number) {
+        return catalog.retireCondition(this.db, id);
+    }
+
+    retireMedicine(id: number) {
+        return catalog.retireMedicine(this.db, id);
+    }
+
+    replaceConditionMedPresets(input: any) {
+        return catalog.replaceConditionMedPresets(this.db, input);
     }
 
     logStats() {

--- a/desktop/src/main/services/EncounterIntegrity.spec.ts
+++ b/desktop/src/main/services/EncounterIntegrity.spec.ts
@@ -344,7 +344,7 @@ describe('migration v7 compatibility', () => {
             expect(migrated.status).toBe('finished');
             expect(migrated.started_at).toBeTruthy();
             expect(migrated.completed_at).toBeTruthy();
-            expect(db.pragma('user_version', { simple: true })).toBe(8);
+            expect(db.pragma('user_version', { simple: true })).toBe(9);
         } finally {
             db.close();
         }
@@ -377,7 +377,7 @@ describe('migration v7 compatibility', () => {
 
             await expect(service.migrate()).resolves.toBeUndefined();
             expect(db.prepare('SELECT count(*) count FROM encounter_requests').get().count).toBe(0);
-            expect(db.pragma('user_version', { simple: true })).toBe(8);
+            expect(db.pragma('user_version', { simple: true })).toBe(9);
         } finally {
             db.close();
         }

--- a/desktop/src/main/updates/updateFeed.spec.ts
+++ b/desktop/src/main/updates/updateFeed.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+    feedHasAppImage,
+    formatReleaseNotes,
+    isNewerVersion,
+    plainUpdateError,
+    resolveOsApplyPath,
+    resolveUpdateFeedConfig,
+    signatureClaim,
+    toElectronUpdaterOptions
+} from './updateFeed';
+
+describe('update feed resolver', () => {
+    it('disables updates when no generic feed URL is set', () => {
+        expect(resolveUpdateFeedConfig({})).toBeNull();
+        expect(resolveUpdateFeedConfig({ NALAMDESK_UPDATE_PROVIDER: 'generic' })).toBeNull();
+    });
+
+    it('uses the documented generic feed URL without GitHub Releases', () => {
+        const config = resolveUpdateFeedConfig({
+            NALAMDESK_UPDATE_FEED_URL: 'https://updates.example.clinic/nalamdesk/'
+        });
+        expect(config).toEqual({
+            provider: 'generic',
+            url: 'https://updates.example.clinic/nalamdesk',
+            signatureMode: 'feed-checksum',
+            downloadPageUrl: 'https://github.com/sankara-sabapathy/nalamdesk'
+        });
+        expect(toElectronUpdaterOptions(config!)).toEqual({
+            provider: 'generic',
+            url: 'https://updates.example.clinic/nalamdesk'
+        });
+        expect(signatureClaim(config!.signatureMode).verifiedSignature).toBe(false);
+    });
+
+    it('leaves a github provider seam without rewriting IPC', () => {
+        const config = resolveUpdateFeedConfig({
+            NALAMDESK_UPDATE_PROVIDER: 'github',
+            NALAMDESK_UPDATE_RELEASE_SIGNED: '1',
+            NALAMDESK_UPDATE_DOWNLOAD_PAGE: 'https://clinic.example/download'
+        });
+        expect(config?.provider).toBe('github');
+        expect(toElectronUpdaterOptions(config!)).toEqual({
+            provider: 'github',
+            owner: 'sankara-sabapathy',
+            repo: 'nalamdesk'
+        });
+        expect(signatureClaim(config!.signatureMode).verifiedSignature).toBe(true);
+    });
+});
+
+describe('version compare and OS apply path', () => {
+    it('detects a newer feed version', () => {
+        expect(isNewerVersion('0.0.9', '0.0.8')).toBe(true);
+        expect(isNewerVersion('0.0.8', '0.0.8')).toBe(false);
+        expect(isNewerVersion('0.0.7', '0.0.8')).toBe(false);
+    });
+
+    it('applies Windows NSIS, macOS DMG, and Linux AppImage in-app', () => {
+        expect(resolveOsApplyPath({ platform: 'win32', isAppImage: false, feedHasAppImage: false }))
+            .toEqual({ mode: 'nsis', canQuitAndInstall: true });
+        expect(resolveOsApplyPath({ platform: 'darwin', isAppImage: false, feedHasAppImage: false }))
+            .toEqual({ mode: 'dmg', canQuitAndInstall: true });
+        expect(resolveOsApplyPath({ platform: 'linux', isAppImage: true, feedHasAppImage: true }))
+            .toEqual({ mode: 'appimage-updater', canQuitAndInstall: true });
+    });
+
+    it('falls back to the download page for Linux .deb or a missing AppImage', () => {
+        expect(resolveOsApplyPath({ platform: 'linux', isAppImage: false, feedHasAppImage: true }).mode)
+            .toBe('open-download-page');
+        expect(resolveOsApplyPath({ platform: 'linux', isAppImage: true, feedHasAppImage: false }).mode)
+            .toBe('open-download-page');
+        expect(feedHasAppImage({ path: 'NalamDesk-0.0.9.AppImage' })).toBe(true);
+        expect(feedHasAppImage({ files: [{ url: 'nalamdesk-desktop_0.0.9_amd64.deb' }] })).toBe(false);
+    });
+});
+
+describe('plain update errors', () => {
+    it('maps offline and bad-feed failures without technical noise', () => {
+        expect(plainUpdateError(new Error('getaddrinfo ENOTFOUND updates.example'))).toMatch(/network/i);
+        expect(plainUpdateError(new Error('Cannot find channel latest.yml'))).toMatch(/feed/i);
+        expect(plainUpdateError(new Error('SHA512 checksum mismatch'))).toMatch(/checksum/i);
+        expect(formatReleaseNotes([{ note: 'Fix queue' }, { note: 'Rx typeahead' }])).toContain('Fix queue');
+    });
+});

--- a/desktop/src/main/updates/updateFeed.spec.ts
+++ b/desktop/src/main/updates/updateFeed.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
     feedHasAppImage,
     formatReleaseNotes,
+    hasInsecureUpdateArtifact,
     isNewerVersion,
     plainUpdateError,
     resolveOsApplyPath,
@@ -70,7 +71,7 @@ describe('update feed resolver', () => {
             owner: 'sankara-sabapathy',
             repo: 'nalamdesk'
         });
-        expect(signatureClaim(config!.signatureMode).verifiedSignature).toBe(true);
+        expect(signatureClaim(config!.signatureMode).verifiedSignature).toBe(false);
     });
 });
 
@@ -79,6 +80,9 @@ describe('version compare and OS apply path', () => {
         expect(isNewerVersion('0.0.9', '0.0.8')).toBe(true);
         expect(isNewerVersion('0.0.8', '0.0.8')).toBe(false);
         expect(isNewerVersion('0.0.7', '0.0.8')).toBe(false);
+        expect(isNewerVersion('1.0.0-rc.2', '1.0.0-rc.1')).toBe(true);
+        expect(isNewerVersion('1.0.0', '1.0.0-rc.1')).toBe(true);
+        expect(isNewerVersion('1.0.0-rc.1', '1.0.0')).toBe(false);
     });
 
     it('applies Windows NSIS, macOS DMG, and Linux AppImage in-app', () => {
@@ -97,6 +101,8 @@ describe('version compare and OS apply path', () => {
             .toBe('open-download-page');
         expect(feedHasAppImage({ path: 'NalamDesk-0.0.9.AppImage' })).toBe(true);
         expect(feedHasAppImage({ files: [{ url: 'nalamdesk-desktop_0.0.9_amd64.deb' }] })).toBe(false);
+        expect(hasInsecureUpdateArtifact({ path: 'NalamDesk-Setup-0.0.9.exe' })).toBe(false);
+        expect(hasInsecureUpdateArtifact({ files: [{ url: 'http://evil.example/nalamdesk.exe' }] })).toBe(true);
     });
 });
 

--- a/desktop/src/main/updates/updateFeed.spec.ts
+++ b/desktop/src/main/updates/updateFeed.spec.ts
@@ -102,7 +102,9 @@ describe('version compare and OS apply path', () => {
         expect(feedHasAppImage({ path: 'NalamDesk-0.0.9.AppImage' })).toBe(true);
         expect(feedHasAppImage({ files: [{ url: 'nalamdesk-desktop_0.0.9_amd64.deb' }] })).toBe(false);
         expect(hasInsecureUpdateArtifact({ path: 'NalamDesk-Setup-0.0.9.exe' })).toBe(false);
+        expect(hasInsecureUpdateArtifact({ files: [{ url: 'https://updates.example.clinic/nalamdesk.exe' }] })).toBe(false);
         expect(hasInsecureUpdateArtifact({ files: [{ url: 'http://evil.example/nalamdesk.exe' }] })).toBe(true);
+        expect(hasInsecureUpdateArtifact({ files: [{ url: 'http://127.0.0.1/nalamdesk.exe' }] })).toBe(true);
     });
 });
 

--- a/desktop/src/main/updates/updateFeed.spec.ts
+++ b/desktop/src/main/updates/updateFeed.spec.ts
@@ -33,6 +33,31 @@ describe('update feed resolver', () => {
         expect(signatureClaim(config!.signatureMode).verifiedSignature).toBe(false);
     });
 
+    it('rejects plaintext HTTP generic feeds except localhost', () => {
+        expect(resolveUpdateFeedConfig({
+            NALAMDESK_UPDATE_FEED_URL: 'http://updates.example.clinic/nalamdesk'
+        })).toBeNull();
+        expect(resolveUpdateFeedConfig({
+            NALAMDESK_UPDATE_FEED_URL: 'ftp://updates.example.clinic/nalamdesk'
+        })).toBeNull();
+        expect(resolveUpdateFeedConfig({
+            NALAMDESK_UPDATE_FEED_URL: 'not a url'
+        })).toBeNull();
+
+        const loopback = resolveUpdateFeedConfig({
+            NALAMDESK_UPDATE_FEED_URL: 'http://127.0.0.1:8080/nalamdesk/'
+        });
+        expect(loopback).toEqual({
+            provider: 'generic',
+            url: 'http://127.0.0.1:8080/nalamdesk',
+            signatureMode: 'feed-checksum',
+            downloadPageUrl: 'https://github.com/sankara-sabapathy/nalamdesk'
+        });
+        expect(resolveUpdateFeedConfig({
+            NALAMDESK_UPDATE_FEED_URL: 'http://localhost/nalamdesk'
+        })?.url).toBe('http://localhost/nalamdesk');
+    });
+
     it('leaves a github provider seam without rewriting IPC', () => {
         const config = resolveUpdateFeedConfig({
             NALAMDESK_UPDATE_PROVIDER: 'github',

--- a/desktop/src/main/updates/updateFeed.ts
+++ b/desktop/src/main/updates/updateFeed.ts
@@ -1,0 +1,144 @@
+/**
+ * In-app update feed configuration.
+ *
+ * Interim channel (this PR): generic provider. Ops hosts approved
+ * `latest*.yml` plus OS packages at `NALAMDESK_UPDATE_FEED_URL`.
+ * Feature CI PR zips / Actions artifacts are not an update channel.
+ *
+ * Later PR seam: set `NALAMDESK_UPDATE_PROVIDER=github` (and optional
+ * owner/repo). IPC and renderer UX stay the same — only this resolver
+ * and `toElectronUpdaterOptions()` change.
+ */
+
+export type UpdateProviderKind = 'generic' | 'github';
+export type SignatureMode = 'feed-checksum' | 'release-signed';
+export type OsApplyMode = 'nsis' | 'dmg' | 'appimage-updater' | 'open-download-page';
+
+export interface GenericUpdateFeed {
+    provider: 'generic';
+    url: string;
+    signatureMode: 'feed-checksum';
+    downloadPageUrl: string;
+}
+
+export interface GithubUpdateFeed {
+    provider: 'github';
+    owner: string;
+    repo: string;
+    signatureMode: SignatureMode;
+    downloadPageUrl: string;
+}
+
+export type UpdateFeedConfig = GenericUpdateFeed | GithubUpdateFeed;
+
+export const DEFAULT_UPDATE_DOWNLOAD_PAGE = 'https://github.com/sankara-sabapathy/nalamdesk';
+
+export function resolveUpdateFeedConfig(env: NodeJS.Dict<string> = process.env): UpdateFeedConfig | null {
+    const downloadPageUrl = trimSlash(env['NALAMDESK_UPDATE_DOWNLOAD_PAGE'] || DEFAULT_UPDATE_DOWNLOAD_PAGE);
+    const provider = (env['NALAMDESK_UPDATE_PROVIDER'] || 'generic').trim().toLowerCase();
+
+    if (provider === 'github') {
+        return {
+            provider: 'github',
+            owner: (env['NALAMDESK_UPDATE_GITHUB_OWNER'] || 'sankara-sabapathy').trim(),
+            repo: (env['NALAMDESK_UPDATE_GITHUB_REPO'] || 'nalamdesk').trim(),
+            signatureMode: env['NALAMDESK_UPDATE_RELEASE_SIGNED'] === '1' ? 'release-signed' : 'feed-checksum',
+            downloadPageUrl
+        };
+    }
+
+    const url = (env['NALAMDESK_UPDATE_FEED_URL'] || '').trim();
+    if (!url) return null;
+    return {
+        provider: 'generic',
+        url: trimSlash(url),
+        signatureMode: 'feed-checksum',
+        downloadPageUrl
+    };
+}
+
+export function toElectronUpdaterOptions(config: UpdateFeedConfig): Record<string, string> {
+    if (config.provider === 'github') {
+        return { provider: 'github', owner: config.owner, repo: config.repo };
+    }
+    return { provider: 'generic', url: config.url };
+}
+
+export function isNewerVersion(latest: string, current: string): boolean {
+    const next = parseVersion(latest);
+    const running = parseVersion(current);
+    for (let i = 0; i < 3; i++) {
+        if (next[i] > running[i]) return true;
+        if (next[i] < running[i]) return false;
+    }
+    return false;
+}
+
+export function feedHasAppImage(updateInfo: { files?: Array<{ url?: string }>; path?: string } | null | undefined): boolean {
+    const names = [updateInfo?.path || '', ...(updateInfo?.files || []).map((file) => file.url || '')];
+    return names.some((name) => /\.AppImage(\?|$)/i.test(name));
+}
+
+export function resolveOsApplyPath(input: {
+    platform: NodeJS.Platform | string;
+    isAppImage: boolean;
+    feedHasAppImage: boolean;
+}): { mode: OsApplyMode; canQuitAndInstall: boolean } {
+    if (input.platform === 'win32') return { mode: 'nsis', canQuitAndInstall: true };
+    if (input.platform === 'darwin') return { mode: 'dmg', canQuitAndInstall: true };
+    if (input.platform === 'linux' && input.isAppImage && input.feedHasAppImage) {
+        return { mode: 'appimage-updater', canQuitAndInstall: true };
+    }
+    return { mode: 'open-download-page', canQuitAndInstall: false };
+}
+
+export function signatureClaim(mode: SignatureMode): { verifiedSignature: boolean; integrityNote: string } {
+    if (mode === 'release-signed') {
+        return {
+            verifiedSignature: true,
+            integrityNote: 'This update is release-signed.'
+        };
+    }
+    return {
+        verifiedSignature: false,
+        integrityNote: 'This feed lists package checksums. NalamDesk does not claim full code-signature verification.'
+    };
+}
+
+export function plainUpdateError(error: unknown): string {
+    const message = String((error as Error)?.message || error || '');
+    if (/ENOTFOUND|ECONNREFUSED|ETIMEDOUT|ENETUNREACH|net::ERR|offline|getaddrinfo/i.test(message)) {
+        return 'Could not reach the update feed. Check the network and try again.';
+    }
+    if (/YAMLException|Cannot find channel|latest.*\.yml|status code 404|404 Not Found/i.test(message)) {
+        return 'The update feed is missing or invalid.';
+    }
+    if (/SHA512|checksum|code signature|not signed/i.test(message)) {
+        return 'The downloaded update did not match the feed checksum.';
+    }
+    if (/cancel/i.test(message)) {
+        return 'Update download cancelled.';
+    }
+    const trimmed = message.trim();
+    return trimmed || 'Update failed.';
+}
+
+export function formatReleaseNotes(notes: string | Array<{ note?: string }> | undefined): string {
+    if (!notes) return '';
+    if (typeof notes === 'string') return notes.trim();
+    return notes.map((item) => String(item?.note || '').trim()).filter(Boolean).join('\n');
+}
+
+function parseVersion(value: string): [number, number, number] {
+    const parts = String(value || '').replace(/^v/i, '').split(/[.-]/);
+    return [toInt(parts[0]), toInt(parts[1]), toInt(parts[2])];
+}
+
+function toInt(part: string | undefined): number {
+    const parsed = parseInt(part || '0', 10);
+    return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function trimSlash(url: string): string {
+    return url.replace(/\/+$/, '');
+}

--- a/desktop/src/main/updates/updateFeed.ts
+++ b/desktop/src/main/updates/updateFeed.ts
@@ -2,8 +2,9 @@
  * In-app update feed configuration.
  *
  * Interim channel (this PR): generic provider. Ops hosts approved
- * `latest*.yml` plus OS packages at `NALAMDESK_UPDATE_FEED_URL`.
- * Feature CI PR zips / Actions artifacts are not an update channel.
+ * `latest*.yml` plus OS packages at `NALAMDESK_UPDATE_FEED_URL` (HTTPS;
+ * HTTP is allowed only for localhost). Feature CI PR zips / Actions
+ * artifacts are not an update channel.
  *
  * Later PR seam: set `NALAMDESK_UPDATE_PROVIDER=github` (and optional
  * owner/repo). IPC and renderer UX stay the same — only this resolver
@@ -48,7 +49,7 @@ export function resolveUpdateFeedConfig(env: NodeJS.Dict<string> = process.env):
     }
 
     const url = (env['NALAMDESK_UPDATE_FEED_URL'] || '').trim();
-    if (!url) return null;
+    if (!url || !isAllowedGenericFeedUrl(url)) return null;
     return {
         provider: 'generic',
         url: trimSlash(url),
@@ -141,4 +142,17 @@ function toInt(part: string | undefined): number {
 
 function trimSlash(url: string): string {
     return url.replace(/\/+$/, '');
+}
+
+function isAllowedGenericFeedUrl(url: string): boolean {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        return false;
+    }
+    if (parsed.protocol === 'https:') return true;
+    if (parsed.protocol !== 'http:') return false;
+    const host = parsed.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+    return host === 'localhost' || host === '127.0.0.1' || host === '::1';
 }

--- a/desktop/src/main/updates/updateFeed.ts
+++ b/desktop/src/main/updates/updateFeed.ts
@@ -82,7 +82,7 @@ export function feedHasAppImage(updateInfo: { files?: Array<{ url?: string }>; p
 }
 
 export function resolveOsApplyPath(input: {
-    platform: NodeJS.Platform | string;
+    platform: string;
     isAppImage: boolean;
     feedHasAppImage: boolean;
 }): { mode: OsApplyMode; canQuitAndInstall: boolean } {
@@ -102,7 +102,7 @@ export function signatureClaim(_mode?: SignatureMode): { verifiedSignature: bool
 }
 
 export function plainUpdateError(error: unknown): string {
-    const message = String((error as Error)?.message || error || '');
+    const message = errorMessage(error);
     if (/ENOTFOUND|ECONNREFUSED|ETIMEDOUT|ENETUNREACH|net::ERR|offline|getaddrinfo/i.test(message)) {
         return 'Could not reach the update feed. Check the network and try again.';
     }
@@ -166,17 +166,28 @@ function parseSemVer(value: string): { core: [number, number, number]; pre: Arra
 }
 
 function isAbsoluteInsecureUrl(value: string): boolean {
-    if (!/^[a-z][a-z0-9+.-]*:/i.test(value)) return false;
-    return !isAllowedGenericFeedUrl(value);
+    try {
+        return !isAllowedGenericFeedUrl(new URL(value).href);
+    } catch {
+        return false;
+    }
 }
 
 function toInt(part: string | undefined): number {
-    const parsed = parseInt(part || '0', 10);
+    const parsed = Number.parseInt(part || '0', 10);
     return Number.isFinite(parsed) ? parsed : 0;
 }
 
 function trimSlash(url: string): string {
-    return url.replace(/\/+$/, '');
+    let end = url.length;
+    while (end > 0 && url.charAt(end - 1) === '/') end -= 1;
+    return url.slice(0, end);
+}
+
+function errorMessage(error: unknown): string {
+    if (error instanceof Error) return error.message;
+    if (typeof error === 'string') return error;
+    return '';
 }
 
 function isAllowedGenericFeedUrl(url: string): boolean {

--- a/desktop/src/main/updates/updateFeed.ts
+++ b/desktop/src/main/updates/updateFeed.ts
@@ -66,13 +66,14 @@ export function toElectronUpdaterOptions(config: UpdateFeedConfig): Record<strin
 }
 
 export function isNewerVersion(latest: string, current: string): boolean {
-    const next = parseVersion(latest);
-    const running = parseVersion(current);
-    for (let i = 0; i < 3; i++) {
-        if (next[i] > running[i]) return true;
-        if (next[i] < running[i]) return false;
-    }
-    return false;
+    return compareSemVer(latest, current) > 0;
+}
+
+export function hasInsecureUpdateArtifact(
+    updateInfo: { files?: Array<{ url?: string }>; path?: string } | null | undefined
+): boolean {
+    const names = [updateInfo?.path || '', ...(updateInfo?.files || []).map((file) => file.url || '')];
+    return names.some((name) => isAbsoluteInsecureUrl(name));
 }
 
 export function feedHasAppImage(updateInfo: { files?: Array<{ url?: string }>; path?: string } | null | undefined): boolean {
@@ -93,13 +94,7 @@ export function resolveOsApplyPath(input: {
     return { mode: 'open-download-page', canQuitAndInstall: false };
 }
 
-export function signatureClaim(mode: SignatureMode): { verifiedSignature: boolean; integrityNote: string } {
-    if (mode === 'release-signed') {
-        return {
-            verifiedSignature: true,
-            integrityNote: 'This update is release-signed.'
-        };
-    }
+export function signatureClaim(_mode?: SignatureMode): { verifiedSignature: boolean; integrityNote: string } {
     return {
         verifiedSignature: false,
         integrityNote: 'This feed lists package checksums. NalamDesk does not claim full code-signature verification.'
@@ -130,9 +125,49 @@ export function formatReleaseNotes(notes: string | Array<{ note?: string }> | un
     return notes.map((item) => String(item?.note || '').trim()).filter(Boolean).join('\n');
 }
 
-function parseVersion(value: string): [number, number, number] {
-    const parts = String(value || '').replace(/^v/i, '').split(/[.-]/);
-    return [toInt(parts[0]), toInt(parts[1]), toInt(parts[2])];
+function compareSemVer(latest: string, current: string): number {
+    const next = parseSemVer(latest);
+    const running = parseSemVer(current);
+    for (let i = 0; i < 3; i++) {
+        if (next.core[i] !== running.core[i]) return next.core[i] > running.core[i] ? 1 : -1;
+    }
+    if (next.pre.length === 0 && running.pre.length === 0) return 0;
+    if (next.pre.length === 0) return 1;
+    if (running.pre.length === 0) return -1;
+    return comparePrerelease(next.pre, running.pre);
+}
+
+function comparePrerelease(left: Array<string | number>, right: Array<string | number>): number {
+    const len = Math.max(left.length, right.length);
+    for (let i = 0; i < len; i++) {
+        if (i >= left.length) return -1;
+        if (i >= right.length) return 1;
+        const l = left[i];
+        const r = right[i];
+        if (l === r) continue;
+        if (typeof l === 'number' && typeof r === 'number') return l > r ? 1 : -1;
+        if (typeof l === 'number') return -1;
+        if (typeof r === 'number') return 1;
+        return String(l) > String(r) ? 1 : -1;
+    }
+    return 0;
+}
+
+function parseSemVer(value: string): { core: [number, number, number]; pre: Array<string | number> } {
+    const raw = String(value || '').replace(/^v/i, '').trim();
+    const dash = raw.indexOf('-');
+    const corePart = dash === -1 ? raw : raw.slice(0, dash);
+    const prePart = dash === -1 ? '' : raw.slice(dash + 1);
+    const coreNums = corePart.split('.');
+    const core: [number, number, number] = [toInt(coreNums[0]), toInt(coreNums[1]), toInt(coreNums[2])];
+    if (!prePart) return { core, pre: [] };
+    const pre = prePart.split('.').map((id) => (/^\d+$/.test(id) ? toInt(id) : id));
+    return { core, pre };
+}
+
+function isAbsoluteInsecureUrl(value: string): boolean {
+    if (!/^[a-z][a-z0-9+.-]*:/i.test(value)) return false;
+    return !isAllowedGenericFeedUrl(value);
 }
 
 function toInt(part: string | undefined): number {

--- a/desktop/src/main/updates/updateFeed.ts
+++ b/desktop/src/main/updates/updateFeed.ts
@@ -167,7 +167,7 @@ function parseSemVer(value: string): { core: [number, number, number]; pre: Arra
 
 function isAbsoluteInsecureUrl(value: string): boolean {
     try {
-        return !isAllowedGenericFeedUrl(new URL(value).href);
+        return new URL(value).protocol !== 'https:';
     } catch {
         return false;
     }

--- a/desktop/src/main/updates/updateService.spec.ts
+++ b/desktop/src/main/updates/updateService.spec.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from 'vitest';
+import { bindUpdateIpc, createUpdateService, type UpdaterPort } from './updateService';
+
+function mockUpdater(overrides: Partial<UpdaterPort> = {}): UpdaterPort {
+    const listeners = new Map<string, Array<(...args: any[]) => void>>();
+    return {
+        autoDownload: true,
+        autoInstallOnAppQuit: true,
+        setFeedURL: vi.fn(),
+        checkForUpdates: vi.fn(),
+        downloadUpdate: vi.fn(),
+        quitAndInstall: vi.fn(),
+        on: vi.fn((event: string, listener: (...args: any[]) => void) => {
+            const list = listeners.get(event) || [];
+            list.push(listener);
+            listeners.set(event, list);
+        }),
+        ...overrides
+    };
+}
+
+function createService(updater: UpdaterPort, extra: Record<string, unknown> = {}) {
+    const send = vi.fn();
+    const openExternal = vi.fn();
+    const service = createUpdateService({
+        updater,
+        isPackaged: true,
+        env: { NALAMDESK_UPDATE_FEED_URL: 'https://updates.example.clinic/nalamdesk' },
+        platform: 'win32',
+        isAppImage: false,
+        getVersion: () => '0.0.8',
+        send,
+        openExternal,
+        ...extra
+    } as any);
+    return { service, send, openExternal, updater };
+}
+
+describe('DesktopUpdateService', () => {
+    it('skips unpackaged / development builds', async () => {
+        const updater = mockUpdater();
+        const { service } = createService(updater, { isPackaged: false });
+        const status = await service.check({ source: 'startup' });
+        expect(status.state).toBe('skipped');
+        expect(status.reason).toBe('unpackaged');
+        expect(updater.checkForUpdates).not.toHaveBeenCalled();
+    });
+
+    it('reports an available update from a mocked feed', async () => {
+        const updater = mockUpdater({
+            checkForUpdates: vi.fn().mockResolvedValue({
+                updateInfo: {
+                    version: '0.0.9',
+                    releaseNotes: 'Queue fix',
+                    path: 'NalamDesk-Setup-0.0.9.exe'
+                }
+            })
+        });
+        const { service, send } = createService(updater);
+        const status = await service.check({ source: 'startup' });
+        expect(status.state).toBe('available');
+        expect(status.currentVersion).toBe('0.0.8');
+        expect(status.availableVersion).toBe('0.0.9');
+        expect(status.releaseNotes).toBe('Queue fix');
+        expect(status.canQuitAndInstall).toBe(true);
+        expect(status.verifiedSignature).toBe(false);
+        expect(status.integrityNote).not.toMatch(/verified signature|fully signed/i);
+        expect(updater.setFeedURL).toHaveBeenCalledWith({
+            provider: 'generic',
+            url: 'https://updates.example.clinic/nalamdesk'
+        });
+        expect(updater.autoDownload).toBe(false);
+        expect(send).toHaveBeenCalled();
+    });
+
+    it('reports up-to-date when the feed matches the running version', async () => {
+        const updater = mockUpdater({
+            checkForUpdates: vi.fn().mockResolvedValue({
+                updateInfo: { version: '0.0.8' }
+            })
+        });
+        const { service } = createService(updater);
+        const status = await service.check({ source: 'manual' });
+        expect(status.state).toBe('up-to-date');
+        expect(status.source).toBe('manual');
+    });
+
+    it('maps a download failure to a plain error and leaves status usable', async () => {
+        const updater = mockUpdater({
+            checkForUpdates: vi.fn().mockResolvedValue({
+                updateInfo: { version: '0.0.9', path: 'NalamDesk-Setup-0.0.9.exe' }
+            }),
+            downloadUpdate: vi.fn().mockRejectedValue(new Error('getaddrinfo ENOTFOUND updates.example.clinic'))
+        });
+        const { service } = createService(updater);
+        await service.check({ source: 'manual' });
+        const status = await service.download();
+        expect(status.state).toBe('error');
+        expect(status.error).toMatch(/network/i);
+        expect(service.getStatus().state).toBe('error');
+        expect(updater.quitAndInstall).not.toHaveBeenCalled();
+    });
+
+    it('opens the download page on Linux .deb instead of quitAndInstall', async () => {
+        const updater = mockUpdater({
+            checkForUpdates: vi.fn().mockResolvedValue({
+                updateInfo: { version: '0.0.9', path: 'nalamdesk-desktop_0.0.9_amd64.deb' }
+            })
+        });
+        const { service, openExternal } = createService(updater, {
+            platform: 'linux',
+            isAppImage: false
+        });
+        const available = await service.check({ source: 'manual' });
+        expect(available.applyMode).toBe('open-download-page');
+        expect(available.canQuitAndInstall).toBe(false);
+        await service.download();
+        expect(openExternal).toHaveBeenCalled();
+        expect(updater.downloadUpdate).not.toHaveBeenCalled();
+        expect(updater.quitAndInstall).not.toHaveBeenCalled();
+    });
+
+    it('cancels an in-flight download and keeps the app usable', async () => {
+        let finishDownload: (value?: unknown) => void = () => undefined;
+        const updater = mockUpdater({
+            checkForUpdates: vi.fn().mockResolvedValue({
+                updateInfo: { version: '0.0.9', path: 'NalamDesk-Setup-0.0.9.exe' }
+            }),
+            downloadUpdate: vi.fn().mockImplementation(() => new Promise((resolve) => {
+                finishDownload = resolve;
+            }))
+        });
+        const { service } = createService(updater);
+        await service.check({ source: 'manual' });
+        const downloading = service.download();
+        const cancelled = service.cancel();
+        expect(cancelled.state).toBe('available');
+        finishDownload();
+        const after = await downloading;
+        expect(after.state).toBe('available');
+        expect(after.error).toBeUndefined();
+    });
+
+    it('binds updates IPC without touching the vault', async () => {
+        const updater = mockUpdater({
+            checkForUpdates: vi.fn().mockResolvedValue({ updateInfo: { version: '0.0.8' } })
+        });
+        const { service } = createService(updater);
+        const handle = vi.fn();
+        bindUpdateIpc({ handle } as any, service);
+        expect(handle).toHaveBeenCalledWith('updates:check', expect.any(Function));
+        expect(handle).toHaveBeenCalledWith('updates:download', expect.any(Function));
+        expect(handle).toHaveBeenCalledWith('updates:install', expect.any(Function));
+        expect(handle).toHaveBeenCalledWith('updates:cancel', expect.any(Function));
+        expect(handle).toHaveBeenCalledWith('updates:status', expect.any(Function));
+    });
+});

--- a/desktop/src/main/updates/updateService.spec.ts
+++ b/desktop/src/main/updates/updateService.spec.ts
@@ -154,4 +154,32 @@ describe('DesktopUpdateService', () => {
         expect(handle).toHaveBeenCalledWith('updates:cancel', expect.any(Function));
         expect(handle).toHaveBeenCalledWith('updates:status', expect.any(Function));
     });
+
+    it('refuses download when the app is already up to date', async () => {
+        const updater = mockUpdater({
+            checkForUpdates: vi.fn().mockResolvedValue({ updateInfo: { version: '0.0.8' } })
+        });
+        const { service } = createService(updater);
+        await service.check({ source: 'manual' });
+        const status = await service.download();
+        expect(status.state).toBe('error');
+        expect(status.error).toMatch(/ready to download/i);
+        expect(updater.downloadUpdate).not.toHaveBeenCalled();
+    });
+
+    it('does not quitAndInstall until an update has downloaded', async () => {
+        const updater = mockUpdater({
+            checkForUpdates: vi.fn().mockResolvedValue({
+                updateInfo: { version: '0.0.9', path: 'NalamDesk-Setup-0.0.9.exe' }
+            }),
+            downloadUpdate: vi.fn().mockResolvedValue(undefined)
+        });
+        const { service } = createService(updater);
+        await service.check({ source: 'manual' });
+        await service.install();
+        expect(updater.quitAndInstall).not.toHaveBeenCalled();
+        await service.download();
+        await service.install();
+        expect(updater.quitAndInstall).toHaveBeenCalledWith(false, true);
+    });
 });

--- a/desktop/src/main/updates/updateService.spec.ts
+++ b/desktop/src/main/updates/updateService.spec.ts
@@ -182,4 +182,33 @@ describe('DesktopUpdateService', () => {
         await service.install();
         expect(updater.quitAndInstall).toHaveBeenCalledWith(false, true);
     });
+
+    it('skips when no feed is configured and ignores updater events until a download starts', async () => {
+        const updater = mockUpdater();
+        const { service, send } = createService(updater, { env: {} });
+        const skipped = await service.check({ source: 'startup' });
+        expect(skipped.state).toBe('skipped');
+        expect(skipped.reason).toBe('no-feed');
+        const progress = (updater.on as any).mock.calls.find((call: any[]) => call[0] === 'download-progress')[1];
+        const downloaded = (updater.on as any).mock.calls.find((call: any[]) => call[0] === 'update-downloaded')[1];
+        const errored = (updater.on as any).mock.calls.find((call: any[]) => call[0] === 'error')[1];
+        progress({ percent: 50 });
+        downloaded();
+        expect(service.getStatus().state).toBe('skipped');
+        errored(new Error('getaddrinfo ENOTFOUND x'));
+        expect(service.getStatus().state).toBe('error');
+        expect(send).toHaveBeenCalled();
+    });
+
+    it('rejects an insecure HTTP artifact URL from the feed', async () => {
+        const updater = mockUpdater({
+            checkForUpdates: vi.fn().mockResolvedValue({
+                updateInfo: { version: '0.0.9', files: [{ url: 'http://evil.example/nalamdesk.exe' }] }
+            })
+        });
+        const { service } = createService(updater);
+        const status = await service.check({ source: 'manual' });
+        expect(status.state).toBe('error');
+        expect(status.error).toMatch(/insecure HTTP/i);
+    });
 });

--- a/desktop/src/main/updates/updateService.ts
+++ b/desktop/src/main/updates/updateService.ts
@@ -1,0 +1,273 @@
+import type { IpcMain } from 'electron';
+import {
+    feedHasAppImage,
+    formatReleaseNotes,
+    isNewerVersion,
+    plainUpdateError,
+    resolveOsApplyPath,
+    resolveUpdateFeedConfig,
+    signatureClaim,
+    toElectronUpdaterOptions,
+    type OsApplyMode,
+    type SignatureMode,
+    type UpdateFeedConfig
+} from './updateFeed';
+
+export type UpdateCheckSource = 'startup' | 'manual';
+export type UpdateState =
+    | 'idle'
+    | 'skipped'
+    | 'checking'
+    | 'up-to-date'
+    | 'available'
+    | 'downloading'
+    | 'downloaded'
+    | 'error';
+
+export interface UpdateInfoLike {
+    version: string;
+    releaseNotes?: string | Array<{ note?: string }>;
+    files?: Array<{ url?: string }>;
+    path?: string;
+}
+
+export interface UpdaterPort {
+    autoDownload: boolean;
+    autoInstallOnAppQuit: boolean;
+    setFeedURL(options: unknown): void;
+    checkForUpdates(): Promise<{ updateInfo: UpdateInfoLike } | null>;
+    downloadUpdate(cancelToken?: CancelToken): Promise<unknown>;
+    quitAndInstall(isSilent?: boolean, isForceRunAfter?: boolean): void;
+    on(event: string, listener: (...args: any[]) => void): void;
+    logger?: unknown;
+}
+
+export interface CancelToken {
+    cancelled: boolean;
+    cancel(): void;
+}
+
+export interface UpdateStatus {
+    state: UpdateState;
+    source: UpdateCheckSource;
+    reason?: string;
+    currentVersion: string;
+    availableVersion?: string;
+    releaseNotes?: string;
+    percent?: number;
+    error?: string;
+    applyMode: OsApplyMode;
+    canQuitAndInstall: boolean;
+    downloadPageUrl?: string;
+    verifiedSignature: boolean;
+    integrityNote: string;
+    packaged: boolean;
+}
+
+export interface UpdateServiceDeps {
+    updater: UpdaterPort;
+    isPackaged: boolean;
+    env: NodeJS.Dict<string>;
+    platform: NodeJS.Platform | string;
+    isAppImage: boolean;
+    getVersion: () => string;
+    send: (channel: string, payload: UpdateStatus) => void;
+    openExternal: (url: string) => Promise<void> | void;
+}
+
+function createCancelToken(): CancelToken {
+    try {
+        const runtime = require('builder-util-runtime') as { CancellationToken: new () => CancelToken };
+        return new runtime.CancellationToken();
+    } catch {
+        const token: CancelToken = {
+            cancelled: false,
+            cancel() {
+                token.cancelled = true;
+            }
+        };
+        return token;
+    }
+}
+
+export class DesktopUpdateService {
+    private status: UpdateStatus;
+    private feed: UpdateFeedConfig | null;
+    private cancelToken: CancelToken | null = null;
+    private lastInfo: UpdateInfoLike | null = null;
+    private configured = false;
+
+    constructor(private readonly deps: UpdateServiceDeps) {
+        this.feed = resolveUpdateFeedConfig(deps.env);
+        this.status = this.baseStatus('idle');
+        this.wireUpdaterEvents();
+    }
+
+    getStatus(): UpdateStatus {
+        return { ...this.status };
+    }
+
+    async check(opts?: { source?: UpdateCheckSource }): Promise<UpdateStatus> {
+        const source = opts?.source || 'manual';
+        if (!this.deps.isPackaged) {
+            return this.publish(this.baseStatus('skipped', source, 'unpackaged'));
+        }
+        if (!this.feed) {
+            return this.publish(this.baseStatus('skipped', source, 'no-feed'));
+        }
+
+        this.configureUpdater();
+        this.publish({ ...this.baseStatus('checking', source) });
+        try {
+            const result = await this.deps.updater.checkForUpdates();
+            return this.applyCheckResult(result?.updateInfo, source);
+        } catch (error) {
+            return this.fail(source, error);
+        }
+    }
+
+    async download(): Promise<UpdateStatus> {
+        if (!this.deps.isPackaged || !this.feed) {
+            return this.check({ source: 'manual' });
+        }
+        if (this.status.state === 'available' && !this.status.canQuitAndInstall) {
+            const url = this.status.downloadPageUrl;
+            if (url) await this.deps.openExternal(url);
+            return this.getStatus();
+        }
+        if (!this.lastInfo) {
+            return this.fail('manual', new Error('No update is ready to download.'));
+        }
+
+        this.configureUpdater();
+        this.cancelToken = createCancelToken();
+        this.publish({ ...this.status, state: 'downloading', percent: 0, error: undefined });
+        try {
+            await this.deps.updater.downloadUpdate(this.cancelToken);
+            if (this.cancelToken.cancelled) {
+                return this.publish({ ...this.status, state: 'available', percent: undefined });
+            }
+            return this.publish({ ...this.status, state: 'downloaded', percent: 100 });
+        } catch (error) {
+            if (this.cancelToken?.cancelled) {
+                return this.publish({ ...this.status, state: 'available', percent: undefined, error: undefined });
+            }
+            return this.fail(this.status.source, error);
+        }
+    }
+
+    async install(): Promise<UpdateStatus> {
+        if (!this.status.canQuitAndInstall) {
+            const url = this.status.downloadPageUrl;
+            if (url) await this.deps.openExternal(url);
+            return this.getStatus();
+        }
+        this.deps.updater.quitAndInstall(false, true);
+        return this.getStatus();
+    }
+
+    cancel(): UpdateStatus {
+        this.cancelToken?.cancel();
+        if (this.status.state === 'downloading') {
+            return this.publish({ ...this.status, state: 'available', percent: undefined });
+        }
+        return this.getStatus();
+    }
+
+    private applyCheckResult(info: UpdateInfoLike | undefined, source: UpdateCheckSource): UpdateStatus {
+        this.lastInfo = info || null;
+        const currentVersion = this.deps.getVersion();
+        const availableVersion = info?.version || '';
+        const apply = resolveOsApplyPath({
+            platform: this.deps.platform,
+            isAppImage: this.deps.isAppImage,
+            feedHasAppImage: feedHasAppImage(info)
+        });
+        const claim = signatureClaim(this.signatureMode());
+        if (!availableVersion || !isNewerVersion(availableVersion, currentVersion)) {
+            return this.publish({
+                ...this.baseStatus('up-to-date', source),
+                ...claim,
+                applyMode: apply.mode,
+                canQuitAndInstall: apply.canQuitAndInstall
+            });
+        }
+        return this.publish({
+            ...this.baseStatus('available', source),
+            availableVersion,
+            releaseNotes: formatReleaseNotes(info?.releaseNotes),
+            applyMode: apply.mode,
+            canQuitAndInstall: apply.canQuitAndInstall,
+            ...claim
+        });
+    }
+
+    private configureUpdater(): void {
+        if (this.configured || !this.feed) return;
+        this.deps.updater.autoDownload = false;
+        this.deps.updater.autoInstallOnAppQuit = false;
+        this.deps.updater.setFeedURL(toElectronUpdaterOptions(this.feed));
+        this.configured = true;
+    }
+
+    private wireUpdaterEvents(): void {
+        this.deps.updater.on('download-progress', (progress: { percent?: number }) => {
+            if (this.status.state !== 'downloading') return;
+            this.publish({ ...this.status, percent: Math.round(progress?.percent || 0) });
+        });
+        this.deps.updater.on('update-downloaded', () => {
+            if (this.cancelToken?.cancelled) return;
+            this.publish({ ...this.status, state: 'downloaded', percent: 100 });
+        });
+        this.deps.updater.on('error', (error: unknown) => {
+            if (this.cancelToken?.cancelled) return;
+            this.fail(this.status.source, error);
+        });
+    }
+
+    private fail(source: UpdateCheckSource, error: unknown): UpdateStatus {
+        const claim = signatureClaim(this.signatureMode());
+        return this.publish({
+            ...this.baseStatus('error', source),
+            error: plainUpdateError(error),
+            ...claim
+        });
+    }
+
+    private baseStatus(state: UpdateState, source: UpdateCheckSource = 'manual', reason?: string): UpdateStatus {
+        const claim = signatureClaim(this.signatureMode());
+        return {
+            state,
+            source,
+            reason,
+            currentVersion: this.deps.getVersion(),
+            applyMode: 'open-download-page',
+            canQuitAndInstall: false,
+            downloadPageUrl: this.feed?.downloadPageUrl,
+            packaged: this.deps.isPackaged,
+            ...claim
+        };
+    }
+
+    private signatureMode(): SignatureMode {
+        return this.feed?.signatureMode || 'feed-checksum';
+    }
+
+    private publish(status: UpdateStatus): UpdateStatus {
+        this.status = status;
+        this.deps.send('updates:event', status);
+        return this.getStatus();
+    }
+}
+
+export function createUpdateService(deps: UpdateServiceDeps): DesktopUpdateService {
+    return new DesktopUpdateService(deps);
+}
+
+export function bindUpdateIpc(ipcMain: Pick<IpcMain, 'handle'>, service: DesktopUpdateService): void {
+    ipcMain.handle('updates:check', (_event, opts) => service.check(opts));
+    ipcMain.handle('updates:download', () => service.download());
+    ipcMain.handle('updates:install', () => service.install());
+    ipcMain.handle('updates:cancel', () => service.cancel());
+    ipcMain.handle('updates:status', () => service.getStatus());
+}

--- a/desktop/src/main/updates/updateService.ts
+++ b/desktop/src/main/updates/updateService.ts
@@ -69,7 +69,7 @@ export interface UpdateServiceDeps {
     updater: UpdaterPort;
     isPackaged: boolean;
     env: NodeJS.Dict<string>;
-    platform: NodeJS.Platform | string;
+    platform: string;
     isAppImage: boolean;
     getVersion: () => string;
     send: (channel: string, payload: UpdateStatus) => void;
@@ -93,7 +93,7 @@ function createCancelToken(): CancelToken {
 
 export class DesktopUpdateService {
     private status: UpdateStatus;
-    private feed: UpdateFeedConfig | null;
+    private readonly feed: UpdateFeedConfig | null;
     private cancelToken: CancelToken | null = null;
     private lastInfo: UpdateInfoLike | null = null;
     private configured = false;
@@ -229,6 +229,7 @@ export class DesktopUpdateService {
         });
         this.deps.updater.on('update-downloaded', () => {
             if (this.cancelToken?.cancelled) return;
+            if (this.status.state !== 'downloading' && this.status.state !== 'downloaded') return;
             this.publish({ ...this.status, state: 'downloaded', percent: 100 });
         });
         this.deps.updater.on('error', (error: unknown) => {

--- a/desktop/src/main/updates/updateService.ts
+++ b/desktop/src/main/updates/updateService.ts
@@ -2,6 +2,7 @@ import type { IpcMain } from 'electron';
 import {
     feedHasAppImage,
     formatReleaseNotes,
+    hasInsecureUpdateArtifact,
     isNewerVersion,
     plainUpdateError,
     resolveOsApplyPath,
@@ -130,7 +131,13 @@ export class DesktopUpdateService {
         if (!this.deps.isPackaged || !this.feed) {
             return this.check({ source: 'manual' });
         }
-        if (this.status.state === 'available' && !this.status.canQuitAndInstall) {
+        if (this.status.state === 'downloading' || this.status.state === 'downloaded') {
+            return this.getStatus();
+        }
+        if (this.status.state !== 'available') {
+            return this.fail('manual', new Error('No update is ready to download.'));
+        }
+        if (!this.status.canQuitAndInstall) {
             const url = this.status.downloadPageUrl;
             if (url) await this.deps.openExternal(url);
             return this.getStatus();
@@ -157,12 +164,14 @@ export class DesktopUpdateService {
     }
 
     async install(): Promise<UpdateStatus> {
+        if (this.status.state === 'downloaded' && this.status.canQuitAndInstall) {
+            this.deps.updater.quitAndInstall(false, true);
+            return this.getStatus();
+        }
         if (!this.status.canQuitAndInstall) {
             const url = this.status.downloadPageUrl;
             if (url) await this.deps.openExternal(url);
-            return this.getStatus();
         }
-        this.deps.updater.quitAndInstall(false, true);
         return this.getStatus();
     }
 
@@ -176,6 +185,9 @@ export class DesktopUpdateService {
 
     private applyCheckResult(info: UpdateInfoLike | undefined, source: UpdateCheckSource): UpdateStatus {
         this.lastInfo = info || null;
+        if (hasInsecureUpdateArtifact(info)) {
+            return this.fail(source, new Error('The update feed listed an insecure HTTP download.'));
+        }
         const currentVersion = this.deps.getVersion();
         const availableVersion = info?.version || '';
         const apply = resolveOsApplyPath({

--- a/desktop/src/renderer/app/app.component.ts
+++ b/desktop/src/renderer/app/app.component.ts
@@ -3,17 +3,19 @@ import { RouterOutlet } from '@angular/router';
 import { ThemeService } from './services/theme.service';
 
 import { UniversalDialogComponent } from './shared/components/universal-dialog/universal-dialog.component';
+import { UpdatePromptComponent } from './shared/components/update-prompt/update-prompt.component';
 
 import { BackupSetupComponent } from './setup/backup-setup.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, UniversalDialogComponent, BackupSetupComponent],
+  imports: [RouterOutlet, UniversalDialogComponent, BackupSetupComponent, UpdatePromptComponent],
   template: `
     <router-outlet></router-outlet>
     <app-universal-dialog></app-universal-dialog>
     <app-backup-setup></app-backup-setup>
+    <app-update-prompt></app-update-prompt>
   `
 })
 export class AppComponent {

--- a/desktop/src/renderer/app/services/update.service.spec.ts
+++ b/desktop/src/renderer/app/services/update.service.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { AppUpdateService } from './update.service';
+
+describe('AppUpdateService', () => {
+    let service: AppUpdateService;
+    let updates: any;
+
+    beforeEach(() => {
+        updates = {
+            check: vi.fn(),
+            download: vi.fn(),
+            install: vi.fn(),
+            cancel: vi.fn(),
+            onEvent: vi.fn().mockReturnValue(() => undefined)
+        };
+        (globalThis as any).electron = {
+            updates,
+            getAppVersion: vi.fn().mockResolvedValue({ packaged: true, version: '0.0.8' })
+        };
+        service = new AppUpdateService({ run: (fn: () => void) => fn() } as any);
+    });
+
+    afterEach(() => {
+        delete (globalThis as any).electron;
+    });
+
+    it('opens Update now / Later when a newer feed version is available', async () => {
+        updates.check.mockResolvedValue({
+            state: 'available',
+            currentVersion: '0.0.8',
+            availableVersion: '0.0.9',
+            verifiedSignature: false
+        });
+        const status = await service.check('startup');
+        expect(status.availableVersion).toBe('0.0.9');
+        expect(service.promptOpen()).toBe(true);
+        expect(service.status().verifiedSignature).toBe(false);
+        service.later();
+        expect(service.promptOpen()).toBe(false);
+        expect(service.status().state).toBe('available');
+    });
+
+    it('downloads then installs on Update now', async () => {
+        updates.download.mockResolvedValue({ state: 'downloaded', canQuitAndInstall: true });
+        updates.install.mockResolvedValue({ state: 'downloaded' });
+        service.status.set({ state: 'available' });
+        await service.updateNow();
+        expect(updates.download).toHaveBeenCalled();
+        expect(updates.install).toHaveBeenCalled();
+    });
+
+    it('keeps the prompt for a failed launch check', async () => {
+        updates.check.mockResolvedValue({
+            state: 'error',
+            source: 'startup',
+            error: 'Could not reach the update feed. Check the network and try again.'
+        });
+        await service.check('startup');
+        expect(service.promptOpen()).toBe(true);
+        expect(service.status().error).toMatch(/network/i);
+    });
+});

--- a/desktop/src/renderer/app/services/update.service.spec.ts
+++ b/desktop/src/renderer/app/services/update.service.spec.ts
@@ -43,6 +43,32 @@ describe('AppUpdateService', () => {
         expect(service.status().state).toBe('available');
     });
 
+    it('wires startup checks, events, cancel, and missing IPC', async () => {
+        updates.check.mockResolvedValue({ state: 'available', source: 'startup', availableVersion: '0.0.9' });
+        service.init();
+        service.init();
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(updates.onEvent).toHaveBeenCalled();
+        expect(updates.check).toHaveBeenCalledWith({ source: 'startup' });
+        const listener = updates.onEvent.mock.calls[0][0];
+        listener({ state: 'downloading', percent: 20 });
+        expect(service.promptOpen()).toBe(true);
+        updates.cancel.mockResolvedValue({ state: 'available' });
+        await service.cancelDownload();
+        expect(updates.cancel).toHaveBeenCalled();
+        service.destroy();
+
+        delete (globalThis as any).electron;
+        const offline = new AppUpdateService({ run: (fn: () => void) => fn() } as any);
+        await offline.check();
+        await offline.updateNow();
+        await offline.install();
+        await offline.cancelDownload();
+        offline.init();
+        expect(offline.status().state).toBe('idle');
+    });
+
     it('downloads then installs on Update now', async () => {
         updates.download.mockResolvedValue({ state: 'downloaded', canQuitAndInstall: true });
         updates.install.mockResolvedValue({ state: 'downloaded' });

--- a/desktop/src/renderer/app/services/update.service.spec.ts
+++ b/desktop/src/renderer/app/services/update.service.spec.ts
@@ -52,6 +52,13 @@ describe('AppUpdateService', () => {
         expect(updates.install).toHaveBeenCalled();
     });
 
+    it('installs a previously downloaded update', async () => {
+        updates.install.mockResolvedValue({ state: 'downloaded', canQuitAndInstall: true });
+        service.status.set({ state: 'downloaded' });
+        await service.install();
+        expect(updates.install).toHaveBeenCalled();
+    });
+
     it('keeps the prompt for a failed launch check', async () => {
         updates.check.mockResolvedValue({
             state: 'error',

--- a/desktop/src/renderer/app/services/update.service.ts
+++ b/desktop/src/renderer/app/services/update.service.ts
@@ -24,7 +24,7 @@ export class AppUpdateService {
     private unsubscribe: (() => void) | null = null;
     private started = false;
 
-    constructor(private ngZone: NgZone) { }
+    constructor(private readonly ngZone: NgZone) { }
 
     init(): void {
         if (this.started) return;
@@ -34,7 +34,7 @@ export class AppUpdateService {
         this.unsubscribe = api.onEvent((status: AppUpdateStatus) => {
             this.ngZone.run(() => this.applyStatus(status));
         });
-        void this.checkStartup();
+        this.checkStartup().catch(() => undefined);
     }
 
     destroy(): void {

--- a/desktop/src/renderer/app/services/update.service.ts
+++ b/desktop/src/renderer/app/services/update.service.ts
@@ -1,0 +1,95 @@
+import { Injectable, NgZone, signal } from '@angular/core';
+
+export interface AppUpdateStatus {
+    state: string;
+    source?: 'startup' | 'manual';
+    reason?: string;
+    currentVersion?: string;
+    availableVersion?: string;
+    releaseNotes?: string;
+    percent?: number;
+    error?: string;
+    applyMode?: string;
+    canQuitAndInstall?: boolean;
+    downloadPageUrl?: string;
+    verifiedSignature?: boolean;
+    integrityNote?: string;
+    packaged?: boolean;
+}
+
+@Injectable({ providedIn: 'root' })
+export class AppUpdateService {
+    readonly status = signal<AppUpdateStatus>({ state: 'idle' });
+    readonly promptOpen = signal(false);
+    private unsubscribe: (() => void) | null = null;
+    private started = false;
+
+    constructor(private ngZone: NgZone) { }
+
+    init(): void {
+        if (this.started) return;
+        this.started = true;
+        const api = (globalThis as any).electron?.updates;
+        if (!api) return;
+        this.unsubscribe = api.onEvent((status: AppUpdateStatus) => {
+            this.ngZone.run(() => this.applyStatus(status));
+        });
+        void this.checkStartup();
+    }
+
+    destroy(): void {
+        this.unsubscribe?.();
+        this.unsubscribe = null;
+    }
+
+    async check(source: 'startup' | 'manual' = 'manual'): Promise<AppUpdateStatus> {
+        const api = (globalThis as any).electron?.updates;
+        if (!api) return this.status();
+        const status = await api.check({ source });
+        this.applyStatus(status);
+        return status;
+    }
+
+    async updateNow(): Promise<void> {
+        const api = (globalThis as any).electron?.updates;
+        if (!api) return;
+        const afterDownload = await api.download();
+        this.applyStatus(afterDownload);
+        if (afterDownload.state === 'downloaded') {
+            await api.install();
+        }
+    }
+
+    later(): void {
+        this.promptOpen.set(false);
+    }
+
+    async cancelDownload(): Promise<void> {
+        const api = (globalThis as any).electron?.updates;
+        if (!api) return;
+        const status = await api.cancel();
+        this.applyStatus(status);
+    }
+
+    private async checkStartup(): Promise<void> {
+        try {
+            const info = await (globalThis as any).electron?.getAppVersion?.();
+            if (!info?.packaged) return;
+            await this.check('startup');
+        } catch {
+            // Launch check is best-effort; the running app stays usable.
+        }
+    }
+
+    private applyStatus(status: AppUpdateStatus): void {
+        this.status.set(status || { state: 'idle' });
+        const state = status?.state;
+        const manual = status?.source === 'manual';
+        const shouldPrompt = state === 'available'
+            || state === 'downloading'
+            || state === 'downloaded'
+            || state === 'error'
+            || (manual && (state === 'up-to-date' || state === 'skipped'));
+        if (shouldPrompt) this.promptOpen.set(true);
+    }
+}

--- a/desktop/src/renderer/app/services/update.service.ts
+++ b/desktop/src/renderer/app/services/update.service.ts
@@ -56,8 +56,15 @@ export class AppUpdateService {
         const afterDownload = await api.download();
         this.applyStatus(afterDownload);
         if (afterDownload.state === 'downloaded') {
-            await api.install();
+            await this.install();
         }
+    }
+
+    async install(): Promise<void> {
+        const api = (globalThis as any).electron?.updates;
+        if (!api) return;
+        const status = await api.install();
+        this.applyStatus(status);
     }
 
     later(): void {

--- a/desktop/src/renderer/app/settings/catalog-settings.component.spec.ts
+++ b/desktop/src/renderer/app/settings/catalog-settings.component.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { CatalogSettingsComponent } from './catalog-settings.component';
+
+describe('CatalogSettingsComponent', () => {
+    let component: CatalogSettingsComponent;
+    let data: { invoke: ReturnType<typeof vi.fn> };
+
+    beforeEach(() => {
+        data = {
+            invoke: vi.fn().mockImplementation((method: string) => {
+                if (method === 'listConditions') return Promise.resolve([{ id: 1, name: 'URI', active: 1 }]);
+                if (method === 'listMedicines') return Promise.resolve([{ id: 2, name: 'Paracetamol', active: 1, dosage: '500mg' }]);
+                if (method === 'getConditionMedPresets') return Promise.resolve([{ medicine: 'Paracetamol', medicine_id: 2 }]);
+                return Promise.resolve({ id: 9, name: 'Influenza' });
+            })
+        };
+        component = new CatalogSettingsComponent(data as any, { run: (fn: () => void) => fn() } as any);
+    });
+
+    it('lists catalogs and saves a new condition', async () => {
+        await component.ngOnInit();
+        expect(component.conditions[0].name).toBe('URI');
+        component.newCondition = 'Influenza';
+        await component.addCondition();
+        expect(data.invoke).toHaveBeenCalledWith('createCondition', { name: 'Influenza' });
+        expect(component.newCondition).toBe('');
+    });
+
+    it('loads and replaces ordered presets', async () => {
+        await component.reload();
+        await component.selectCondition({ id: 1, name: 'URI' });
+        expect(component.presetLines[0].medicine).toBe('Paracetamol');
+        component.addPresetLine();
+        await component.savePresets();
+        expect(data.invoke).toHaveBeenCalledWith('replaceConditionMedPresets', expect.objectContaining({
+            conditionId: 1
+        }));
+    });
+
+    it('shows a plain error for duplicate active names', async () => {
+        data.invoke.mockImplementation((method: string) => {
+            if (method.startsWith('list')) return Promise.resolve([]);
+            return Promise.reject(new Error('DUPLICATE_ACTIVE_NAME'));
+        });
+        component.newMedicine = 'Paracetamol';
+        await component.addMedicine();
+        expect(component.success).toBe(false);
+        expect(component.message).toMatch(/already exists/i);
+    });
+});

--- a/desktop/src/renderer/app/settings/catalog-settings.component.spec.ts
+++ b/desktop/src/renderer/app/settings/catalog-settings.component.spec.ts
@@ -20,8 +20,14 @@ describe('CatalogSettingsComponent', () => {
         component = new CatalogSettingsComponent(data as any, { run: (fn: () => void) => fn() } as any);
     });
 
+    it('loads catalogs during init', () => {
+        const reload = vi.spyOn(component, 'reload').mockResolvedValue();
+        component.ngOnInit();
+        expect(reload).toHaveBeenCalled();
+    });
+
     it('lists catalogs and saves a new condition', async () => {
-        await component.ngOnInit();
+        await component.reload();
         expect(component.conditions[0].name).toBe('URI');
         component.newCondition = 'Influenza';
         await component.addCondition();
@@ -62,5 +68,24 @@ describe('CatalogSettingsComponent', () => {
         expect(component.selectedCondition).toEqual({ id: 1, name: 'URI' });
         await component.retire('retireCondition', { id: 1, name: 'URI' });
         expect(component.selectedCondition).toBeNull();
+    });
+
+    it('saves medicine rows, preset lines, and catalog errors', async () => {
+        await component.reload();
+        await component.selectCondition({ id: 1, name: 'URI' });
+        component.onPresetMedicine(0);
+        component.addPresetLine();
+        component.removePreset(1);
+        await component.saveCondition({ id: 1, name: 'URI' });
+        await component.saveMedicine({ id: 2, name: 'Paracetamol', dosage: '500mg' });
+        component.newMedicine = 'Cetirizine';
+        await component.addMedicine();
+        expect(data.invoke).toHaveBeenCalledWith('updateCondition', { id: 1, name: 'URI' });
+        expect(data.invoke).toHaveBeenCalledWith('createMedicine', { name: 'Cetirizine' });
+
+        data.invoke.mockRejectedValueOnce(new Error('NAME_REQUIRED'));
+        component.newCondition = '';
+        await component.addCondition();
+        expect(component.message).toMatch(/required/i);
     });
 });

--- a/desktop/src/renderer/app/settings/catalog-settings.component.spec.ts
+++ b/desktop/src/renderer/app/settings/catalog-settings.component.spec.ts
@@ -36,7 +36,11 @@ describe('CatalogSettingsComponent', () => {
         component.addPresetLine();
         await component.savePresets();
         expect(data.invoke).toHaveBeenCalledWith('replaceConditionMedPresets', expect.objectContaining({
-            conditionId: 1
+            conditionId: 1,
+            lines: [
+                { medicine: 'Paracetamol', medicine_id: 2 },
+                expect.objectContaining({ medicine_id: null })
+            ]
         }));
     });
 
@@ -49,5 +53,14 @@ describe('CatalogSettingsComponent', () => {
         await component.addMedicine();
         expect(component.success).toBe(false);
         expect(component.message).toMatch(/already exists/i);
+    });
+
+    it('does not hide condition presets when a medicine with the same id is retired', async () => {
+        await component.reload();
+        await component.selectCondition({ id: 1, name: 'URI' });
+        await component.retire('retireMedicine', { id: 1, name: 'Old syrup' });
+        expect(component.selectedCondition).toEqual({ id: 1, name: 'URI' });
+        await component.retire('retireCondition', { id: 1, name: 'URI' });
+        expect(component.selectedCondition).toBeNull();
     });
 });

--- a/desktop/src/renderer/app/settings/catalog-settings.component.ts
+++ b/desktop/src/renderer/app/settings/catalog-settings.component.ts
@@ -1,0 +1,203 @@
+import { Component, NgZone, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { DataService } from '../services/api.service';
+
+@Component({
+    selector: 'app-catalog-settings',
+    standalone: true,
+    imports: [CommonModule, FormsModule],
+    template: `
+    <div class="h-full overflow-y-auto p-4 md:p-8">
+      <h2 class="text-2xl font-bold text-gray-800 mb-2">Diagnosis &amp; medicine catalogs</h2>
+      <p class="text-sm text-gray-500 mb-6">Clinic-local lists for Plan &amp; Rx. Soft-retire hides a term from typeahead; saved visits keep their original text.</p>
+
+      <div class="flex gap-2 mb-4">
+        <button type="button" class="btn btn-sm" [class.btn-primary]="section === 'conditions'" (click)="section = 'conditions'">Conditions</button>
+        <button type="button" class="btn btn-sm" [class.btn-primary]="section === 'medicines'" (click)="section = 'medicines'">Medicines</button>
+        <label class="ml-auto flex items-center gap-2 text-xs text-gray-600">
+          <input type="checkbox" class="checkbox checkbox-xs" [(ngModel)]="includeRetired" (ngModelChange)="reload()" />
+          Show retired
+        </label>
+      </div>
+
+      <p *ngIf="message" class="text-sm mb-3" [class.text-red-600]="!success" [class.text-green-700]="success">{{ message }}</p>
+
+      <div *ngIf="section === 'conditions'" class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div class="bg-white border rounded-lg p-4">
+          <h3 class="font-semibold mb-3">Conditions</h3>
+          <div class="flex gap-2 mb-3">
+            <input class="input input-bordered input-sm flex-1" [(ngModel)]="newCondition" placeholder="Add condition" />
+            <button class="btn btn-sm btn-primary" type="button" (click)="addCondition()">Add</button>
+          </div>
+          <div *ngFor="let row of conditions" class="flex items-center gap-2 py-2 border-b border-gray-100">
+            <input class="input input-bordered input-xs flex-1" [(ngModel)]="row.name" [disabled]="row.active === 0" />
+            <button class="btn btn-xs" type="button" [disabled]="row.active === 0" (click)="saveCondition(row)">Save</button>
+            <button class="btn btn-xs btn-ghost text-error" type="button" [disabled]="row.active === 0" (click)="retire('retireCondition', row)">Retire</button>
+            <button class="btn btn-xs btn-ghost" type="button" (click)="selectCondition(row)">Presets</button>
+          </div>
+        </div>
+        <div class="bg-white border rounded-lg p-4" *ngIf="selectedCondition">
+          <h3 class="font-semibold mb-3">Presets for {{ selectedCondition.name }}</h3>
+          <div *ngFor="let line of presetLines; let i = index" class="grid grid-cols-12 gap-1 mb-2">
+            <select class="select select-bordered select-xs col-span-5" [(ngModel)]="line.medicine_id" (ngModelChange)="onPresetMedicine(i)">
+              <option [ngValue]="null">Medicine</option>
+              <option *ngFor="let med of medicines" [ngValue]="med.id">{{ med.name }}</option>
+            </select>
+            <input class="input input-bordered input-xs col-span-3" [(ngModel)]="line.dosage" placeholder="Dose" />
+            <input class="input input-bordered input-xs col-span-3" [(ngModel)]="line.duration" placeholder="Duration" />
+            <button class="btn btn-xs btn-ghost text-error col-span-1" type="button" (click)="removePreset(i)">✕</button>
+          </div>
+          <div class="flex gap-2 mt-3">
+            <button class="btn btn-sm" type="button" (click)="addPresetLine()">+ Line</button>
+            <button class="btn btn-sm btn-primary" type="button" (click)="savePresets()">Save presets</button>
+          </div>
+        </div>
+      </div>
+
+      <div *ngIf="section === 'medicines'" class="bg-white border rounded-lg p-4">
+        <h3 class="font-semibold mb-3">Medicines</h3>
+        <div class="flex gap-2 mb-3">
+          <input class="input input-bordered input-sm flex-1" [(ngModel)]="newMedicine" placeholder="Add medicine" />
+          <button class="btn btn-sm btn-primary" type="button" (click)="addMedicine()">Add</button>
+        </div>
+        <div *ngFor="let row of medicines" class="grid grid-cols-12 gap-2 py-2 border-b border-gray-100 items-center">
+          <input class="input input-bordered input-xs col-span-4" [(ngModel)]="row.name" [disabled]="row.active === 0" />
+          <input class="input input-bordered input-xs col-span-2" [(ngModel)]="row.dosage" [disabled]="row.active === 0" placeholder="Dose" />
+          <input class="input input-bordered input-xs col-span-2" [(ngModel)]="row.frequency" [disabled]="row.active === 0" placeholder="Freq" />
+          <input class="input input-bordered input-xs col-span-2" [(ngModel)]="row.duration" [disabled]="row.active === 0" placeholder="Days" />
+          <button class="btn btn-xs col-span-1" type="button" [disabled]="row.active === 0" (click)="saveMedicine(row)">Save</button>
+          <button class="btn btn-xs btn-ghost text-error col-span-1" type="button" [disabled]="row.active === 0" (click)="retire('retireMedicine', row)">Retire</button>
+        </div>
+      </div>
+    </div>
+  `
+})
+export class CatalogSettingsComponent implements OnInit {
+    section: 'conditions' | 'medicines' = 'conditions';
+    includeRetired = false;
+    conditions: any[] = [];
+    medicines: any[] = [];
+    selectedCondition: any = null;
+    presetLines: any[] = [];
+    newCondition = '';
+    newMedicine = '';
+    message = '';
+    success = false;
+
+    constructor(private data: DataService, private ngZone: NgZone) { }
+
+    async ngOnInit(): Promise<void> {
+        await this.reload();
+    }
+
+    async reload(): Promise<void> {
+        const [conditions, medicines] = await Promise.all([
+            this.data.invoke('listConditions', this.includeRetired),
+            this.data.invoke('listMedicines', this.includeRetired)
+        ]);
+        this.ngZone.run(() => {
+            this.conditions = conditions || [];
+            this.medicines = medicines || [];
+        });
+    }
+
+    async addCondition(): Promise<void> {
+        await this.create('createCondition', { name: this.newCondition }, () => { this.newCondition = ''; });
+    }
+
+    async addMedicine(): Promise<void> {
+        await this.create('createMedicine', { name: this.newMedicine }, () => { this.newMedicine = ''; });
+    }
+
+    async saveCondition(row: any): Promise<void> {
+        await this.write('updateCondition', { id: row.id, name: row.name });
+    }
+
+    async saveMedicine(row: any): Promise<void> {
+        await this.write('updateMedicine', row);
+    }
+
+    async retire(method: 'retireCondition' | 'retireMedicine', row: any): Promise<void> {
+        await this.write(method, row.id);
+        if (this.selectedCondition?.id === row.id) this.selectedCondition = null;
+    }
+
+    async selectCondition(row: any): Promise<void> {
+        const lines = await this.data.invoke('getConditionMedPresets', row.id);
+        this.ngZone.run(() => {
+            this.selectedCondition = row;
+            this.presetLines = (lines || []).map((line: any) => ({ ...line }));
+        });
+    }
+
+    addPresetLine(): void {
+        this.presetLines = [...this.presetLines, {
+            medicine_id: null, medicine: '', form: 'Tab', dosage: '', route: 'Oral',
+            frequency: '1-0-1', duration: '3 days', instruction: 'After Food'
+        }];
+    }
+
+    removePreset(index: number): void {
+        this.presetLines = this.presetLines.filter((_, i) => i !== index);
+    }
+
+    onPresetMedicine(index: number): void {
+        const line = this.presetLines[index];
+        const med = this.medicines.find((item) => item.id === line.medicine_id);
+        if (!med) return;
+        this.presetLines[index] = {
+            ...line,
+            medicine: med.name,
+            form: med.form || line.form,
+            dosage: med.dosage || line.dosage,
+            route: med.route || line.route,
+            frequency: med.frequency || line.frequency,
+            duration: med.duration || line.duration,
+            instruction: med.instruction || line.instruction
+        };
+    }
+
+    async savePresets(): Promise<void> {
+        if (!this.selectedCondition) return;
+        await this.write('replaceConditionMedPresets', {
+            conditionId: this.selectedCondition.id,
+            lines: this.presetLines
+        });
+    }
+
+    private async create(method: string, payload: { name: string }, reset: () => void): Promise<void> {
+        try {
+            await this.data.invoke(method, payload);
+            reset();
+            this.flash(true, 'Saved.');
+            await this.reload();
+        } catch (error) {
+            this.flash(false, this.catalogError(error));
+        }
+    }
+
+    private async write(method: string, payload: unknown): Promise<void> {
+        try {
+            await this.data.invoke(method, payload);
+            this.flash(true, 'Saved.');
+            await this.reload();
+        } catch (error) {
+            this.flash(false, this.catalogError(error));
+        }
+    }
+
+    private flash(ok: boolean, text: string): void {
+        this.ngZone.run(() => {
+            this.success = ok;
+            this.message = text;
+        });
+    }
+
+    private catalogError(error: unknown): string {
+        const message = String((error as Error)?.message || error || '');
+        if (/NAME_REQUIRED/i.test(message)) return 'Name is required.';
+        if (/DUPLICATE_ACTIVE_NAME/i.test(message)) return 'That active name already exists.';
+        return 'Could not save catalog changes.';
+    }
+}

--- a/desktop/src/renderer/app/settings/catalog-settings.component.ts
+++ b/desktop/src/renderer/app/settings/catalog-settings.component.ts
@@ -85,10 +85,10 @@ export class CatalogSettingsComponent implements OnInit {
     message = '';
     success = false;
 
-    constructor(private data: DataService, private ngZone: NgZone) { }
+    constructor(private readonly data: DataService, private readonly ngZone: NgZone) { }
 
-    async ngOnInit(): Promise<void> {
-        await this.reload();
+    ngOnInit(): void {
+        this.reload().catch(() => undefined);
     }
 
     async reload(): Promise<void> {
@@ -197,7 +197,7 @@ export class CatalogSettingsComponent implements OnInit {
     }
 
     private catalogError(error: unknown): string {
-        const message = String((error as Error)?.message || error || '');
+        const message = error instanceof Error ? error.message : (typeof error === 'string' ? error : '');
         if (/NAME_REQUIRED/i.test(message)) return 'Name is required.';
         if (/DUPLICATE_ACTIVE_NAME/i.test(message)) return 'That active name already exists.';
         return 'Could not save catalog changes.';

--- a/desktop/src/renderer/app/settings/catalog-settings.component.ts
+++ b/desktop/src/renderer/app/settings/catalog-settings.component.ts
@@ -120,7 +120,9 @@ export class CatalogSettingsComponent implements OnInit {
 
     async retire(method: 'retireCondition' | 'retireMedicine', row: any): Promise<void> {
         await this.write(method, row.id);
-        if (this.selectedCondition?.id === row.id) this.selectedCondition = null;
+        if (method === 'retireCondition' && this.selectedCondition?.id === row.id) {
+            this.selectedCondition = null;
+        }
     }
 
     async selectCondition(row: any): Promise<void> {

--- a/desktop/src/renderer/app/settings/settings.component.html
+++ b/desktop/src/renderer/app/settings/settings.component.html
@@ -69,6 +69,12 @@
                     class="w-full text-left px-3 py-2 rounded-md transition-colors font-medium flex items-center gap-3 border-l-4">
                     <span>Audit Logs</span>
                 </button>
+
+                <button (click)="switchTab('catalogs')"
+                    [class]="activeTab === 'catalogs' ? 'bg-blue-50 text-blue-700 border-blue-500' : 'text-gray-600 hover:bg-gray-50 border-transparent'"
+                    class="w-full text-left px-3 py-2 rounded-md transition-colors font-medium flex items-center gap-3 border-l-4">
+                    <span>Catalogs</span>
+                </button>
             </ng-container>
         </nav>
 
@@ -104,6 +110,19 @@
             <div class="bg-white p-4 md:p-6 rounded-lg shadow-sm border border-gray-200" *ngIf="isElectron">
                 <div class="flex items-center justify-between mb-4">
                     <div>
+                        <h3 class="text-lg font-medium text-gray-800">Updates</h3>
+                        <p class="text-sm text-gray-500">Installed version: <span class="font-mono">{{ appVersion || 'unknown' }}</span></p>
+                    </div>
+                    <button type="button" class="btn btn-outline btn-sm" [disabled]="updateBusy" (click)="checkForUpdates()">
+                        Check for updates
+                    </button>
+                </div>
+                <p class="text-xs text-gray-500">Packaged desktop builds check a clinic update feed. This app does not claim full code-signature verification unless a later signed release channel is configured.</p>
+            </div>
+
+            <div class="bg-white p-4 md:p-6 rounded-lg shadow-sm border border-gray-200 mt-6" *ngIf="isElectron">
+                <div class="flex items-center justify-between mb-4">
+                    <div>
                         <h3 class="text-lg font-medium text-purple-700">Online Booking</h3>
                         <p class="text-sm text-gray-500">Enable public appointment booking on nalamdesk.com</p>
                     </div>
@@ -115,6 +134,10 @@
                     <strong>Status:</strong> Active &bull; <strong>Clinic ID:</strong> {{ cloudClinicId }}
                 </div>
             </div>
+        </div>
+
+        <div *ngIf="activeTab === 'catalogs'" class="h-full overflow-hidden">
+            <app-catalog-settings></app-catalog-settings>
         </div>
 
         <!-- 2. USERS TAB -->

--- a/desktop/src/renderer/app/settings/settings.component.spec.ts
+++ b/desktop/src/renderer/app/settings/settings.component.spec.ts
@@ -16,11 +16,13 @@ import { inject } from '@angular/core';
 import { DataService } from '../services/api.service';
 import { AuthService } from '../services/auth.service';
 import { Router } from '@angular/router';
+import { AppUpdateService } from '../services/update.service';
 
 // Mock Child Components
 vi.mock('../shared/components/table/table.component', () => ({ SharedTableComponent: class { } }));
 vi.mock('../shared/components/table/renderers/action-renderer.component', () => ({ ActionRendererComponent: class { } }));
 vi.mock('../shared/components/date-picker/date-picker.component', () => ({ DatePickerComponent: class { } }));
+vi.mock('./catalog-settings.component', () => ({ CatalogSettingsComponent: class { } }));
 
 describe('SettingsComponent Validation', () => {
     let component: SettingsComponent;
@@ -258,5 +260,19 @@ describe('SettingsComponent Validation', () => {
         expect(component.appVersion).toContain('development');
         expect(component.appVersion).not.toBe('0.0.0');
         expect(component.appVersion).not.toBe('v0.0.0');
+    });
+
+    it('checks for updates from Settings on packaged Electron', async () => {
+        const updates = { check: vi.fn().mockResolvedValue({ state: 'up-to-date' }) };
+        vi.mocked(inject).mockImplementation((token) => {
+            if (token === AuthService) return mockAuth;
+            if (token === DataService) return mockData;
+            if (token === AppUpdateService) return updates;
+            return { navigate: vi.fn() };
+        });
+        component = new SettingsComponent(mockNgZone);
+        component.isElectron = true;
+        await component.checkForUpdates();
+        expect(updates.check).toHaveBeenCalledWith('manual');
     });
 });

--- a/desktop/src/renderer/app/settings/settings.component.ts
+++ b/desktop/src/renderer/app/settings/settings.component.ts
@@ -8,11 +8,13 @@ import { SharedTableComponent } from '../shared/components/table/table.component
 import { ActionRendererComponent } from '../shared/components/table/renderers/action-renderer.component';
 import { ColDef, ValueGetterParams } from 'ag-grid-community';
 import { DatePickerComponent } from '../shared/components/date-picker/date-picker.component';
+import { CatalogSettingsComponent } from './catalog-settings.component';
+import { AppUpdateService } from '../services/update.service';
 
 @Component({
   selector: 'app-settings',
   standalone: true,
-  imports: [CommonModule, FormsModule, SharedTableComponent, ActionRendererComponent, DatePickerComponent],
+  imports: [CommonModule, FormsModule, SharedTableComponent, ActionRendererComponent, DatePickerComponent, CatalogSettingsComponent],
   templateUrl: './settings.component.html',
   styles: [`
     :host { display: block; height: 100%; }
@@ -35,6 +37,7 @@ export class SettingsComponent implements OnInit {
   staffFilter = 'all';
 
   appVersion = '';
+  updateBusy = false;
 
   // General Settings
   settings = {
@@ -266,6 +269,7 @@ export class SettingsComponent implements OnInit {
   private dataService = inject(DataService);
   private authService = inject(AuthService);
   private router = inject(Router);
+  private updates = inject(AppUpdateService, { optional: true });
   constructor(private ngZone: NgZone) { }
 
   ngOnInit() {
@@ -291,6 +295,22 @@ export class SettingsComponent implements OnInit {
       });
     } catch (e) {
       console.error('[Settings] Failed to load packaged app version', e);
+    }
+  }
+
+  async checkForUpdates(): Promise<void> {
+    if (!this.isElectron || this.updateBusy) return;
+    this.updateBusy = true;
+    try {
+      if (this.updates) {
+        await this.updates.check('manual');
+        return;
+      }
+      await window.electron.updates.check({ source: 'manual' });
+    } catch (e) {
+      console.error('[Settings] Update check failed', e);
+    } finally {
+      this.updateBusy = false;
     }
   }
 

--- a/desktop/src/renderer/app/shared/components/catalog-typeahead/catalog-typeahead.component.spec.ts
+++ b/desktop/src/renderer/app/shared/components/catalog-typeahead/catalog-typeahead.component.spec.ts
@@ -38,4 +38,33 @@ describe('CatalogTypeaheadComponent', () => {
         expect(component.value).toBe('Viral fever');
         expect(component.error).toMatch(/already/i);
     });
+
+    it('ignores an older search that finishes after a newer query', async () => {
+        let resolveOlder: (hits: { id: number; name: string }[]) => void = () => undefined;
+        let resolveNewer: (hits: { id: number; name: string }[]) => void = () => undefined;
+        const older = new Promise<{ id: number; name: string }[]>((resolve) => {
+            resolveOlder = resolve;
+        });
+        const newer = new Promise<{ id: number; name: string }[]>((resolve) => {
+            resolveNewer = resolve;
+        });
+        let calls = 0;
+        component.searchFn = vi.fn().mockImplementation(() => {
+            calls += 1;
+            return calls === 1 ? older : newer;
+        });
+
+        component.value = 'fl';
+        component.onFocus();
+        component.value = 'flu';
+        component.onFocus();
+
+        resolveOlder([{ id: 1, name: 'Flower' }]);
+        await Promise.resolve();
+        expect(component.hits).toEqual([]);
+
+        resolveNewer([{ id: 2, name: 'Influenza' }]);
+        await Promise.resolve();
+        expect(component.hits).toEqual([{ id: 2, name: 'Influenza' }]);
+    });
 });

--- a/desktop/src/renderer/app/shared/components/catalog-typeahead/catalog-typeahead.component.spec.ts
+++ b/desktop/src/renderer/app/shared/components/catalog-typeahead/catalog-typeahead.component.spec.ts
@@ -39,6 +39,41 @@ describe('CatalogTypeaheadComponent', () => {
         expect(component.error).toMatch(/already/i);
     });
 
+    it('searches on focus and debounce, and ignores failed searches', async () => {
+        vi.useFakeTimers();
+        component.onInput('flu');
+        await vi.advanceTimersByTimeAsync(160);
+        expect(component.searchFn).toHaveBeenCalledWith('flu');
+        vi.useRealTimers();
+
+        component.searchFn = vi.fn().mockRejectedValue(new Error('offline'));
+        component.value = 'x';
+        component.onFocus();
+        await Promise.resolve();
+        expect(component.hits).toEqual([]);
+    });
+
+    it('offers Add new only when the typed name is not already a hit', () => {
+        component.value = 'Viral fever';
+        component.hits = [{ id: 1, name: 'Influenza' }];
+        expect(component.canAdd).toBe(true);
+        component.hits = [{ id: 2, name: 'Viral fever' }];
+        expect(component.canAdd).toBe(false);
+    });
+
+    it('maps add-new validation errors', async () => {
+        component.value = ' ';
+        await component.addNew();
+        component.value = 'x';
+        component.createFn = vi.fn().mockRejectedValue(new Error('NAME_REQUIRED'));
+        await component.addNew();
+        expect(component.error).toMatch(/required/i);
+        component.createFn = vi.fn().mockRejectedValue('offline');
+        await component.addNew();
+        expect(component.error).toMatch(/keep the typed name/i);
+        component.ngOnDestroy();
+    });
+
     it('ignores an older search that finishes after a newer query', async () => {
         let resolveOlder: (hits: { id: number; name: string }[]) => void = () => undefined;
         let resolveNewer: (hits: { id: number; name: string }[]) => void = () => undefined;

--- a/desktop/src/renderer/app/shared/components/catalog-typeahead/catalog-typeahead.component.spec.ts
+++ b/desktop/src/renderer/app/shared/components/catalog-typeahead/catalog-typeahead.component.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { CatalogTypeaheadComponent } from './catalog-typeahead.component';
+
+describe('CatalogTypeaheadComponent', () => {
+    let component: CatalogTypeaheadComponent;
+
+    beforeEach(() => {
+        component = new CatalogTypeaheadComponent();
+        component.searchFn = vi.fn().mockResolvedValue([{ id: 1, name: 'Influenza' }]);
+        component.createFn = vi.fn().mockResolvedValue({ id: 2, name: 'Viral fever' });
+    });
+
+    it('emits a picked catalog row', () => {
+        const picked = vi.fn();
+        component.picked.subscribe(picked);
+        component.pick({ id: 1, name: 'Influenza' });
+        expect(component.value).toBe('Influenza');
+        expect(picked).toHaveBeenCalledWith({ id: 1, name: 'Influenza' });
+        expect(component.open).toBe(false);
+    });
+
+    it('adds a new catalog row then selects it', async () => {
+        component.value = 'Viral fever';
+        const picked = vi.fn();
+        component.picked.subscribe(picked);
+        await component.addNew();
+        expect(component.createFn).toHaveBeenCalledWith('Viral fever');
+        expect(picked).toHaveBeenCalledWith({ id: 2, name: 'Viral fever' });
+    });
+
+    it('keeps typed text usable when add new fails', async () => {
+        component.value = 'Viral fever';
+        component.createFn = vi.fn().mockRejectedValue(new Error('DUPLICATE_ACTIVE_NAME'));
+        await component.addNew();
+        expect(component.value).toBe('Viral fever');
+        expect(component.error).toMatch(/already/i);
+    });
+});

--- a/desktop/src/renderer/app/shared/components/catalog-typeahead/catalog-typeahead.component.ts
+++ b/desktop/src/renderer/app/shared/components/catalog-typeahead/catalog-typeahead.component.ts
@@ -1,0 +1,110 @@
+import { Component, EventEmitter, Input, OnDestroy, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+export interface CatalogPick {
+    id: number;
+    name: string;
+    [key: string]: any;
+}
+
+@Component({
+    selector: 'app-catalog-typeahead',
+    standalone: true,
+    imports: [CommonModule, FormsModule],
+    template: `
+    <div class="relative">
+      <input type="text"
+             [ngModel]="value"
+             (ngModelChange)="onInput($event)"
+             (focus)="onFocus()"
+             [placeholder]="placeholder"
+             [disabled]="disabled"
+             [attr.data-testid]="testId"
+             class="w-full p-2 border border-gray-300 rounded focus:ring-2 focus:ring-purple-500 outline-none font-medium" />
+      <div *ngIf="open && !disabled" class="absolute z-30 mt-1 w-full bg-white border border-gray-200 rounded shadow-lg max-h-48 overflow-y-auto">
+        <button type="button" *ngFor="let hit of hits"
+                class="block w-full text-left px-3 py-2 text-sm hover:bg-blue-50"
+                (mousedown)="pick(hit)">{{ hit.name }}</button>
+        <button type="button" *ngIf="canAdd"
+                class="block w-full text-left px-3 py-2 text-sm text-blue-700 hover:bg-blue-50 font-medium"
+                (mousedown)="addNew()">+ Add new “{{ value.trim() }}”</button>
+        <div *ngIf="hits.length === 0 && !canAdd" class="px-3 py-2 text-xs text-gray-400">No matching catalog entries</div>
+      </div>
+      <p *ngIf="error" class="text-xs text-red-500 mt-1">{{ error }}</p>
+    </div>
+  `
+})
+export class CatalogTypeaheadComponent implements OnDestroy {
+    @Input() value = '';
+    @Input() placeholder = '';
+    @Input() disabled = false;
+    @Input() testId = 'catalog-typeahead';
+    @Input() searchFn?: (query: string) => Promise<CatalogPick[]>;
+    @Input() createFn?: (name: string) => Promise<CatalogPick>;
+    @Output() valueChange = new EventEmitter<string>();
+    @Output() picked = new EventEmitter<CatalogPick>();
+
+    hits: CatalogPick[] = [];
+    open = false;
+    error = '';
+    private timer: ReturnType<typeof setTimeout> | null = null;
+
+    ngOnDestroy(): void {
+        if (this.timer) clearTimeout(this.timer);
+    }
+
+    onFocus(): void {
+        if (this.disabled) return;
+        this.open = true;
+        void this.search(this.value);
+    }
+
+    onInput(next: string): void {
+        this.value = next;
+        this.valueChange.emit(next);
+        this.error = '';
+        this.open = true;
+        if (this.timer) clearTimeout(this.timer);
+        this.timer = setTimeout(() => void this.search(next), 150);
+    }
+
+    pick(hit: CatalogPick): void {
+        this.value = hit.name;
+        this.valueChange.emit(hit.name);
+        this.open = false;
+        this.picked.emit(hit);
+    }
+
+    async addNew(): Promise<void> {
+        if (!this.createFn || !this.value.trim()) return;
+        try {
+            const created = await this.createFn(this.value.trim());
+            this.pick(created);
+        } catch (error) {
+            this.error = this.createError(error);
+        }
+    }
+
+    get canAdd(): boolean {
+        const typed = this.value.trim().toLowerCase();
+        if (!typed || !this.createFn) return false;
+        return !this.hits.some((hit) => hit.name.trim().toLowerCase() === typed);
+    }
+
+    private async search(query: string): Promise<void> {
+        if (!this.searchFn) return;
+        try {
+            this.hits = await this.searchFn(query);
+        } catch {
+            this.hits = [];
+        }
+    }
+
+    private createError(error: unknown): string {
+        const message = String((error as Error)?.message || error || '');
+        if (/NAME_REQUIRED/i.test(message)) return 'Name is required.';
+        if (/DUPLICATE_ACTIVE_NAME/i.test(message)) return 'That name is already in the catalog.';
+        return 'Could not add this catalog entry. You can keep the typed name.';
+    }
+}

--- a/desktop/src/renderer/app/shared/components/catalog-typeahead/catalog-typeahead.component.ts
+++ b/desktop/src/renderer/app/shared/components/catalog-typeahead/catalog-typeahead.component.ts
@@ -49,9 +49,11 @@ export class CatalogTypeaheadComponent implements OnDestroy {
     open = false;
     error = '';
     private timer: ReturnType<typeof setTimeout> | null = null;
+    private searchGeneration = 0;
 
     ngOnDestroy(): void {
         if (this.timer) clearTimeout(this.timer);
+        this.searchGeneration += 1;
     }
 
     onFocus(): void {
@@ -70,6 +72,7 @@ export class CatalogTypeaheadComponent implements OnDestroy {
     }
 
     pick(hit: CatalogPick): void {
+        this.searchGeneration += 1;
         this.value = hit.name;
         this.valueChange.emit(hit.name);
         this.open = false;
@@ -94,9 +97,13 @@ export class CatalogTypeaheadComponent implements OnDestroy {
 
     private async search(query: string): Promise<void> {
         if (!this.searchFn) return;
+        const generation = ++this.searchGeneration;
         try {
-            this.hits = await this.searchFn(query);
+            const hits = await this.searchFn(query);
+            if (generation !== this.searchGeneration) return;
+            this.hits = hits;
         } catch {
+            if (generation !== this.searchGeneration) return;
             this.hits = [];
         }
     }

--- a/desktop/src/renderer/app/shared/components/catalog-typeahead/catalog-typeahead.component.ts
+++ b/desktop/src/renderer/app/shared/components/catalog-typeahead/catalog-typeahead.component.ts
@@ -109,7 +109,7 @@ export class CatalogTypeaheadComponent implements OnDestroy {
     }
 
     private createError(error: unknown): string {
-        const message = String((error as Error)?.message || error || '');
+        const message = error instanceof Error ? error.message : (typeof error === 'string' ? error : '');
         if (/NAME_REQUIRED/i.test(message)) return 'Name is required.';
         if (/DUPLICATE_ACTIVE_NAME/i.test(message)) return 'That name is already in the catalog.';
         return 'Could not add this catalog entry. You can keep the typed name.';

--- a/desktop/src/renderer/app/shared/components/catalog-typeahead/catalog-typeahead.component.ts
+++ b/desktop/src/renderer/app/shared/components/catalog-typeahead/catalog-typeahead.component.ts
@@ -25,10 +25,10 @@ export interface CatalogPick {
       <div *ngIf="open && !disabled" class="absolute z-30 mt-1 w-full bg-white border border-gray-200 rounded shadow-lg max-h-48 overflow-y-auto">
         <button type="button" *ngFor="let hit of hits"
                 class="block w-full text-left px-3 py-2 text-sm hover:bg-blue-50"
-                (mousedown)="pick(hit)">{{ hit.name }}</button>
+                (click)="pick(hit)">{{ hit.name }}</button>
         <button type="button" *ngIf="canAdd"
                 class="block w-full text-left px-3 py-2 text-sm text-blue-700 hover:bg-blue-50 font-medium"
-                (mousedown)="addNew()">+ Add new “{{ value.trim() }}”</button>
+                (click)="addNew()">+ Add new “{{ value.trim() }}”</button>
         <div *ngIf="hits.length === 0 && !canAdd" class="px-3 py-2 text-xs text-gray-400">No matching catalog entries</div>
       </div>
       <p *ngIf="error" class="text-xs text-red-500 mt-1">{{ error }}</p>

--- a/desktop/src/renderer/app/shared/components/update-prompt/update-prompt.component.spec.ts
+++ b/desktop/src/renderer/app/shared/components/update-prompt/update-prompt.component.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { UpdatePromptComponent } from './update-prompt.component';
+import { AppUpdateService } from '../../../services/update.service';
+import { inject } from '@angular/core';
+
+vi.mock('@angular/core', async () => {
+    const actual = await vi.importActual('@angular/core');
+    return { ...actual as any, inject: vi.fn() };
+});
+
+describe('UpdatePromptComponent', () => {
+    let component: UpdatePromptComponent;
+    let updates: AppUpdateService;
+
+    beforeEach(() => {
+        updates = {
+            init: vi.fn(),
+            destroy: vi.fn(),
+            later: vi.fn(),
+            updateNow: vi.fn(),
+            cancelDownload: vi.fn(),
+            promptOpen: () => true,
+            status: () => ({
+                state: 'available',
+                currentVersion: '0.0.8',
+                availableVersion: '0.0.9',
+                releaseNotes: 'Notes',
+                canQuitAndInstall: true,
+                verifiedSignature: false,
+                integrityNote: 'This feed lists package checksums. NalamDesk does not claim full code-signature verification.'
+            })
+        } as any;
+        vi.mocked(inject).mockReturnValue(updates);
+        component = new UpdatePromptComponent();
+        component.ngOnInit();
+    });
+
+    it('shows current vs new version without claiming signature verify', () => {
+        expect(component.body).toContain('0.0.8');
+        expect(component.body).toContain('0.0.9');
+        expect(component.status.verifiedSignature).toBe(false);
+        expect(component.status.integrityNote).not.toMatch(/full code-signature verification is complete/i);
+        component.later();
+        expect(updates.later).toHaveBeenCalled();
+    });
+});

--- a/desktop/src/renderer/app/shared/components/update-prompt/update-prompt.component.spec.ts
+++ b/desktop/src/renderer/app/shared/components/update-prompt/update-prompt.component.spec.ts
@@ -21,6 +21,7 @@ describe('UpdatePromptComponent', () => {
             destroy: vi.fn(),
             later: vi.fn(),
             updateNow: vi.fn(),
+            install: vi.fn(),
             cancelDownload: vi.fn(),
             promptOpen: () => true,
             status: () => ({
@@ -45,5 +46,18 @@ describe('UpdatePromptComponent', () => {
         expect(component.status.integrityNote).not.toMatch(/full code-signature verification is complete/i);
         component.later();
         expect(updates.later).toHaveBeenCalled();
+    });
+
+    it('installs a downloaded update from the prompt', () => {
+        updates.status = () => ({
+            state: 'downloaded',
+            currentVersion: '0.0.8',
+            availableVersion: '0.0.9',
+            canQuitAndInstall: true,
+            verifiedSignature: false
+        });
+        expect(component.title).toMatch(/downloaded/i);
+        component.install();
+        expect(updates.install).toHaveBeenCalled();
     });
 });

--- a/desktop/src/renderer/app/shared/components/update-prompt/update-prompt.component.spec.ts
+++ b/desktop/src/renderer/app/shared/components/update-prompt/update-prompt.component.spec.ts
@@ -48,6 +48,30 @@ describe('UpdatePromptComponent', () => {
         expect(updates.later).toHaveBeenCalled();
     });
 
+    it('covers prompt titles, install, cancel, and keyboard dismiss', () => {
+        updates.status = () => ({ state: 'error', error: 'Could not reach the update feed.' });
+        expect(component.title).toMatch(/failed/i);
+        expect(component.body).toMatch(/reach/i);
+        updates.status = () => ({ state: 'up-to-date', currentVersion: '0.0.8' });
+        expect(component.title).toMatch(/up to date/i);
+        expect(component.body).toContain('0.0.8');
+        updates.status = () => ({ state: 'skipped', reason: 'unpackaged' });
+        expect(component.body).toMatch(/packaged/i);
+        updates.status = () => ({ state: 'skipped', reason: 'no-feed' });
+        expect(component.body).toMatch(/feed/i);
+        updates.status = () => ({ state: 'downloading', percent: 40 });
+        expect(component.title).toMatch(/Downloading/i);
+        component.cancel();
+        expect(updates.cancelDownload).toHaveBeenCalled();
+        component.updateNow();
+        expect(updates.updateNow).toHaveBeenCalled();
+        const event = { key: 'Escape', preventDefault: vi.fn() } as any;
+        component.onPromptKeydown(event);
+        expect(event.preventDefault).toHaveBeenCalled();
+        component.ngAfterViewChecked();
+        component.ngOnDestroy();
+    });
+
     it('installs a downloaded update from the prompt', () => {
         updates.status = () => ({
             state: 'downloaded',

--- a/desktop/src/renderer/app/shared/components/update-prompt/update-prompt.component.ts
+++ b/desktop/src/renderer/app/shared/components/update-prompt/update-prompt.component.ts
@@ -1,0 +1,93 @@
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AppUpdateService } from '../../../services/update.service';
+
+@Component({
+    selector: 'app-update-prompt',
+    standalone: true,
+    imports: [CommonModule],
+    template: `
+    <div *ngIf="showPrompt" class="fixed inset-0 z-[110] flex items-center justify-center p-4" role="dialog" aria-modal="true">
+      <div class="fixed inset-0 bg-black/50" (click)="later()"></div>
+      <div class="relative w-full max-w-lg rounded-lg bg-white p-6 shadow-xl border border-gray-200">
+        <h3 class="text-xl font-bold text-gray-900">{{ title }}</h3>
+        <p class="mt-2 text-sm text-gray-700 whitespace-pre-line">{{ body }}</p>
+        <p *ngIf="status.integrityNote && status.state !== 'error'" class="mt-3 text-xs text-gray-500">{{ status.integrityNote }}</p>
+        <div *ngIf="status.state === 'downloading'" class="mt-4">
+          <div class="h-2 rounded bg-gray-200 overflow-hidden">
+            <div class="h-full bg-blue-600" [style.width.%]="status.percent || 0"></div>
+          </div>
+          <p class="text-xs text-gray-500 mt-1">{{ status.percent || 0 }}%</p>
+        </div>
+        <div class="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+          <button *ngIf="status.state === 'downloading'" type="button"
+                  class="px-4 py-2 rounded border border-gray-300 text-gray-700 hover:bg-gray-50"
+                  (click)="cancel()">Cancel</button>
+          <button *ngIf="status.state === 'available'" type="button"
+                  class="px-4 py-2 rounded border border-gray-300 text-gray-700 hover:bg-gray-50"
+                  (click)="later()">Later</button>
+          <button *ngIf="status.state === 'available'" type="button"
+                  class="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 font-medium"
+                  (click)="updateNow()">{{ status.canQuitAndInstall === false ? 'Open download page' : 'Update now' }}</button>
+          <button *ngIf="status.state === 'error' || status.state === 'up-to-date' || status.state === 'skipped'" type="button"
+                  class="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 font-medium"
+                  (click)="later()">OK</button>
+        </div>
+      </div>
+    </div>
+  `
+})
+export class UpdatePromptComponent implements OnInit, OnDestroy {
+    private updates = inject(AppUpdateService);
+
+    ngOnInit(): void {
+        this.updates.init();
+    }
+
+    ngOnDestroy(): void {
+        this.updates.destroy();
+    }
+
+    get status() {
+        return this.updates.status();
+    }
+
+    get showPrompt(): boolean {
+        return this.updates.promptOpen();
+    }
+
+    get title(): string {
+        if (this.status.state === 'error') return 'Update failed';
+        if (this.status.state === 'up-to-date') return 'You’re up to date';
+        if (this.status.state === 'skipped') return 'Updates';
+        if (this.status.state === 'downloading') return 'Downloading update';
+        return 'Update available';
+    }
+
+    get body(): string {
+        if (this.status.state === 'error') {
+            return this.status.error || 'Update failed.';
+        }
+        if (this.status.state === 'up-to-date') {
+            return `This app is ${this.status.currentVersion || 'current'}.`;
+        }
+        if (this.status.state === 'skipped') {
+            if (this.status.reason === 'unpackaged') return 'In-app updates run only in a packaged desktop build.';
+            return 'No update feed is configured on this device.';
+        }
+        const notes = this.status.releaseNotes ? `\n\n${this.status.releaseNotes}` : '';
+        return `Current version: ${this.status.currentVersion || 'unknown'}\nNew version: ${this.status.availableVersion || 'unknown'}${notes}`;
+    }
+
+    later(): void {
+        this.updates.later();
+    }
+
+    updateNow(): void {
+        void this.updates.updateNow();
+    }
+
+    cancel(): void {
+        void this.updates.cancelDownload();
+    }
+}

--- a/desktop/src/renderer/app/shared/components/update-prompt/update-prompt.component.ts
+++ b/desktop/src/renderer/app/shared/components/update-prompt/update-prompt.component.ts
@@ -44,7 +44,7 @@ import { AppUpdateService } from '../../../services/update.service';
   `
 })
 export class UpdatePromptComponent implements OnInit, OnDestroy, AfterViewChecked {
-    private updates = inject(AppUpdateService);
+    private readonly updates = inject(AppUpdateService);
     private previousFocus: HTMLElement | null = null;
     private promptFocused = false;
 

--- a/desktop/src/renderer/app/shared/components/update-prompt/update-prompt.component.ts
+++ b/desktop/src/renderer/app/shared/components/update-prompt/update-prompt.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { AfterViewChecked, Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AppUpdateService } from '../../../services/update.service';
 
@@ -7,10 +7,12 @@ import { AppUpdateService } from '../../../services/update.service';
     standalone: true,
     imports: [CommonModule],
     template: `
-    <div *ngIf="showPrompt" class="fixed inset-0 z-[110] flex items-center justify-center p-4" role="dialog" aria-modal="true">
+    <div *ngIf="showPrompt" class="fixed inset-0 z-[110] flex items-center justify-center p-4"
+         role="dialog" aria-modal="true" aria-labelledby="update-prompt-title"
+         (keydown)="onPromptKeydown($event)">
       <div class="fixed inset-0 bg-black/50" (click)="later()"></div>
       <div class="relative w-full max-w-lg rounded-lg bg-white p-6 shadow-xl border border-gray-200">
-        <h3 class="text-xl font-bold text-gray-900">{{ title }}</h3>
+        <h3 id="update-prompt-title" tabindex="-1" class="text-xl font-bold text-gray-900">{{ title }}</h3>
         <p class="mt-2 text-sm text-gray-700 whitespace-pre-line">{{ body }}</p>
         <p *ngIf="status.integrityNote && status.state !== 'error'" class="mt-3 text-xs text-gray-500">{{ status.integrityNote }}</p>
         <div *ngIf="status.state === 'downloading'" class="mt-4">
@@ -23,13 +25,17 @@ import { AppUpdateService } from '../../../services/update.service';
           <button *ngIf="status.state === 'downloading'" type="button"
                   class="px-4 py-2 rounded border border-gray-300 text-gray-700 hover:bg-gray-50"
                   (click)="cancel()">Cancel</button>
-          <button *ngIf="status.state === 'available'" type="button"
+          <button *ngIf="status.state === 'available' || status.state === 'downloaded'" type="button"
                   class="px-4 py-2 rounded border border-gray-300 text-gray-700 hover:bg-gray-50"
                   (click)="later()">Later</button>
-          <button *ngIf="status.state === 'available'" type="button"
+          <button *ngIf="status.state === 'available'" type="button" id="update-prompt-primary"
                   class="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 font-medium"
                   (click)="updateNow()">{{ status.canQuitAndInstall === false ? 'Open download page' : 'Update now' }}</button>
+          <button *ngIf="status.state === 'downloaded'" type="button" id="update-prompt-primary"
+                  class="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 font-medium"
+                  (click)="install()">{{ status.canQuitAndInstall === false ? 'Open download page' : 'Install and restart' }}</button>
           <button *ngIf="status.state === 'error' || status.state === 'up-to-date' || status.state === 'skipped'" type="button"
+                  id="update-prompt-primary"
                   class="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 font-medium"
                   (click)="later()">OK</button>
         </div>
@@ -37,8 +43,10 @@ import { AppUpdateService } from '../../../services/update.service';
     </div>
   `
 })
-export class UpdatePromptComponent implements OnInit, OnDestroy {
+export class UpdatePromptComponent implements OnInit, OnDestroy, AfterViewChecked {
     private updates = inject(AppUpdateService);
+    private previousFocus: HTMLElement | null = null;
+    private promptFocused = false;
 
     ngOnInit(): void {
         this.updates.init();
@@ -46,6 +54,18 @@ export class UpdatePromptComponent implements OnInit, OnDestroy {
 
     ngOnDestroy(): void {
         this.updates.destroy();
+    }
+
+    ngAfterViewChecked(): void {
+        if (!this.showPrompt) {
+            this.restoreFocus();
+            return;
+        }
+        if (this.promptFocused) return;
+        this.previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+        const target = document.getElementById('update-prompt-primary') || document.getElementById('update-prompt-title');
+        target?.focus();
+        this.promptFocused = true;
     }
 
     get status() {
@@ -61,6 +81,7 @@ export class UpdatePromptComponent implements OnInit, OnDestroy {
         if (this.status.state === 'up-to-date') return 'You’re up to date';
         if (this.status.state === 'skipped') return 'Updates';
         if (this.status.state === 'downloading') return 'Downloading update';
+        if (this.status.state === 'downloaded') return 'Update downloaded';
         return 'Update available';
     }
 
@@ -81,13 +102,48 @@ export class UpdatePromptComponent implements OnInit, OnDestroy {
 
     later(): void {
         this.updates.later();
+        this.restoreFocus();
     }
 
     updateNow(): void {
-        void this.updates.updateNow();
+        this.updates.updateNow();
+    }
+
+    install(): void {
+        this.updates.install();
     }
 
     cancel(): void {
-        void this.updates.cancelDownload();
+        this.updates.cancelDownload();
+    }
+
+    onPromptKeydown(event: KeyboardEvent): void {
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            this.later();
+            return;
+        }
+        if (event.key !== 'Tab') return;
+        const nodes = Array.from(document.querySelectorAll<HTMLElement>(
+            '[role="dialog"][aria-modal="true"] button:not([disabled])'
+        ));
+        if (nodes.length === 0) return;
+        const first = nodes[0];
+        const last = nodes[nodes.length - 1];
+        const active = document.activeElement;
+        if (event.shiftKey && active === first) {
+            event.preventDefault();
+            last.focus();
+        } else if (!event.shiftKey && active === last) {
+            event.preventDefault();
+            first.focus();
+        }
+    }
+
+    private restoreFocus(): void {
+        if (!this.promptFocused) return;
+        this.promptFocused = false;
+        this.previousFocus?.focus();
+        this.previousFocus = null;
     }
 }

--- a/desktop/src/renderer/app/visits/prescription/prescription.component.spec.ts
+++ b/desktop/src/renderer/app/visits/prescription/prescription.component.spec.ts
@@ -78,4 +78,12 @@ describe('PrescriptionComponent', () => {
         expect(component.items()[0].medicine).toBe('Paracetamol extra');
         expect(component.changed.emit).toHaveBeenCalled();
     });
+
+    it('searches and creates medicines through catalog IPC when available', async () => {
+        await expect(component.searchMedicines('para')).resolves.toEqual([]);
+        await expect(component.createMedicine('ORS')).resolves.toEqual({ id: 0, name: 'ORS' });
+        component.disabled = true;
+        component.onMedicineTyped(0, 'x');
+        expect(component.items()[0].medicine).toBe('');
+    });
 });

--- a/desktop/src/renderer/app/visits/prescription/prescription.component.spec.ts
+++ b/desktop/src/renderer/app/visits/prescription/prescription.component.spec.ts
@@ -68,4 +68,14 @@ describe('PrescriptionComponent', () => {
         expect(component.items()).toHaveLength(1);
         expect(component.changed.emit).not.toHaveBeenCalled();
     });
+
+    it('copies catalog defaults when a medicine is picked and keeps the line editable', () => {
+        vi.spyOn(component.changed, 'emit');
+        component.onMedicinePicked(0, { id: 3, name: 'Paracetamol', dosage: '500mg', form: 'Tab' });
+        expect(component.items()[0].medicine).toBe('Paracetamol');
+        expect(component.items()[0].dosage).toBe('500mg');
+        component.onMedicineTyped(0, 'Paracetamol extra');
+        expect(component.items()[0].medicine).toBe('Paracetamol extra');
+        expect(component.changed.emit).toHaveBeenCalled();
+    });
 });

--- a/desktop/src/renderer/app/visits/prescription/prescription.component.ts
+++ b/desktop/src/renderer/app/visits/prescription/prescription.component.ts
@@ -124,7 +124,7 @@ import { DataService } from '../../services/api.service';
   `
 })
 export class PrescriptionComponent {
-  private dataService = inject(DataService, { optional: true });
+  private readonly dataService = inject(DataService, { optional: true });
 
   @Input() set initialData(value: any[]) {
     if (value && value.length > 0) this.items.set(value);

--- a/desktop/src/renderer/app/visits/prescription/prescription.component.ts
+++ b/desktop/src/renderer/app/visits/prescription/prescription.component.ts
@@ -1,11 +1,13 @@
-import { Component, Input, Output, EventEmitter, signal } from '@angular/core';
+import { Component, Input, Output, EventEmitter, signal, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { CatalogTypeaheadComponent } from '../../shared/components/catalog-typeahead/catalog-typeahead.component';
+import { DataService } from '../../services/api.service';
 
 @Component({
   selector: 'app-prescription',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, CatalogTypeaheadComponent],
   template: `
     <div class="card bg-base-100 border border-base-200" [class.opacity-70]="disabled">
       <div class="card-body p-3 md:p-4">
@@ -25,10 +27,16 @@ import { FormsModule } from '@angular/forms';
           <!-- 1. Medicine (Full Width on Mobile) -->
           <div class="col-span-12 md:col-span-3">
             <span class="text-xs text-gray-500 md:hidden font-bold">Medicine</span>
-            <input type="text" placeholder="Medicine Name" 
-                   [(ngModel)]="item.medicine" (ngModelChange)="emitChange()"
-                   [disabled]="disabled"
-                   class="input input-bordered input-sm w-full font-medium" />
+            <app-catalog-typeahead
+              [value]="item.medicine"
+              [disabled]="disabled"
+              [placeholder]="'Medicine Name'"
+              [testId]="'rx-medicine-' + i"
+              [searchFn]="searchMedicines"
+              [createFn]="createMedicine"
+              (valueChange)="onMedicineTyped(i, $event)"
+              (picked)="onMedicinePicked(i, $event)">
+            </app-catalog-typeahead>
           </div>
 
           <!-- 2. Form (1/3 Mobile) -->
@@ -116,6 +124,8 @@ import { FormsModule } from '@angular/forms';
   `
 })
 export class PrescriptionComponent {
+  private dataService = inject(DataService, { optional: true });
+
   @Input() set initialData(value: any[]) {
     if (value && value.length > 0) this.items.set(value);
   }
@@ -125,6 +135,14 @@ export class PrescriptionComponent {
   items = signal<any[]>([
     { medicine: '', form: 'Tab', dosage: '', route: 'Oral', frequency: '1-0-1', duration: '3 days', instruction: 'After Food' }
   ]);
+
+  searchMedicines = (query: string) => this.dataService
+    ? this.dataService.invoke('searchMedicines', query)
+    : Promise.resolve([]);
+
+  createMedicine = (name: string) => this.dataService
+    ? this.dataService.invoke('createMedicine', { name })
+    : Promise.resolve({ id: 0, name });
 
   add() {
     if (this.disabled) return;
@@ -141,5 +159,27 @@ export class PrescriptionComponent {
   emitChange() {
     if (this.disabled) return;
     this.changed.emit(this.items());
+  }
+
+  onMedicineTyped(index: number, name: string) {
+    this.patchLine(index, { medicine: name });
+  }
+
+  onMedicinePicked(index: number, hit: any) {
+    this.patchLine(index, {
+      medicine: hit.name,
+      form: hit.form || this.items()[index]?.form || 'Tab',
+      dosage: hit.dosage ?? this.items()[index]?.dosage ?? '',
+      route: hit.route || this.items()[index]?.route || 'Oral',
+      frequency: hit.frequency || this.items()[index]?.frequency || '1-0-1',
+      duration: hit.duration || this.items()[index]?.duration || '3 days',
+      instruction: hit.instruction || this.items()[index]?.instruction || 'After Food'
+    });
+  }
+
+  private patchLine(index: number, patch: Record<string, unknown>) {
+    if (this.disabled) return;
+    this.items.update((list) => list.map((item, i) => i === index ? { ...item, ...patch } : item));
+    this.emitChange();
   }
 }

--- a/desktop/src/renderer/app/visits/visit/visit.component.spec.ts
+++ b/desktop/src/renderer/app/visits/visit/visit.component.spec.ts
@@ -704,4 +704,33 @@ describe('VisitComponent', () => {
         component.copyLastVisit();
         expect(component.visitForm.patchValue).toHaveBeenCalledWith(expect.objectContaining({ diagnosis: 'Flu' }));
     });
+
+    it('applies editable condition presets when a catalog diagnosis is picked', async () => {
+        component.chartWritable = true;
+        component.isConsulting = true;
+        component.encounterId = 7;
+        mockDataService.invoke.mockImplementation((method: string) => {
+            if (method === 'getConditionMedPresets') {
+                return Promise.resolve([{ medicine: 'Paracetamol', dosage: '500mg', duration: '3 days' }]);
+            }
+            return Promise.resolve([]);
+        });
+        await component.onConditionPicked({ id: 4, name: 'Influenza' });
+        expect(component.visitForm.patchValue).toHaveBeenCalledWith({ diagnosis: 'Influenza' });
+        expect(component.currentPrescription[0].medicine).toBe('Paracetamol');
+        component.currentPrescription[0].duration = '7 days';
+        expect(component.currentPrescription[0].duration).toBe('7 days');
+    });
+
+    it('adds a new diagnosis without blocking free-text entry', async () => {
+        component.chartWritable = true;
+        component.isConsulting = true;
+        component.encounterId = 7;
+        mockDataService.invoke.mockResolvedValue({ id: 8, name: 'Viral fever' });
+        const created = await component.createCondition('Viral fever');
+        expect(mockDataService.invoke).toHaveBeenCalledWith('createCondition', { name: 'Viral fever' });
+        expect(created.name).toBe('Viral fever');
+        component.onDiagnosisTyped('Free text diagnosis');
+        expect(component.visitForm.patchValue).toHaveBeenCalledWith({ diagnosis: 'Free text diagnosis' });
+    });
 });

--- a/desktop/src/renderer/app/visits/visit/visit.component.spec.ts
+++ b/desktop/src/renderer/app/visits/visit/visit.component.spec.ts
@@ -722,6 +722,36 @@ describe('VisitComponent', () => {
         expect(component.currentPrescription[0].duration).toBe('7 days');
     });
 
+    it('ignores stale condition presets after a later diagnosis pick', async () => {
+        component.chartWritable = true;
+        component.isConsulting = true;
+        component.encounterId = 7;
+        let resolveFlu: (lines: any[]) => void = () => undefined;
+        let resolveUri: (lines: any[]) => void = () => undefined;
+        const fluPresets = new Promise<any[]>((resolve) => {
+            resolveFlu = resolve;
+        });
+        const uriPresets = new Promise<any[]>((resolve) => {
+            resolveUri = resolve;
+        });
+        mockDataService.invoke.mockImplementation((method: string, id?: number) => {
+            if (method === 'getConditionMedPresets') {
+                return id === 1 ? fluPresets : uriPresets;
+            }
+            return Promise.resolve([]);
+        });
+
+        const fluPick = component.onConditionPicked({ id: 1, name: 'Influenza' });
+        const uriPick = component.onConditionPicked({ id: 2, name: 'URI' });
+        resolveFlu([{ medicine: 'Oseltamivir' }]);
+        await fluPick;
+        expect(component.currentPrescription).toEqual([]);
+
+        resolveUri([{ medicine: 'Paracetamol' }]);
+        await uriPick;
+        expect(component.currentPrescription[0].medicine).toBe('Paracetamol');
+    });
+
     it('adds a new diagnosis without blocking free-text entry', async () => {
         component.chartWritable = true;
         component.isConsulting = true;

--- a/desktop/src/renderer/app/visits/visit/visit.component.ts
+++ b/desktop/src/renderer/app/visits/visit/visit.component.ts
@@ -5,6 +5,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 import { PdfService } from '../../services/pdf.service';
 import { PrescriptionComponent } from '../../visits/prescription/prescription.component';
+import { CatalogTypeaheadComponent } from '../../shared/components/catalog-typeahead/catalog-typeahead.component';
 import { AuthService } from '../../services/auth.service';
 import { DataService } from '../../services/api.service';
 import { newRequestId } from '../../services/request-id';
@@ -33,7 +34,7 @@ interface Visit {
 @Component({
   selector: 'app-visit',
   standalone: true,
-  imports: [CommonModule, FormsModule, ReactiveFormsModule, PrescriptionComponent],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, PrescriptionComponent, CatalogTypeaheadComponent],
   template: `
     <div class="flex h-full bg-gray-50 font-sans overflow-hidden relative">
       
@@ -186,9 +187,16 @@ interface Visit {
                     <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
                         <div class="md:col-span-3">
                              <label class="block text-xs font-bold text-gray-500 uppercase mb-1">Diagnosis <span class="text-red-500">*</span></label>
-                             <input formControlName="diagnosis" type="text" placeholder="Primary Diagnosis" 
-                                class="w-full p-2 border border-gray-300 rounded focus:ring-2 focus:ring-purple-500 outline-none font-medium text-lg"
-                                [class.border-red-500]="visitForm.get('diagnosis')?.invalid && (visitForm.get('diagnosis')?.dirty || visitForm.get('diagnosis')?.touched)">
+                             <app-catalog-typeahead
+                                [value]="visitForm.get('diagnosis')?.value || ''"
+                                [disabled]="!canEditChart"
+                                placeholder="Primary Diagnosis"
+                                testId="diagnosis-input"
+                                [searchFn]="searchConditions"
+                                [createFn]="createCondition"
+                                (valueChange)="onDiagnosisTyped($event)"
+                                (picked)="onConditionPicked($event)">
+                             </app-catalog-typeahead>
                              <p *ngIf="visitForm.get('diagnosis')?.invalid && (visitForm.get('diagnosis')?.dirty)" class="text-xs text-red-500 mt-1">Diagnosis is required</p>
                         </div>
                         <div class="md:col-span-1">
@@ -518,6 +526,31 @@ export class VisitComponent implements OnInit {
   updatePrescription(items: any[]) {
     if (!this.canEditChart) return;
     this.visitForm.patchValue({ prescription: items });
+  }
+
+  searchConditions = (query: string) => this.dataService.invoke('searchConditions', query);
+
+  createCondition = (name: string) => this.dataService.invoke('createCondition', { name });
+
+  onDiagnosisTyped(name: string) {
+    if (!this.canEditChart) return;
+    this.visitForm.patchValue({ diagnosis: name });
+    this.visitForm.get('diagnosis')?.markAsDirty?.();
+  }
+
+  async onConditionPicked(hit: { id: number; name: string }) {
+    if (!this.canEditChart) return;
+    this.visitForm.patchValue({ diagnosis: hit.name });
+    try {
+      const presets = await this.dataService.invoke<any[]>('getConditionMedPresets', hit.id);
+      if (presets && presets.length > 0) {
+        const lines = presets.map((line) => ({ ...line }));
+        this.currentPrescription = lines;
+        this.visitForm.patchValue({ prescription: lines });
+      }
+    } catch (e) {
+      console.warn('Could not apply condition presets', e);
+    }
   }
 
   async saveVisit(): Promise<boolean> {

--- a/desktop/src/renderer/app/visits/visit/visit.component.ts
+++ b/desktop/src/renderer/app/visits/visit/visit.component.ts
@@ -302,6 +302,7 @@ export class VisitComponent implements OnInit {
   showMobileHistory = false;
 
   currentPrescription: any[] = [];
+  private conditionPresetGeneration = 0;
   viewMode = false;
   viewVisitId: number | null = null;
   viewedVisit: Visit | null = null;
@@ -534,6 +535,7 @@ export class VisitComponent implements OnInit {
 
   onDiagnosisTyped(name: string) {
     if (!this.canEditChart) return;
+    this.conditionPresetGeneration += 1;
     this.visitForm.patchValue({ diagnosis: name });
     this.visitForm.get('diagnosis')?.markAsDirty?.();
   }
@@ -541,14 +543,17 @@ export class VisitComponent implements OnInit {
   async onConditionPicked(hit: { id: number; name: string }) {
     if (!this.canEditChart) return;
     this.visitForm.patchValue({ diagnosis: hit.name });
+    const generation = ++this.conditionPresetGeneration;
     try {
       const presets = await this.dataService.invoke<any[]>('getConditionMedPresets', hit.id);
+      if (generation !== this.conditionPresetGeneration) return;
       if (presets && presets.length > 0) {
         const lines = presets.map((line) => ({ ...line }));
         this.currentPrescription = lines;
         this.visitForm.patchValue({ prescription: lines });
       }
     } catch (e) {
+      if (generation !== this.conditionPresetGeneration) return;
       console.warn('Could not apply condition presets', e);
     }
   }
@@ -694,6 +699,7 @@ export class VisitComponent implements OnInit {
 
   copyLastVisit() {
     if (!this.canEditChart || this.history.length === 0) return;
+    this.conditionPresetGeneration += 1;
     const last = this.history[0];
     this.visitForm.patchValue({
       diagnosis: last.diagnosis,

--- a/desktop/src/renderer/types.d.ts
+++ b/desktop/src/renderer/types.d.ts
@@ -58,6 +58,18 @@ declare global {
                 removeFromQueue: (id: number) => Promise<any>;
                 // Audit
                 getAuditLogs: (limit: number) => Promise<any[]>;
+                searchConditions: (query: string, limit?: number) => Promise<any[]>;
+                searchMedicines: (query: string, limit?: number) => Promise<any[]>;
+                createCondition: (input: { name: string }) => Promise<any>;
+                createMedicine: (input: any) => Promise<any>;
+                getConditionMedPresets: (conditionId: number) => Promise<any[]>;
+                listConditions: (includeRetired?: boolean) => Promise<any[]>;
+                listMedicines: (includeRetired?: boolean) => Promise<any[]>;
+                updateCondition: (input: any) => Promise<any>;
+                updateMedicine: (input: any) => Promise<any>;
+                retireCondition: (id: number) => Promise<any>;
+                retireMedicine: (id: number) => Promise<any>;
+                replaceConditionMedPresets: (input: { conditionId: number; lines: any[] }) => Promise<any[]>;
             };
             drive: {
                 isAuthenticated: () => Promise<boolean>;
@@ -67,13 +79,13 @@ declare global {
                 restore: (fileId: string) => Promise<{ success: boolean; restartRequired?: boolean; error?: string }>;
                 listBackups: () => Promise<any[]>;
             };
-            updater: {
-                checkForUpdates: () => Promise<any>;
-                quitAndInstall: () => Promise<void>;
-                onUpdateAvailable: (callback: (info: any) => void) => void;
-                onUpdateDownloaded: (callback: (info: any) => void) => void;
-                onDownloadProgress: (callback: (progress: any) => void) => void;
-                onUpdateError: (callback: (err: any) => void) => void;
+            updates: {
+                check: (opts?: { source?: 'startup' | 'manual' }) => Promise<any>;
+                download: () => Promise<any>;
+                install: () => Promise<any>;
+                cancel: () => Promise<any>;
+                getStatus: () => Promise<any>;
+                onEvent: (callback: (status: any) => void) => () => void;
             };
             cloud: {
                 getStatus: () => Promise<{ enabled: boolean; clinicId: string | null }>;

--- a/desktop/src/server/app.spec.ts
+++ b/desktop/src/server/app.spec.ts
@@ -107,6 +107,47 @@ describe('HTTP /api/ipc queue wrapper', () => {
     });
 });
 
+describe('HTTP /api/ipc catalog methods', () => {
+    let server: ApiServer;
+    let db: any;
+
+    beforeEach(() => {
+        db = {
+            beginWork: vi.fn(),
+            endWork: vi.fn(),
+            getPermissions: vi.fn().mockReturnValue(['searchConditions', 'createCondition', 'createMedicine']),
+            searchConditions: vi.fn().mockReturnValue([{ id: 1, name: 'Influenza' }]),
+            createCondition: vi.fn().mockReturnValue({ id: 2, name: 'URI' }),
+            createMedicine: vi.fn().mockReturnValue({ id: 3, name: 'Paracetamol' })
+        };
+        server = new ApiServer(db, os.tmpdir());
+    });
+
+    afterEach(async () => {
+        await server.close();
+    });
+
+    it('forwards catalog search and Add new with the same args Electron IPC unpacks', async () => {
+        const token = jwt.sign({ id: 15, role: 'doctor', username: 'doc' }, JWT_SECRET, { expiresIn: '1h' });
+        const search = await server.inject({
+            method: 'POST',
+            url: '/api/ipc/searchConditions',
+            headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+            payload: ['flu']
+        });
+        const create = await server.inject({
+            method: 'POST',
+            url: '/api/ipc/createCondition',
+            headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+            payload: [{ name: 'URI' }]
+        });
+        expect(search.statusCode).toBe(200);
+        expect(create.statusCode).toBe(200);
+        expect(db.searchConditions).toHaveBeenCalledWith('flu');
+        expect(db.createCondition).toHaveBeenCalledWith({ name: 'URI' });
+    });
+});
+
 describe('hash SPA fallback', () => {
     let server: ApiServer;
 

--- a/desktop/src/server/app.ts
+++ b/desktop/src/server/app.ts
@@ -34,7 +34,11 @@ const ALLOWED_IPC_METHODS = [
     'getVitals', 'saveVitals',
     'getSettings', 'getPublicSettings', 'saveSettings',
     'getDoctors',
-    'getUsers', 'saveUser', 'deleteUser', 'updateUserPassword'
+    'getUsers', 'saveUser', 'deleteUser', 'updateUserPassword',
+    'searchConditions', 'searchMedicines', 'createCondition', 'createMedicine',
+    'getConditionMedPresets', 'listConditions', 'listMedicines',
+    'updateCondition', 'updateMedicine', 'retireCondition', 'retireMedicine',
+    'replaceConditionMedPresets'
 ];
 
 export class ApiServer {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -62,6 +62,7 @@ sonar.coverage.exclusions=\
   **/*.d.ts,\
   **/polyfills.ts,\
   desktop/src/main.ts,\
+  desktop/src/main/main.ts,\
   desktop/src/renderer/main.ts,\
   desktop/src/styles.css,\
   desktop/src/tailwind.css,\


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #43 and #46.

Desktop Electron only. Does not add a publish workflow, Automated Release, silent force-update, Drive/cloud catalogs, or a second API.

## #43 In-app upgrades
Packaged builds check a **generic** feed (`NALAMDESK_UPDATE_FEED_URL` serving `latest*.yml` + OS packages). Ops places approved builds there — not Feature CI PR zips. Generic feeds must be **HTTPS** (HTTP is allowed only for localhost). Absolute artifact URLs must be HTTPS — including loopback HTTP (`http://127.0.0.1/...`). Relative package names on an HTTPS feed are unchanged.

- Launch (packaged) + Settings **Check for updates**
- Prompt: current vs new version, notes if present, **Update now** / **Later**; **Install and restart** after download
- Download progress + cancel; `quitAndInstall` only after `downloaded`
- Failures: plain error; app stays usable; vault/`userData` is not wiped or re-encrypted
- Checksum-only / unsigned feeds do **not** claim full signature verify (`verifiedSignature` stays false even if `NALAMDESK_UPDATE_RELEASE_SIGNED=1`)
- GitHub provider seam: `NALAMDESK_UPDATE_PROVIDER=github` (IPC/UX unchanged)

### OS apply
| OS | Package | In-app apply |
| --- | --- | --- |
| Windows | NSIS | updater `quitAndInstall` |
| macOS | DMG | updater `quitAndInstall` |
| Linux | AppImage | updater `quitAndInstall` |
| Linux | `.deb` (clinic first-install) | **Open download page** if not running as AppImage or if the feed has no AppImage. No apt repo. |

## #46 Visit diagnosis / Rx inventory
One SQLite migration: `condition_catalog`, `medicine_catalog`, `condition_med_presets` (unique active names, soft-retire `active=0`).

- Visit write path unchanged: denormalized `diagnosis` TEXT + `prescription_json`
- Plan & Rx: diagnosis typeahead + Add new; condition pick applies editable presets; Rx typeahead + Add new
- Settings → Catalogs: list/edit/soft-retire + ordered presets
- Missing terms do not block the visit
- IPC extends existing `db:*` / `invokeDbMethod` (Electron + HTTP `/api/ipc`); doctor/admin search+create; admin maintains catalogs

## Review follow-up
- Catalog typeahead ignores out-of-order search responses; list actions use `click` for keyboard
- Condition presets ignore stale loads after a later pick or typed diagnosis
- Retired medicines are omitted when loading condition presets
- Partial `updateMedicine` keeps existing Rx fields
- Generic feed URLs reject plaintext HTTP except localhost; absolute artifact URLs must be HTTPS
- `download()` / `install()` are guarded on updater state

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0973bdb-7dbf-49b0-b35d-be41e9f85d5c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0973bdb-7dbf-49b0-b35d-be41e9f85d5c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added condition and medicine catalogs with search-as-you-type entry, new-item creation, administrator management, retirement, and editable condition-based prescription presets.
  * Added packaged-app update checks with progress, cancel, install, and defer options, plus download-page fallback where in-app installation isn’t available.
* **Documentation**
  * Updated user and developer guides with catalog workflows, update behavior, Linux installation guidance, and database documentation.
* **Bug Fixes**
  * Preserved existing visit text and medication snapshots when catalog entries are retired.
  * Improved update error handling without modifying the local vault.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds desktop in-app upgrades and clinic-local diagnosis and medicine catalogs.
- Adds packaged-app update checks, download progress, cancellation, installation, and Linux download-page fallback.
- Requires HTTPS for generic production feeds and rejects all absolute non-HTTPS artifact URLs.
- Adds SQLite-backed condition, medicine, and ordered prescription-preset catalogs with role-gated IPC access.
- Adds catalog typeaheads, administrative maintenance, stale-response protection, and expanded tests and documentation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the previous findings are resolved and no new actionable defect was identified.

The follow-up artifact validation now rejects loopback HTTP and every other absolute non-HTTPS artifact URL. The other previous findings were manually resolved after stale typeahead and preset responses were guarded and retired medicines were excluded from loaded presets.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| desktop/src/main/updates/updateFeed.ts | Resolves update providers, enforces feed and artifact transport policy, compares versions, and selects OS apply behavior. |
| desktop/src/main/updates/updateService.ts | Implements the packaged desktop update state machine, cancellation, fallback, and guarded installation. |
| desktop/src/main/catalog/catalogStore.ts | Implements catalog search, creation, maintenance, retirement, and ordered condition presets. |
| desktop/src/main/schema/migrations.ts | Adds the three catalog tables, active-name uniqueness, indexes, foreign keys, and doctor permissions. |
| desktop/src/renderer/app/visits/visit/visit.component.ts | Integrates diagnosis typeahead and applies presets while rejecting stale asynchronous responses. |
| desktop/src/renderer/app/shared/components/catalog-typeahead/catalog-typeahead.component.ts | Adds reusable catalog search and creation UI with stale-search response protection. |
| desktop/src/renderer/app/settings/catalog-settings.component.ts | Adds administrator catalog and condition-preset maintenance UI. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Settings[Settings or startup] --> UpdateIPC[Update IPC]
  UpdateIPC --> Feed[Approved HTTPS update feed]
  Feed --> Package{Supported in-app package?}
  Package -->|Yes| Download[Download and verify checksum]
  Download --> Install[Install and restart]
  Package -->|No| Page[Open download page]

  Visit[Plan and Rx] --> CatalogIPC[Catalog IPC]
  Admin[Admin settings] --> CatalogIPC
  CatalogIPC --> SQLite[(Condition, medicine, and preset catalogs)]
  SQLite --> Snapshot[Editable denormalized visit snapshot]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(desktop): reject all absolute HTTP u..."](https://github.com/sankara-sabapathy/nalamdesk/commit/d1c3d12ff61a5ea461770bcd0c4d3e2e4baf34de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62983816)</sub>

<!-- /greptile_comment -->